### PR TITLE
Add str function, use with at-expressions

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -216,7 +216,7 @@ bind.infoer 'build_reverse_cons_infoer($in_id, ($a_in, $b_in))':
   | '($a_ann, $a_id, $a_info, ($a_bind_info ...), $a_matcher, $a_binder, $a_data)':
       match bind_ct.unpack_info(b)
       | '($b_ann, $b_id, $b_info, ($b_bind_info ...), $b_matcher, $b_binder, $b_data)':
-          '($("matching((_ :: " & unwrap_syntax(a_ann) & ") <> (_ :: " & unwrap_syntax(b_ann) & "))"),
+          '($(@str{matching((_ :: @unwrap_syntax[a_ann]) <> (_ :: @unwrap_syntax[b_ann]))}),
             pair,
             (),
             ($a_bind_info ... $b_bind_info ...),
@@ -342,7 +342,7 @@ fun
 | add_two(x) :: Number:
     x + 2.0
 | add_two(x, y) :: String:
-    x & " and " & y
+    @str{@x and @y}
 
 add_two(7) .= 9.0
 add_two(6, 7) == "6 and 7"
@@ -390,7 +390,7 @@ vec.angle
 vec.magnitude
 
 def AlsoPosn(also_x, also_y): Posn(10, 20)
