### PR TITLE
Custom Syntax Classes and `begin_for_meta`

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -700,3 +700,28 @@ for:
   ~each (key, val): {3: "c", 4: "d"}
   displayln(key & " -> " & val)
 
+// stx_class
+
+stx_class Arithmetic
+| '$x + $y'
+| '$x - $y'
+
+val '$(exp :: Arithmetic)': '1 + 2'
+exp.x
+
+begin_for_meta:
+  stx_class Arithmetic2:
+    pattern
+    | '$x * $y'
+    | '$x / $y'
+
+expr.macro 'add_one_to_expr $(exp :: Arithmetic2) $tail ...':
+  values('$exp ... + 1', '$tail ...')
+
+add_one_to_expr 2 * 3
+
+expr.macro 'right_operand $(exp :: Arithmetic2)':
+  values(exp.y, '')
+
+right_operand 3 * 2
+right_operand 4 / 5

--- a/rhombus/macro.rkt
+++ b/rhombus/macro.rkt
@@ -17,7 +17,7 @@
         "private/syntax-error.rkt"
         "private/parsed.rkt"
         "private/syntax-meta-value.rkt"
-        (submod "private/syntax-class.rkt" for-macro))
+        (submod "private/syntax-class-syntax.rkt" for-macro))
 
 (require (only-in "private/import.rkt" for_meta))
 (provide (for-space rhombus/import for_meta))

--- a/rhombus/main.rkt
+++ b/rhombus/main.rkt
@@ -47,6 +47,8 @@
         "private/print.rkt"
         "private/syntax-object.rkt"
         "private/syntax-class.rkt"
+        "private/syntax-class-syntax.rkt"
+        "private/begin-for-meta.rkt"
         "private/for.rkt"
         "private/range.rkt")
 

