### PR TITLE
Fix doc grammar maybe_result_annotation, :: or -:

### DIFF
--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -30,7 +30,8 @@
     $keyword: $binding $$(@tt{=}) $default_expr,
   
   grammar maybe_result_annotation:
-    :: $annotation
+    : :: $annotation
+    -: $annotation
     $$("ϵ")
 ]{
 


### PR DESCRIPTION
Fixes the `maybe_result_annotation` entry in the `fun` grammar so that it renders as `::` instead of `:`, and adds the `-:` variant.