-also_x & "," & also_y
+@str{@also_x, @also_y}
 
 expr.macro 'or_zero $p $tail ...':
   values(static_info_ct.wrap('$p || Posn(0,0)',
@@ -468,7 +468,7 @@ def local_map: Map(symbol(alice), Posn(4, 5),
 
 fun locale(who, neighborhood :: Map.of(Symbol, Posn)):
   val p: neighborhood[who]
-  p.x & ", " & p.y
+  @str{@(p.x), @(p.y)}
 
 locale(symbol(alice), local_map)
 
@@ -644,7 +644,7 @@ fun enumerate(l :: List):
   for:
     ~each v: l
     ~and  i: 0..
-    displayln(i & ". " & v)
+    displayln(@str{@i. @v})
 
 enumerate(["a", "b", "c"])
 
@@ -694,11 +694,11 @@ point_xs([[Posn(1, 2), Posn(0, 5)], [], [Posn(3, 3)]])
 
 for:
   ~each values(key, val): {1: "a", 2: "b"}
-  displayln(key & " -> " & val)
+  displayln(@str{@key -> @val})
 
 for:
   ~each (key, val): {3: "c", 4: "d"}
-  displayln(key & " -> " & val)
+  displayln(@str{@key -> @val})
 
 // stx_class
 

--- a/rhombus/private/string.rkt
+++ b/rhombus/private/string.rkt
@@ -1,17 +1,12 @@
 #lang racket/base
 (require racket/symbol
          racket/keyword
-         "define-operator.rkt"
          (prefix-in rhombus: "print.rkt"))
 
-(provide &)
+(provide str)
 
-(define-infix & append-as-strings
-  #:stronger-than (===))
-
-(define (append-as-strings a b)
-  (string-append-immutable (to-string a)
-                           (to-string b)))
+(define (str lst)
+  (apply string-append-immutable (map to-string lst)))
 
 (define (to-string a)
   (cond

--- a/rhombus/scribblings/bind-macro-protocol.scrbl
+++ b/rhombus/scribblings/bind-macro-protocol.scrbl
@@ -226,7 +226,7 @@ form. A builder must be used in tail position, and it's
       val b_info: bind_ct.get_info(b, '()')
       val '($a_ann, $a_name, ($a_val_info ...), ($a_bind ...), $_, $_, $_)': bind_ct.unpack_info(a_info)
       val '($b_ann, $b_name, ($b_val_info ...), ($b_bind ...), $_, $_, $_)': bind_ct.unpack_info(b_info)
-      val ann: "and(" & unwrap_syntax(a_ann) & ", " & unwrap_syntax(b_ann) & ")"
+      val ann: @str{and(@unwrap_syntax[a_ann], @unwrap_syntax[b_ann])}
       '($ann,
         $a_name,
         ($a_val_info ... $b_val_info ...),

--- a/rhombus/scribblings/conditional.scrbl
+++ b/rhombus/scribblings/conditional.scrbl
@@ -99,9 +99,9 @@ case with the right number of arguments.
 @(rhombusblock:
     fun
     | hello(name):
-        "Hello, " & name    // & coerces to strings and concatenates
+        @str{Hello, @name}    // str coerces to strings and concatenates
     | hello(first, last):
-        hello(first & " " & last)
+        hello(@str{@first @last})
 
     hello("World")             // prints "Hello, World"
     hello("Inigo", "Montoya")  // prints "Hello, Inigo Montoya"

--- a/rhombus/scribblings/for.scrbl
+++ b/rhombus/scribblings/for.scrbl
@@ -31,7 +31,7 @@ all elements are used for the second @rhombus[~each] clause, and so on.
   for:
     ~each friend: ["Alice", "Bob", "Carol"]
     ~each say: ["Hello", "Goodbye"]
-    displayln(say & ", " & friend & "!")
+    displayln(@str{@say, @friend!})
 ]
 
 An advantage of having @rhombus[~each] clauses in the body of
@@ -42,9 +42,9 @@ languages, is that definitions or expressions can be written among
 @demo[
   for:
     ~each friend: ["Alice", "Bob", "Carol"]
-    val dear_friend: "dear " & friend
+    val dear_friend: @str{dear @friend}
     ~each say: ["Hello", "Goodbye"]
-    displayln(say & ", " & dear_friend & "!")
+    displayln(@str{@say, @dear_friend!})
 ]
 
 To draw elements from sequences in parallel, use @rhombus[~and]
@@ -54,7 +54,7 @@ instead of @rhombus[~each] for every additional sequence.
   for:
     ~each friend: ["Alice", "Bob", "Carol"]
     ~and  index: 1..4
-    displayln(index & ". " & friend)
+    displayln(@str{@index. @friend})
 ]
 
 In this latest example, the sequence for @rhombus[index] could be
@@ -72,7 +72,7 @@ body.
 @demo[
   for List:
     ~each i: 1..4
-    "number " & i,
+    @str{number @i},
   for List:
     ~each i: [1, 2]
     ~each j: ["a", "b", "c"]

--- a/rhombus/scribblings/map.scrbl
+++ b/rhombus/scribblings/map.scrbl
@@ -90,7 +90,7 @@ for keys and one for values:
 @(rhombusblock:
     fun locale(who, neighborhood -: Map.of(String, Posn)):
       val p: neighborhood[who]
-      p.x & ", " & p.y
+      @str{@(p.x), @(p.y)}
 
     locale("alice", neighborhood)  // prints "4, 5"
   )

--- a/rhombus/scribblings/ref-for.scrbl
+++ b/rhombus/scribblings/ref-for.scrbl
@@ -86,7 +86,7 @@
   for:
     ~each v: ["a", "b", "c"]
     ~and  i: 0..
-    displayln(i & ". " & v),
+    displayln(@str{@i. @v}),
   fun grid(m, n):
     for List:
       ~each i: 0..m
@@ -114,7 +114,7 @@
   grid2(2, 3),
   for Map:
     ~each i: 0..3
-    values(i, i & "!")
+    values(i, @str{@i!})
 ]
 
 }

--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -93,9 +93,9 @@
 
 @examples[
   fun | hello(name):
-          "Hello, " & name
+          @str{Hello, @name}
       | hello(first, last):
-          hello(first & " " & last),
+          hello(@str{@first @last}),
   hello("World"),
   hello("Inigo", "Montoya"),
 ]

--- a/rhombus/scribblings/ref-string.scrbl
+++ b/rhombus/scribblings/ref-string.scrbl
@@ -12,19 +12,20 @@
 }
 
 @doc[
-  operator (v1 & v2) :: String
+  fun str(lst :: List) :: String
 ]{
 
- Coerces @rhombus[v1] and @rhombus[v2] to a string, then appends the strings.
+ Coerces all of the elements of @rhombus[lst] to strings, then appends the strings.
 
  The string for of a value is the same way that @rhombus[display] would
  print it, which means that strings, symbols, and keywords print as their
  character content.
 
 @examples[
-  "hello" & "world",
-  "it goes to " & 11,
-  "the list " & [1, 2, 3] & " has " & 3 & " elements"
+  str(["hello", "world"]),
+  str(["it goes to ", 11]),
+  str(["the list ", [1, 2, 3], " has ", 3, " elements"]),
+  @str{the list @([1, 2, 3]) has @3 elements}
 ]
 
 }

--- a/scribble/private/docmodule.rhm
+++ b/scribble/private/docmodule.rhm
@@ -20,9 +20,8 @@ for_meta:
     match mod
     | '$(a :: Id)': a
     | '$a / $b ...':
-        base.#{string->symbol}(unwrap_syntax(a)
-                                 & "/"
-                                 & unwrap_syntax(translate_mod('$b ...')))
+        base.#{string->symbol}(
+          @str{@unwrap_syntax[a]/@unwrap_syntax[translate_mod('$b ...')]})
     | 'lib($str)':
         [symbol(lib), str]
 


### PR DESCRIPTION
Takes a single list argument because that's what at-expressions with `{}` expect.

```
> str(["the list ", [1, 2, 3], " has ", 3, " elements"])
"the list [1, 2, 3] has 3 elements"
> @str{the list @([1, 2, 3]) has @3 elements}
"the list [1, 2, 3] has 3 elements"
```