--- a/rhombus/private/begin-for-meta.rkt
+++ b/rhombus/private/begin-for-meta.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse
+                     "parse.rkt")
+         (for-meta 2 racket/base)
+         "definition.rkt")
+
+(provide begin_for_meta)
+
+(define-syntax begin_for_meta
+  (definition-transformer
+    (lambda (stx)
+      (syntax-parse stx
+        #:datum-literals (block)
+        [(_ (block groups ...))
+         (list #`(begin-for-syntax
+                   (rhombus-top groups ...)))]
+        [_
+         (raise-syntax-error #f "expected block" stx)]))))

--- a/rhombus/private/syntax-class-syntax.rkt
+++ b/rhombus/private/syntax-class-syntax.rkt
@@ -1,0 +1,59 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse
+                     racket/list
+                     racket/set)
+         syntax/parse
+         (submod "quasiquote.rkt" convert)
+         (submod "syntax-class.rkt" for-syntax-class-syntax)
+         "definition.rkt"
+         "name-root.rkt")
+
+(provide
+ (rename-out [class stx_class]))
+
+(module+ for-macro
+  (provide syntax))
+
+(define-simple-name-root syntax
+  class)
+
+(define-for-syntax (generate-pattern-and-attributes stx)
+  (syntax-parse stx
+    #:datum-literals (alts group quotes)
+    [(block (group (quotes in-quotes)))
+     (define-values (p idrs sidrs can-be-empty?)
+       (convert-pattern #:splice? #t
+                        #'in-quotes))
+     (with-syntax ([((attr ...) ...)
+                    (map (lambda (binding) (cons '#:attr binding)) idrs)])
+       (values #`(pattern #,p attr ... ...)
+               (map (lambda (binding) (syntax-e (car (syntax->list binding)))) idrs)))]))
+
+(define-for-syntax (generate-syntax-class class-name alts)
+  (let-values ([(patterns attributes)
+                (for/lists (patterns attributes
+                                     #:result (values patterns (apply set-intersect attributes)))
+                           ([alt-stx (in-list alts)])
+                  (generate-pattern-and-attributes alt-stx))])
+    (list
+     #`(define-splicing-syntax-class #,class-name
+         #:datum-literals (block group quotes)
+         #,@patterns)
+     #`(define-syntax #,(in-syntax-class-space class-name)
+         (rhombus-syntax-class 'term #'#,class-name '#,attributes #f)))))
+
+(define-syntax class
+  (definition-transformer
+    (lambda (stx)
+      (syntax-parse stx
+        #:datum-literals (alts group quotes block pattern description)
+        ;; Classname and patterns shorthand
+        [(form-id class-name (alts alt ...))
+         (generate-syntax-class #'class-name (syntax->list #'(alt ...)))]
+        ;; Specify patterns with "pattern"
+        [(form-id class-name
+                  (block (group pattern (alts alt ...))))
+         (generate-syntax-class #'class-name (syntax->list #'(alt ...)))]
+        [_
+         (raise-syntax-error #f "expected alternatives" stx)]))))

--- a/rhombus/private/syntax-class.rkt
+++ b/rhombus/private/syntax-class.rkt
@@ -16,33 +16,27 @@
          Block
          Multi)
 
-(module+ for-macro
-  (provide syntax))
-
 (module+ for-quasiquote
   (provide (for-syntax in-syntax-class-space
                        rhombus-syntax-class?
                        rhombus-syntax-class-kind
-                       rhombus-syntax-class-class)))
+                       rhombus-syntax-class-class
+                       rhombus-syntax-class-attributes
+                       rhombus-syntax-class-built-in?)))
+                       
+(module+ for-syntax-class-syntax
+  (provide (for-syntax rhombus-syntax-class in-syntax-class-space)))
 
 (begin-for-syntax
   (define in-syntax-class-space (make-interned-syntax-introducer/add 'rhombus/syntax-class))
 
-  (struct rhombus-syntax-class (kind class)))
+  (struct rhombus-syntax-class (kind class attributes built-in?)))  
 
-(define-syntax Term (rhombus-syntax-class 'term #f))
-(define-syntax Id (rhombus-syntax-class 'term #'identifier))
-(define-syntax Op (rhombus-syntax-class 'term #':operator))
-(define-syntax Id_Op (rhombus-syntax-class 'term #':operator-or-identifier))
-(define-syntax Keyw (rhombus-syntax-class 'term #'keyword))
-(define-syntax Group (rhombus-syntax-class 'group #f))
-(define-syntax Multi (rhombus-syntax-class 'multi #f))
-(define-syntax Block (rhombus-syntax-class 'block #f))
-
-(define-simple-name-root syntax
-  class)
-
-(define-syntax class
-  (definition-transformer
-    (lambda (stx)
-      (raise-syntax-error 'syntax.class "not supported, yet" stx))))
+(define-syntax Term (rhombus-syntax-class 'term #f null #t))
+(define-syntax Id (rhombus-syntax-class 'term #'identifier null #t))
+(define-syntax Op (rhombus-syntax-class 'term #':operator null #t))
+(define-syntax Id_Op (rhombus-syntax-class 'term #':operator-or-identifier null #t))
+(define-syntax Keyw (rhombus-syntax-class 'term #'keyword null #t))
+(define-syntax Group (rhombus-syntax-class 'group #f null #t))
+(define-syntax Multi (rhombus-syntax-class 'multi #f null #t))
+(define-syntax Block (rhombus-syntax-class 'block #f null #t))

--- a/rhombus/private/syntax-rhs.rkt
+++ b/rhombus/private/syntax-rhs.rkt
@@ -27,11 +27,12 @@
   (define kind (syntax-parse pre-parsed
                  [(_ _ _ kind . _) (syntax-e #'kind)]))
   (define (macro-clause self-id left-ids tail-pattern rhs)
-    (define-values (pattern idrs can-be-empty?)
+    (define-values (pattern idrs sidrs can-be-empty?)
       (if (eq? kind 'rule)
           (convert-pattern #`(multi (group #,@tail-pattern (op $) tail (op rhombus...))))
           (convert-pattern #`(multi (group . #,tail-pattern)) #:as-tail? #t)))
     (with-syntax ([((id id-ref) ...) idrs]
+                  [((sid sid-ref) ...) sidrs]
                   [(left-id ...) left-ids])
       (define body
         (if (eq? kind 'rule)
@@ -40,7 +41,8 @@
             #`(rhombus-body-expression #,rhs)))
       #`[#,pattern
          (let ([id id-ref] ... [#,self-id self] [left-id left] ...)
-           #,body)]))
+           (let-syntax ([sid sid-ref] ...)
+             #,body))]))
   (define (convert-rule-template block ids)
     (syntax-parse block
       #:datum-literals (block group quotes op)
@@ -218,15 +220,17 @@
     [(pre-parsed id
                  tail-pattern
                  rhs)
-     (define-values (pattern idrs can-be-empty?) (convert-pattern #`(multi (group . tail-pattern)) #:as-tail? #t))
-     (with-syntax ([((p-id id-ref) ...) idrs])
+     (define-values (pattern idrs sidrs can-be-empty?) (convert-pattern #`(multi (group . tail-pattern)) #:as-tail? #t))
+     (with-syntax ([((p-id id-ref) ...) idrs]
+                   [((s-id sid-ref) ...) sidrs] )
        #`(#,make-transformer-id
           (let ([id (lambda (tail #,@tail-ids #,self-id)
                       (syntax-parse (respan-empty #,self-id tail)
                         [#,pattern
                          (let ([p-id id-ref] ...)
-                           #,(wrap-for-tail
-                              #`(rhombus-body-expression rhs)))]))])
+                           (let-syntax ([s-id sid-ref] ...)
+                             #,(wrap-for-tail
+                                #`(rhombus-body-expression rhs))))]))])
             id)))]))
 
 (define-for-syntax (parse-transformer-definition-sequence-rhs pre-parsed self-id
@@ -237,10 +241,12 @@
                                     #:tail-ids #'(tail-id)
                                     #:wrap-for-tail
                                     (lambda (body)
-                                      (define-values (pattern idrs can-be-empty?)
+                                      (define-values (pattern idrs sidrs can-be-empty?)
                                         (convert-pattern #`(multi . #,gs-stx)))
-                                      (with-syntax ([((p-id id-ref) ...) idrs])
+                                      (with-syntax ([((p-id id-ref) ...) idrs]
+                                                    [((s-id sid-ref) ...) sidrs])
                                         #`(syntax-parse tail-id
                                             [#,pattern
                                              (let ([p-id id-ref] ...)
-                                               #,body)])))))
+                                               (let-syntax ([s-id sid-ref] ...)
+                                                 #,body))])))))

--- a/rhombus/scribblings/macro.rhm
+++ b/rhombus/scribblings/macro.rhm
@@ -7,6 +7,7 @@ import:
 
 export:
   make_macro_eval
+  make_for_meta_eval
   close_eval
 
 fun make_macro_eval():
@@ -17,3 +18,15 @@ fun make_macro_eval():
     import: rhombus/macro open
   ]
   macro_eval
+
+fun make_for_meta_eval():
+  val meta_eval: manual.make_rhombus_eval()
+  @examples[
+    ~eval: meta_eval,
+    ~hidden: #true,
+    import: 
+      rhombus/macro open
+      for_meta:
+        rhombus open
+  ]
+  meta_eval

--- a/rhombus/scribblings/overview.scrbl
+++ b/rhombus/scribblings/overview.scrbl
@@ -23,3 +23,4 @@
 @include_section["defn-macro.scrbl"]
 @include_section["bind-macro.scrbl"]
 @include_section["annotation-vs-bind.scrbl"]
+@include_section["syntax-class.scrbl"]

--- a/rhombus/scribblings/syntax-class.scrbl
+++ b/rhombus/scribblings/syntax-class.scrbl
@@ -1,0 +1,89 @@
+#lang scribble/rhombus/manual
+@(import:
+    "util.rhm" open
+    "common.rhm" open)
+
+@title[~tag: "syntax-classes"]{Syntax Classes}
+
+In a Rhombus syntax form, pattern variables escaped with @rhombus[$] and 
+surrounded by parenthesescan be annotated with a syntax class name using 
+@rhombus[::] to specify the kind of syntax the pattern variable can match on. 
+Rhombus has several built-in syntax classes such as @rhombus[Term], 
+@rhombus[Group], and @rhombus[Multi].
+
+@(rhombusblock:
+    val '$(x :: Term)': '1'
+)
+
+Rhombus also supports user-defined syntax classes that can annotate pattern 
+variables in the same way. Custom syntax classes are useful for defining 
+resusable patterns that can vary. To define a syntax class, use the 
+@rhombus[stx_class] special form with a block that contains the form 
+@rhombus[pattern] followed by alternatives. 
+
+@(rhombusblock:
+    stx_class Arithmetic:
+        pattern
+        | '$x + $y'
+        | '$x - $y'
+)
+
+Or, use a shorthand syntax that omits the use of @rhombus[pattern].
+
+@(rhombusblock:
+    stx_class Arithmetic
+    | '$x + $y'
+    | '$x - $y'
+)
+
+To use a syntax class definion for a macro, place it inside a 
+@rhombus[begin_for_meta] block.
+
+@(rhombusblock:
+    begin_for_meta:
+        stx_class Arithmetic
+        | '$x + $y'
+        | '$x - $y'
+)
+
+The patterns of a syntax class are defined with quasiquoted syntax objects (@rhombus[''])
+and can include any literal syntax. Once defined, a custom syntax 
+class can be used to annotate a pattern variable that will match on the shape 
+of one of the specified pattern alternatives.
+
+@(rhombusblock:
+    expr.macro 'add_one_to_expr $(expr :: Arithmetic)':
+        values('$expr ... + 1', '')
+    
+    add_one_to_expr 1 + 1 // expands to: 1 + 1 + 1
+    add_one_to_expr 1 - 2 // expands to: 1 - 2 + 1
+    add_one_to_expr 2 > 3 // error, "expected Arithmetic"
+)
+
+The @rhombus[$]-escaped variables in a syntax class's patterns will bind to 
+matched syntax as attributes of the class. They can be accessed from a pattern 
+variable using dot-notation. 
+
+@(rhombusblock:
+    expr.macro 'right_operand $(expr :: Arithmetic)':
+        values(expr.y, '')
+    
+    right_operand 2 + 3 // expands to: 3
+    right_operand 8 - 4 // expands to: 4
+)
+
+Attributes of a syntax class must appear in every pattern alternative in order 
+to be referred to with dot-notation.
+
+@(rhombusblock:
+    stx_class Arithmetic
+    | '$x + $y + $z'
+    | '$x - $y'
+
+    val '$(expr :: Arithmetic)': '1 + 2 + 3' // matches successfully
+    expr.y // expands to: '2'
+    expr.z // error: attribute "z" not found
+)
+
+In other words, the attributes of a syntax class are defined by the intersection 
+of all escaped pattern variables found in the pattern alternatives. 


### PR DESCRIPTION
This pull request introduces user-defined custom syntax classes based on the design in [this discussion ](https://github.com/racket/rhombus-prototype/discussions/218). 

Features of syntax classes as of this PR:
- User-defined syntax class definition syntax with alternate syntax patterns
- Attributes of syntax classes defined by pattern variables in the alternates 
- Attributes accessible using dot notation

Features yet to come:
- Syntax class description field
- Extra attributes defined outside the given patterns
- Syntax classes usable within the definition of a syntax class
- Guards on alternates (`~when` clause) 

There were many changes to escaping inside quasiquote.rkt to allow a user of syntax classes to annotate pattern variables and be able to access the matched syntax as well as newly introduced attributes. One change to take note of is the introduction of `sidrs` or "syntax idrs" being returned from `convert-pattern` along with `idrs`. These `sidrs` are used with `let-syntax` to treat matched pattern variables as special macros that may dispatch on either the full syntax or an attribute of the syntax's syntax class using dot notation. 

This PR also includes the introduction of `begin_for_meta` which works just like `begin-for-syntax` in Racket. 

See overview documentation in syntax-class.scrbl, reference in ref-stxobj.scrbl, and examples in demo.rhm. 
