### PR TITLE
Add string case for ++ append

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -12,7 +12,7 @@ use_static_dot
 
 #false || !(#false || #false)
       
-"hello" & " " & "world"
+"hello" ++ " " ++ "world"
 
 // define and call a function
 
@@ -179,7 +179,7 @@ prefix_plus 7 9
 
 expr.rule 'just_five': '"five"'
 
-just_five & " is the result"
+just_five ++ " is the result"
 
 // another way to write that
 
@@ -581,7 +581,7 @@ def
 
 weirdly
 weirdly coconut
-weirdly & "none"
+weirdly ++ "none"
 1 weirdly 5
 1 weirdly 5 + 7
 

--- a/rhombus/private/map-ref.rkt
+++ b/rhombus/private/map-ref.rkt
@@ -51,16 +51,18 @@
     [(list? map) (list-ref map index)]
     [(hash? map) (hash-ref map index)]
     [(set? map) (hash-ref (set-ht map) index #f)]
+    [(string? map) (string-ref map index)]
     [else
      (raise-argument-error* 'Map.ref rhombus-realm "Map" map)]))
 
 (define (map-set! map index val)
   (cond
-    [(vector? map) (vector-set! map index val)]
+    [(and (vector? map) (not (immutable? map))) (vector-set! map index val)]
     [(and (hash? map) (not (immutable? map))) (hash-set! map index val)]
     [(and (set? map) (not (immutable? (set-ht map)))) (if val
                                                           (hash-set! (set-ht map) index #t)
                                                           (hash-remove! (set-ht map) index))]
+    [(and (string? map) (not (immutable? map))) (string-set! map index val)]
     [else
      (raise-argument-error* 'Map.assign rhombus-realm "Mutable_Map" map)]))
 
@@ -106,4 +108,10 @@
                                                  "cannot append a set and other value"
                                                  "set" map1
                                                  "other value" map2)])]
-    [else (raise-argument-error* '++ rhombus-realm "or(List, Array, Map, Set)" map1)]))
+    [(string? map1) (cond
+                      [(string? map2) (string-append-immutable map1 map2)]
+                      [else (raise-arguments-error* '++ rhombus-realm
+                                                    "cannot append a string and other value"
+                                                    "string" map1
+                                                    "other value" map2)])]
+    [else (raise-argument-error* '++ rhombus-realm "or(List, Array, Map, Set, String)" map1)]))

--- a/rhombus/scribblings/ref-map.scrbl
+++ b/rhombus/scribblings/ref-map.scrbl
@@ -89,14 +89,15 @@ operator.
   operator ((v1 :: Map) ++ (v2 :: Map)) :: Map,
   operator ((v1 :: Set) ++ (v2 :: Set)) :: Set,
   operator ((v1 :: List) ++ (v2 :: List)) :: List,
+  operator ((v1 :: String) ++ (v2 :: String)) :: String,
 ]{
 
- Appends @rhombus[v1] and @rhombus[v2] to create a new map, set, or
- list. In the case of maps, mappings for keys in @rhombus[v2] replace
+ Appends @rhombus[v1] and @rhombus[v2] to create a new map, set, list, or
+ string. In the case of maps, mappings for keys in @rhombus[v2] replace
  ones that exist already in @rhombus[v1]. In the case of sets, the new
- set has all of the elements of @rhombus[v1] and @rhombus[v2]. In the case
- of lists, the elements of @rhombus[v1] appear first in the result list
- followed by the elements of @rhombus[v2].
+ set has all of the elements of @rhombus[v1] and @rhombus[v2].
+ In the case of lists and strings, the elements of @rhombus[v1] appear
+ first in the result followed by the elements of @rhombus[v2].
 
  The combination
  @rhombus[$$(@rhombus(map_expr, ~var)) ++ {$$(@rhombus(key_expr, ~var)): $$(@rhombus(value_expr, ~var))}]
@@ -109,7 +110,8 @@ operator.
   m ++ {"x": 0},
   m,
   {1, 2, 3} ++ {"four", "five"},
-  [1, 2, 3] ++ [4, 5]
+  [1, 2, 3] ++ [4, 5],
+  "hello" ++ " " ++ "world"
 ]
 
 }


### PR DESCRIPTION
Adds a string case for `++` append so that two strings can be appended with it. It does not coerce other values to strings like `&` does.