### PR TITLE
revise syntax class documentation

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -700,9 +700,9 @@ for:
   ~each (key, val): {3: "c", 4: "d"}
   displayln(key & " -> " & val)
 
-// stx_class
+// syntax.class
 
-stx_class Arithmetic
+syntax.class Arithmetic
 | '$x + $y'
 | '$x - $y'
 
@@ -710,7 +710,7 @@ val '$(exp :: Arithmetic)': '1 + 2'
 exp.x
 
 begin_for_meta:
-  stx_class Arithmetic2:
+  syntax.class Arithmetic2:
     pattern
     | '$x * $y'
     | '$x / $y'

--- a/rhombus/macro.rkt
+++ b/rhombus/macro.rkt
@@ -16,8 +16,7 @@
         "private/import-syntax.rkt"
         "private/syntax-error.rkt"
         "private/parsed.rkt"
-        "private/syntax-meta-value.rkt"
-        (submod "private/syntax-class-syntax.rkt" for-macro))
+        "private/syntax-meta-value.rkt")
 
 (require (only-in "private/import.rkt" for_meta))
 (provide (for-space rhombus/import for_meta))

--- a/rhombus/main.rkt
+++ b/rhombus/main.rkt
@@ -50,7 +50,8 @@
         "private/syntax-class-syntax.rkt"
         "private/begin-for-meta.rkt"
         "private/for.rkt"
-        "private/range.rkt")
+        "private/range.rkt"
+        "private/syntax-class-syntax.rkt")
 
 (module reader syntax/module-reader
   #:language 'rhombus

--- a/rhombus/private/syntax-class-syntax.rkt
+++ b/rhombus/private/syntax-class-syntax.rkt
@@ -9,11 +9,7 @@
          "definition.rkt"
          "name-root.rkt")
 
-(provide
- (rename-out [class stx_class]))
-
-(module+ for-macro
-  (provide syntax))
+(provide syntax)
 
 (define-simple-name-root syntax
   class)

--- a/rhombus/scribblings/ref-begin-meta.scrbl
+++ b/rhombus/scribblings/ref-begin-meta.scrbl
@@ -1,0 +1,27 @@
+#lang scribble/rhombus/manual
+@(import: 
+    "common.rhm" open 
+    "macro.rhm")
+
+@title{For-Meta Sequences}
+
+@doc[
+  defn.macro 'begin_for_meta:
+                $body
+                ...'
+]{
+
+ The same as the @rhombus[body] sequence, but shifted to one phase
+ greater. Defintions inside a @rhombus[begin_for_meta] block can be
+ referenced in macro implements, for example.
+
+@examples[
+  ~eval: macro.make_for_meta_eval(),
+  begin_for_meta:
+    syntax.class Arithmetic
+    | '$x + $y'
+    | '$x - $y',
+  expr.macro 'right_operand $(exp :: Arithmetic)':
+    values(exp.y, ''),
+  right_operand 1 + 2
+]}

--- a/rhombus/scribblings/ref-stxobj.scrbl
+++ b/rhombus/scribblings/ref-stxobj.scrbl
@@ -3,7 +3,7 @@
     "common.rhm" open 
     "macro.rhm")
 
-@title{Syntax Objects}
+@title[~tag: "stxobj"]{Syntax Objects}
 
 Syntax objects can be constructed using the expression syntax
 @rhombus['$$(@rhombus[term, ~var]) ...; ...'], which creates
@@ -74,7 +74,8 @@ corresponding portion of a candidate syntax object. Ellipses, etc.
  object that matches the @rhombus['', ~bind] form.
 
  The @rhombus[syntax_class] can be @rhombus[Term, ~stxclass], @rhombus[Id, ~stxclass],
- or @rhombus[Group, ~stxclass], among others.
+ or @rhombus[Group, ~stxclass], among other built-in classes, or it can be a class defined
+ with @rhombus[syntax.class].
 
 }
 
@@ -132,88 +133,4 @@ corresponding portion of a candidate syntax object. Ellipses, etc.
   literal_syntax (x),
   literal_syntax '1 ... 2',
   literal_syntax '$ $ $'
