### PR TITLE
Custom attributes for syntax classes

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -725,3 +725,31 @@ expr.macro 'right_operand $(exp :: Arithmetic2)':
 
 right_operand 3 * 2
 right_operand 4 / 5
+
+syntax.class NTerms
+| '~one $a':
+    ~attr b:
+      '0'
+    ~attr c:
+      '0'
+    def sum:
+      unwrap_syntax(a) + unwrap_syntax(b) + unwrap_syntax(c)
+    ~attr average:
+      '$(sum / 2)'
+| '~two $a $b':
+    ~attr c:
+      '0'
+    def sum:
+      unwrap_syntax(a) + unwrap_syntax(b) + unwrap_syntax(c)
+    ~attr average:
+      '$(sum / 2)'
+| '~three $a $b $c':
+    def sum:
+      unwrap_syntax(a) + unwrap_syntax(b) + unwrap_syntax(c)
+    ~attr average:
+      '$(sum / 2)'
+
+val '$(two_terms :: NTerms)': '~two 24 42'
+two_terms.a
+two_terms.c
+two_terms.average

--- a/rhombus/private/syntax-class-syntax.rkt
+++ b/rhombus/private/syntax-class-syntax.rkt
@@ -37,11 +37,15 @@
                  ([g (in-list (syntax->list #'(groups ...)))])
          (syntax-parse g
            #:datum-literals (group block)
-           [(group #:attr id (block in-block ...))
-            (with-syntax ([(other ...) (reverse other-forms)])
+           [(group #:attr attr-id (block in-block ...))
+            (with-syntax ([(other ...) (reverse other-forms)]
+                          [((id id-ref) ...) (append idrs attrs)])
               (values
                other-forms
-               (cons #`[id (rhombus-body other ... in-block ...)] attrs)))]
+               (cons
+                #`[attr-id (let ([id id-ref] ...)
+                             (rhombus-body-at attr-id other ... in-block ...))]
+                attrs)))]
            [other
             (values (cons #'other other-forms) attrs)])))
      (define all-attrs (append idrs explicit-attrs))

--- a/rhombus/private/syntax-class-syntax.rkt
+++ b/rhombus/private/syntax-class-syntax.rkt
@@ -41,7 +41,7 @@
             (with-syntax ([(other ...) (reverse other-forms)])
               (values
                other-forms
-               (cons #`[id (quote-syntax (rhombus-body other ... in-block ...))] attrs)))]
+               (cons #`[id (rhombus-body other ... in-block ...)] attrs)))]
            [other
             (values (cons #'other other-forms) attrs)])))
      (define all-attrs (append idrs explicit-attrs))

--- a/rhombus/scribblings/ref-syntax-class.scrbl
+++ b/rhombus/scribblings/ref-syntax-class.scrbl
@@ -10,17 +10,23 @@
 @doc[
   defn.macro '«syntax.class $name:
                 pattern
-                | $syntax_pattern
+                | $clause
                 | ...»',
   defn.macro '«syntax.class $name
-               | $syntax_pattern
-               | ...»'
+               | $clause
+               | ...»',
+  grammar clause:
+    $syntax_pattern
+    $syntax_pattern: $pattern_body; ...,
+  grammar pattern_body:
+    $body
+    ~attr $identifier: $body; ...
 ]{
 
  Defines a syntax class that can be used in syntax patterns with
  @rhombus[::]. The @rhombus[pattern] subform is optional in the sense
  that pattern alternatives can be inlined directly in the
- @rhombus[syntax.class] form (but the @rhombus[patttern] subform makes
+ @rhombus[syntax.class] form (but the @rhombus[pattern] subform makes
  room for additional subforms in the future).
 
  When a variable @rhombus[id, ~var] is bound through a
@@ -48,10 +54,12 @@
  the variable in a syntax template.
 
 Custom attributes of a syntax class can be defined in a block following a 
-pattern alternative with the form @rhombus[~attr id: attribute]. Inside the 
-block after a pattern alternatives, any definition form is valid but only the 
-variables defined with @rhombus[~attr] are exported as attributes of the syntax 
-class.
+pattern alternative. Inside this block, any code is valid including local 
+definitions. Pattern variables mentioned in the original syntax pattern
+will be bound and available for use in the scope of this block. The 
+@rhombus[~attr id: body] form can be used inside a pattern body to define a 
+custom attribute. Identifiers bound to values with @rhombus[~attr] will be 
+available for use locally and also exported as an attribute of the syntax class. 
 
 @examples[
   ~eval: macro.make_for_meta_eval(),

--- a/rhombus/scribblings/ref-syntax-class.scrbl
+++ b/rhombus/scribblings/ref-syntax-class.scrbl
@@ -36,16 +36,22 @@
  accessed from @rhombus[id, ~var] using
  @list[@rhombus[id, ~var], @rhombus[.], @rhombus[attr_id, ~var]]. To use an attribute
  within a template, parentheses are needed around the variable name,
- @rhombus[.], and attribue name to group them together if the variable
+ @rhombus[.], and attribute name to group them together if the variable
  name is preceded by a @rhombus[$] escape:
  @rhombus[$($$(@list[@rhombus[id, ~var], @rhombus[.], @rhombus[attr_id, ~var]]))].
 
  A variable bound with a syntax class (within a syntax pattern) can be
  used without dot notation. In that case, the result is a sequence of
  syntax objects corresponding to the entire match of a
- @rhombus[syntax_pattern], as opposed to an indvidual attributes within
+ @rhombus[syntax_pattern], as opposed to an individual attributes within
  the match. Use @rhombus[...] after a @rhombus[$]-escaped reference to
  the variable in a syntax template.
+
+Custom attributes of a syntax class can be defined in a block following a 
+pattern alternative with the form @rhombus[~attr id: attribute]. Inside the 
+block after a pattern alternatives, any definition form is valid but only the 
+variables defined with @rhombus[~attr] are exported as attributes of the syntax 
+class.
 
 @examples[
   ~eval: macro.make_for_meta_eval(),
@@ -58,5 +64,24 @@
   doubled_operands 3 + 5,
   expr.macro 'add_one_to_expression $(e :: Arithmetic)':
     values('$e ... + 1', ''),
-  add_one_to_expression 2 + 2
+  add_one_to_expression 2 + 2,
+  begin_for_meta:
+    syntax.class NTerms
+    | '~one $a':
+        ~attr b:
+          '0'
+        ~attr average:
+          '$(unwrap_syntax(a) / 2)'
+    | '~two $a $b':
+        def sum:
+          unwrap_syntax(a) + unwrap_syntax(b)
+        ~attr average:
+          '$(sum / 2)',
+  expr.macro 'second_term $(e :: NTerms)':
+    values(e.b, ''),
+  second_term ~two 1 2,
+  second_term ~one 3,
+  expr.macro 'average $(e :: NTerms)':
+    values(e.average, ''),
+  average ~two 24 42
 ]}


### PR DESCRIPTION
This PR introduces a feature to syntax classes that allows users to define custom explicit attributes on top of the one implicit in the patterns. This also allows users to write arbitrary definitions after a pattern alternative and then choose definitions to expose with the `~attr id: value` form. 