### PR TITLE
Use hashalw for maps and sets instead of hash

### DIFF
--- a/rhombus/private/map.rkt
+++ b/rhombus/private/map.rkt
@@ -33,7 +33,7 @@
 
 (define Map
   (lambda args
-    (define ht (hash))
+    (define ht (hashalw))
     (let loop ([ht ht] [args args])
       (cond
         [(null? args) ht]
@@ -70,7 +70,7 @@
      (syntax-parse stx
        [(_)
         #`[begin
-           ([ht #hash()])
+           ([ht #hashalw()])
            (add-to-map ht)
            #,map-static-info]]))))
 

--- a/rhombus/private/set.rkt
+++ b/rhombus/private/set.rkt
@@ -36,7 +36,7 @@
       (hash-remove! (set-ht s) v)))
 
 (define (Set . vals)
-  (define base-ht (hash))
+  (define base-ht (hashalw))
   (set (for/fold ([ht base-ht]) ([val (in-list vals)])
          (hash-set ht val #t))))
 
@@ -58,7 +58,7 @@
   (#%call-result ((#%map-ref set-ref))))
 
 (define (make_set . vals)
-  (define ht (make-hash))
+  (define ht (make-hashalw))
   (for ([v (in-list vals)])
     (hash-set! ht v #t))
   (set ht))

--- a/rhombus/tests/equality-map-set.rhm
+++ b/rhombus/tests/equality-map-set.rhm
@@ -1,0 +1,104 @@
+#lang rhombus
+import:
+  "check.rhm" open
+  racket/base open:
+    only: mcons
+
+check:
+  "apple" == "apple"
+  #true
+
+check:
+  [1, 2, 3] == 1
+  #false
+
+check:
+  [1, "apple", {"alice": 97}] == [1, "apple", {"alice": 97}]
+  #true
+
+check:
+  1 == 1.0
+  #false
+
+check:
+  "yes" == "yes"
+  #true
+
+check:
+  "yes" == "no"
+  #false
+
+check:
+  6 * 7 == 42
+  #true
+
+check:
+  expt(2, 100) == expt(2, 100)
+  #true
+
+check:
+  2 == 2.0
+  #false
+
+check:
+  [1, 2] == [1, 2]
+  #true
+
+check:
+  begin:
+    val v: mcons(1, 2)
+    v == v
+  #true
+
+check:
+  mcons(1, 2) == mcons(1, 2)
+  #false
+
+check:
+  {[1, 2]: 3}[[1, 2]]
+  3
+
+check:
+  ~exn
+  {mcons(1, 2): 3}[mcons(1, 2)]
+  "hash-ref: no value found for key"
+
+begin:
+  val a: mcons(1, 2)
+  val b: mcons(1, 2)
+  val m: {a: "a", b: "b"}
+  check:
+    m[a]
+    "a"
+  check:
+    m[b]
+    "b"
+
+check:
+  {[1, 2]}[[1, 2]]
+  #true
+
+check:
+  {mcons(1, 2)}[mcons(1, 2)]
+  #false
+
+check:
+  begin:
+    val v: mcons(1, 2)
+    {v}[v]
+  #true
+
+begin:
+  val a: mcons(1, 2)
+  val b: mcons(1, 2)
+  val c: mcons(1, 2)
+  val s: {a, b}
+  check:
+    s[a]
+    #true
+  check:
+    s[b]
+    #true
+  check:
+    s[c]
+    #false


### PR DESCRIPTION
Since the default equality operator `==` has equal-always behavior, maps and sets should be the same.