-]}
-
-While many syntax classes available for use are built into the language, rhombus 
-also supports user-defined syntax classes with @rhombus[stx_class]. 
-
-@doc[
-  defn.macro '«stx_class $name:
-                pattern
-                | '$expr_pattern'
-                | ...»',
-  defn.macro '«stx_class $name
-               | '$expr_pattern'
-               |...»'
-]{
-
-Syntax classes can be defined with the use of @rhombus[stx_class] followed by 
-an identifier and a block containing the form @rhombus[patterns] followed by
-alternatives. They can also be defined with a shorthand syntax where the 
-alternatives come right after the identifier. 
-
-In each alternative, there should be a syntax pattern. 
-These will define the patterns that will be matched on when the syntax class is 
-used to annotate a pattern variable in another syntax pattern. 
-
-Any pattern variables included in these syntax pattern alternatives will be 
-available as attributes of the syntax class using dot-notation. For an attribute
-to be accessible, it must be pressent in every alternate syntax pattern in the 
-syntax class definition.
-
-@examples[
-  stx_class Arithmetic
-  | '$x + $y'
-  | '$x - $y',
-  stx_class Labeled:
-    pattern
-    | '~foo $n'
-    | '~bar $n',
-  val '$(exp :: Arithmetic)': '1 + 2',
-  exp.x,
-  val '$(l :: Labeled)': '~bar 5',
-  l.n
-]}
-
-To use a syntax class inside a macro definion, put the definition inside a 
-@rhombus[begin_for_meta] block. Any and all defintions inside a 
-@rhombus[begin_for_meta] block will be defined for use inside macros. 
-
-@doc[
-  defn.macro 'begin_for_meta:
-                $body
-                ...'
-]{
-
-@examples[
-  ~eval: macro.make_for_meta_eval(),
-  begin_for_meta:
-    stx_class Arithmetic
-    | '$x + $y'
-    | '$x - $y',
-  expr.macro 'right_operand $(exp :: Arithmetic)':
-    values(exp.y, ''),
-  right_operand 1 + 2
-]
-
-Pattern variables annotated with a syntax class can be used on their own 
-to generate the syntax they are bound to or inside templates where they 
-are escaped with a @rhombus[$]. To use an attribute on a pattern variable 
-inside a template, the form must be a @rhombus[$] escape followed by 
-parentheses that have the pattern variable identifier, a dot, and then the 
-attribute identifier. To use the entire syntax that was matched, escape the 
-identifier with @rhombus[$] and follow it with @rhombus[...]. 
-
-@examples[
-  ~eval: macro.make_for_meta_eval(),
-  begin_for_meta:
-    stx_class Arithmetic
-    | '$x + $y'
-    | '$x - $y',
-  expr.macro 'doubled_operands $(e :: Arithmetic)':
-    values('$(e.x) * 2 + $(e.y) * 2', ''),
-  doubled_operands 3 + 5,
-  expr.macro 'add_one_to_expression $(e :: Arithmetic)':
-    values('$e ... + 1', ''),
-  add_one_to_expression 2 + 2
 ]}

