### PR TITLE
Syntax class description

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -715,6 +715,7 @@ exp.x
 
 begin_for_meta:
   syntax.class Arithmetic2:
+    description: "multiplication or division forms"
     pattern
     | '$x * $y'
     | '$x / $y'

--- a/rhombus/private/syntax-class-syntax.rkt
+++ b/rhombus/private/syntax-class-syntax.rkt
@@ -98,7 +98,7 @@
                   (generate-pattern-and-attributes alt-stx))])
     (list
      #`(define-splicing-syntax-class #,class-name
-         #:description #,(if description #`(rhombus-body #,description) #f)
+         #:description #,(if description #`(rhombus-body #,@description) #f)
          #:datum-literals (block group quotes)
          #,@patterns)
      #`(define-syntax #,(in-syntax-class-space class-name)
@@ -142,7 +142,7 @@
         ;; Specify patterns with "pattern"
         [(form-id class-name
                   (block
-                   (~optional (group description (block class-desc)))
+                   (~optional (group description (block class-desc ...)))
                    (group pattern (alts alt ...))))
          (generate-syntax-class stx #'class-name (syntax->list #'(alt ...)) (attribute class-desc))]
         [_

--- a/rhombus/private/syntax-class-syntax.rkt
+++ b/rhombus/private/syntax-class-syntax.rkt
@@ -90,7 +90,7 @@
                    (block body ...)))
      (generate #'in-quotes #'(body ...))]))
 
-(define-for-syntax (generate-syntax-class stx class-name alts)
+(define-for-syntax (generate-syntax-class stx class-name alts description)
   (let-values ([(patterns attributes)
                 (for/lists (patterns attributess
                                      #:result (values patterns (intersect-attributes stx attributess)))
@@ -98,6 +98,7 @@
                   (generate-pattern-and-attributes alt-stx))])
     (list
      #`(define-splicing-syntax-class #,class-name
+         #:description #,(if description #`(rhombus-body #,description) #f)
          #:datum-literals (block group quotes)
          #,@patterns)
      #`(define-syntax #,(in-syntax-class-space class-name)
@@ -129,7 +130,6 @@
      ;; convert back to list of pairs
      (for/list ([(sym depth) (in-hash ht)])
        (cons sym depth))]))
-      
 
 (define-syntax class
   (definition-transformer
@@ -138,10 +138,12 @@
         #:datum-literals (alts group quotes block pattern description)
         ;; Classname and patterns shorthand
         [(form-id class-name (alts alt ...))
-         (generate-syntax-class stx #'class-name (syntax->list #'(alt ...)))]
+         (generate-syntax-class stx #'class-name (syntax->list #'(alt ...)) #f)]
         ;; Specify patterns with "pattern"
         [(form-id class-name
-                  (block (group pattern (alts alt ...))))
-         (generate-syntax-class stx #'class-name (syntax->list #'(alt ...)))]
+                  (block
+                   (~optional (group description (block class-desc)))
+                   (group pattern (alts alt ...))))
+         (generate-syntax-class stx #'class-name (syntax->list #'(alt ...)) (attribute class-desc))]
         [_
          (raise-syntax-error #f "expected alternatives" stx)]))))

--- a/rhombus/scribblings/ref-syntax-class.scrbl
+++ b/rhombus/scribblings/ref-syntax-class.scrbl
@@ -10,12 +10,16 @@
 
 @doc[
   defn.macro '«syntax.class $name:
+                $maybe_description
                 pattern
                 | $clause
                 | ...»',
   defn.macro '«syntax.class $name
                | $clause
                | ...»',
+  grammar maybe_description:
+    description: $body
+    $$("ϵ"),
   grammar clause:
     $syntax_pattern
     $syntax_pattern: $pattern_body; ...,
@@ -33,7 +37,12 @@
  @rhombus[::]. The @rhombus[pattern] subform is optional in the sense
  that pattern alternatives can be inlined directly in the
  @rhombus[syntax.class] form (but the @rhombus[pattern] subform makes
- room for additional subforms in the future).
+ room for additional subforms in the future). The optional
+ @rhombus[description] subform can be used before @rhombus[pattern] to define
+ the description of the syntax class. This description is used to produce 
+ clearer error messages when a term is rejected by the syntax class. 
+ It takes a block with an expression that may evaluate to a string or 
+ @rhombus[#false].
 
  When a variable @rhombus[id, ~var] is bound through a
  @seclink["stxobj"]{syntax pattern} with

--- a/rhombus/scribblings/ref-syntax-class.scrbl
+++ b/rhombus/scribblings/ref-syntax-class.scrbl
@@ -18,7 +18,7 @@
                | $clause
                | ...»',
   grammar maybe_description:
-    description: $body
+    description: $body; ...
     $$("ϵ"),
   grammar clause:
     $syntax_pattern
@@ -37,12 +37,15 @@
  @rhombus[::]. The @rhombus[pattern] subform is optional in the sense
  that pattern alternatives can be inlined directly in the
  @rhombus[syntax.class] form (but the @rhombus[pattern] subform makes
- room for additional subforms in the future). The optional
- @rhombus[description] subform can be used before @rhombus[pattern] to define
- the description of the syntax class. This description is used to produce 
- clearer error messages when a term is rejected by the syntax class. 
- It takes a block with an expression that may evaluate to a string or 
- @rhombus[#false].
+ room for additional subforms in the future). 
+
+ The optional @rhombus[description] subform can be used before @rhombus[pattern] 
+ to define the description of the syntax class. This description is used to 
+ produce clearer error messages when a term is rejected by the syntax class. 
+ It takes a block whose result must evaluate to a string or 
+ @rhombus[#false]. (Setting a description to @rhombus[#false] is equivalent
+ to not specifying a description at all and will mean the error message is not
+ customized.)
 
  When a variable @rhombus[id, ~var] is bound through a
  @seclink["stxobj"]{syntax pattern} with

--- a/rhombus/tests/syntax-class.rhm
+++ b/rhombus/tests/syntax-class.rhm
@@ -98,3 +98,20 @@ begin:
     match 'a 1'
     | '$(f :: Foo)': f.x
     '1'
+
+// check that syntax class description appears in match error
+begin:
+  check:
+    ~eval_exn
+    import:
+      rhombus/macro open
+    begin_for_meta:
+      syntax.class Arithmetic:
+        description: "an expression with addition or subtraction"
+        pattern
+        | '$x + $y'
+        | '$x - $y'
+    expr.macro 'right_operand $(e :: Arithmetic)':
+      values(e.y, '')
+    right_operand 1 +
+    "expression with addition or subtraction"


### PR DESCRIPTION
This adds the optional `description` field for syntax classes. It is equivalent to the `#:description` attribute on Racket syntax classes, so the field can be populated with any expression that evaluates to a string or `#false` and it will appear in error messages where a term is rejected by the syntax class. 