### PR TITLE
Fix multiple evaluations of function body when return annotation is present

### DIFF
--- a/rhombus/private/function.rkt
+++ b/rhombus/private/function.rkt
@@ -449,9 +449,9 @@
      (cond
        [(syntax-e #'pred)
         #`(let ([result e])
-            (if (pred e)
-                e
-                (result-failure 'name e)))]
+            (if (pred result)
+                result
+                (result-failure 'name result)))]
        [else #'e])]))
 
 (define (result-failure who val)


### PR DESCRIPTION
When the return annotation is present on a function the body gets evaluated more than once.  Here's a demonstration program
```
#lang rhombus

import:
    racket/base

val mutable i: 0

fun make_array(n) :: Array:
    i := i + 1
    base.#{build-vector}(n, fun(o): o + i)

make_array(10)
i
```

Which returns
```
Array(3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
3
```

It should return
```
Array(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
1
```