--- a/rhombus/scribblings/ref-syntax-class.scrbl
+++ b/rhombus/scribblings/ref-syntax-class.scrbl
@@ -1,0 +1,62 @@
+#lang scribble/rhombus/manual
+@(import: 
+    "common.rhm" open 
+    "macro.rhm")
+
+@(def list(xs, ...): xs)
+
+@title{Syntax Classes}
+
+@doc[
+  defn.macro '«syntax.class $name:
+                pattern
+                | $syntax_pattern
+                | ...»',
+  defn.macro '«syntax.class $name
+               | $syntax_pattern
+               | ...»'
+]{
+
+ Defines a syntax class that can be used in syntax patterns with
+ @rhombus[::]. The @rhombus[pattern] subform is optional in the sense
+ that pattern alternatives can be inlined directly in the
+ @rhombus[syntax.class] form (but the @rhombus[patttern] subform makes
+ room for additional subforms in the future).
+
+ When a variable @rhombus[id, ~var] is bound through a
+ @seclink["stxobj"]{syntax pattern} with
+ @rhombus[$($$(@rhombus[id, ~var]) :: $$(@rhombus[stx_class_id, ~var]))],
+ it matches a syntax object that matches any of the
+ @rhombus[syntax_pattern]s in the definition of
+ @rhombus[stx_class_id ,~var], the @rhombus[syntax_pattern]s are tried
+ first to last. A pattern variable that is included in all of the
+ @rhombus[syntax_pattern]s is an attribute of the syntax class, which is
+ accessed from a binding @rhombus[id, ~var] using dot notation. For
+ example, if the pattern variable is @rhombus[attr_id, ~var], its value is
+ accessed from @rhombus[id, ~var] using
+ @list[@rhombus[id, ~var], @rhombus[.], @rhombus[attr_id, ~var]]. To use an attribute
+ within a template, parentheses are needed around the variable name,
+ @rhombus[.], and attribue name to group them together if the variable
+ name is preceded by a @rhombus[$] escape:
+ @rhombus[$($$(@list[@rhombus[id, ~var], @rhombus[.], @rhombus[attr_id, ~var]]))].
+
+ A variable bound with a syntax class (within a syntax pattern) can be
+ used without dot notation. In that case, the result is a sequence of
+ syntax objects corresponding to the entire match of a
+ @rhombus[syntax_pattern], as opposed to an indvidual attributes within
+ the match. Use @rhombus[...] after a @rhombus[$]-escaped reference to
+ the variable in a syntax template.
+
+@examples[
+  ~eval: macro.make_for_meta_eval(),
+  begin_for_meta:
+    syntax.class Arithmetic
+    | '$x + $y'
+    | '$x - $y',
+  expr.macro 'doubled_operands $(e :: Arithmetic)':
+    values('$(e.x) * 2 + $(e.y) * 2', ''),
+  doubled_operands 3 + 5,
+  expr.macro 'add_one_to_expression $(e :: Arithmetic)':
+    values('$e ... + 1', ''),
+  add_one_to_expression 2 + 2
+]}

--- a/rhombus/scribblings/reference.scrbl
+++ b/rhombus/scribblings/reference.scrbl
@@ -32,7 +32,9 @@
 @include_section["ref-values.scrbl"]
 @include_section["ref-annotation.scrbl"]
 @include_section["ref-stxobj.scrbl"]
+@include_section["ref-syntax-class.scrbl"]
 @include_section["ref-macro.scrbl"]
+@include_section["ref-begin-meta.scrbl"]
 
 @include_section["ref-io.scrbl"]
 

--- a/rhombus/scribblings/syntax-class.scrbl
+++ b/rhombus/scribblings/syntax-class.scrbl
@@ -5,78 +5,80 @@
 
 @title[~tag: "syntax-classes"]{Syntax Classes}
 
-In a Rhombus syntax form, pattern variables escaped with @rhombus[$] and 
-surrounded by parenthesescan be annotated with a syntax class name using 
-@rhombus[::] to specify the kind of syntax the pattern variable can match on. 
-Rhombus has several built-in syntax classes such as @rhombus[Term], 
-@rhombus[Group], and @rhombus[Multi].
+As shown in @secref["syntax"], a variable can be bound in a syntax
+pattern via @rhombus[$], parentheses, @rhombus[::], and a
+@deftech{syntax class} name to specify the kind of syntax the pattern
+variable can match. The syntax classes @rhombus[Term, ~stxclass],
+@rhombus[Group, ~stxclass], and @rhombus[Multi, ~stxclass] are built in,
+among others.
 
 @(rhombusblock:
     val '$(x :: Term)': '1'
 )
 
-Rhombus also supports user-defined syntax classes that can annotate pattern 
-variables in the same way. Custom syntax classes are useful for defining 
-resusable patterns that can vary. To define a syntax class, use the 
-@rhombus[stx_class] special form with a block that contains the form 
-@rhombus[pattern] followed by alternatives. 
+Rhombus also supports user-defined syntax classes via
+@rhombus[syntax.class]. Use the @rhombus[syntax.class] form with a block
+that contains @rhombus[pattern] with pattern alternatives:
 
 @(rhombusblock:
-    stx_class Arithmetic:
-        pattern
-        | '$x + $y'
-        | '$x - $y'
+    syntax.class Arithmetic:
+     pattern
+     | '$x + $y'
+     | '$x - $y'
 )
 
-Or, use a shorthand syntax that omits the use of @rhombus[pattern].
+Equivalently, use a shorthand syntax that omits the use of
+@rhombus[pattern] an inlines alternatives into the immediate
+@rhombus[syntax.class] form:
 
 @(rhombusblock:
-    stx_class Arithmetic
+    syntax.class Arithmetic
     | '$x + $y'
     | '$x - $y'
 )
 
-To use a syntax class definion for a macro, place it inside a 
+Defining a syntax class in this way makes it available for use in syntax
+patterns, such as in @rhombus[match]. The syntax class must be defined
+at the same phase as the referencing pattern. To define a syntax class
+for use in a macro definition, place it inside a
 @rhombus[begin_for_meta] block.
 
 @(rhombusblock:
     begin_for_meta:
-        stx_class Arithmetic
-        | '$x + $y'
-        | '$x - $y'
+      syntax.class Arithmetic
+      | '$x + $y'
+      | '$x - $y'
 )
 
-The patterns of a syntax class are defined with quasiquoted syntax objects (@rhombus[''])
-and can include any literal syntax. Once defined, a custom syntax 
-class can be used to annotate a pattern variable that will match on the shape 
-of one of the specified pattern alternatives.
+Once defined, a syntax class can be used to annotate a pattern variable
+that matches any of pattern alternatives specified in the syntax class.
 
 @(rhombusblock:
     expr.macro 'add_one_to_expr $(expr :: Arithmetic)':
-        values('$expr ... + 1', '')
-    
+      values('$expr ... + 1', '')
+
     add_one_to_expr 1 + 1 // expands to: 1 + 1 + 1
     add_one_to_expr 1 - 2 // expands to: 1 - 2 + 1
     add_one_to_expr 2 > 3 // error, "expected Arithmetic"
 )
 
-The @rhombus[$]-escaped variables in a syntax class's patterns will bind to 
-matched syntax as attributes of the class. They can be accessed from a pattern 
-variable using dot-notation. 
+The @rhombus[$]-escaped variables in a syntax class's patterns bind to
+matched syntax objects as attributes of the class. They can be accessed
+from a pattern variable using dot notation.
 
 @(rhombusblock:
     expr.macro 'right_operand $(expr :: Arithmetic)':
-        values(expr.y, '')
-    
+      values(expr.y, '')
+
     right_operand 2 + 3 // expands to: 3
     right_operand 8 - 4 // expands to: 4
 )
 
-Attributes of a syntax class must appear in every pattern alternative in order 
-to be referred to with dot-notation.
+An attribute is accessible only when it appears in every pattern
+alternative of a syntax class.
 
 @(rhombusblock:
-    stx_class Arithmetic
+    syntax.class Arithmetic
     | '$x + $y + $z'
     | '$x - $y'
 

--- a/scribble/private/typeset-doc.rkt
+++ b/scribble/private/typeset-doc.rkt
@@ -16,10 +16,10 @@
                   in-folder-space)
          (only-in rhombus
                   def val fun operator :: |.| $
-                  [= rhombus-=])
-         (only-in rhombus/macro
-                  decl defn expr imp annotation bind folder
+                  [= rhombus-=]
                   [syntax rhombus-syntax])
+         (only-in rhombus/macro
+                  decl defn expr imp annotation bind folder)
          (only-in "rhombus.rhm"
                   rhombusblock
                   [rhombus one-rhombus])


### PR DESCRIPTION
Besides reorganizing the documentation a little, this patch drops `stx_class` in favor of `syntax.class`, which was also in
place before. (As `stx_class` was being developed, I had forgotten that a dummy `syntax.class` was in place already. Seeing it at the level of documentation made me think it might be better).

Part of the reorganization is a style for the reference area that is different than the guide area. A reference page is not so much meant to be read from top to bottom, but instead the description of something like `syntax.class` is meant to be all under the `doc` form for `syntax.class`. Another part of the reorganization splits things into separate sections; I'm not sure that's better, but I like it more after trying it.

Finally, `syntax` (to access `syntax.class`) moves here from `rhombus/macro` to just `rhombus`, since it's useful at phase 0 with `match` and similar. It gets imported at phase 1 by importing `rhombus/macro`, since `rhombus/macro` reexports all of `rhombus` at phase 1.