### PR TITLE
at-notation: use `()` instead of `[]` for arguments

### DIFF
--- a/enforest/scribblings/common.rhm
+++ b/enforest/scribblings/common.rhm
@@ -13,4 +13,4 @@ export:
 def shrubbery_doc: [symbol(lib), "shrubbery/scribblings/shrubbery.scrbl"]
 def rhombus_doc: [symbol(lib), "rhombus/scribblings/rhombus.scrbl"]
 
-def Rhombus: @seclink[~doc: rhombus_doc, "top"]{Rhombus}
+def Rhombus: @seclink(~doc: rhombus_doc, "top"){Rhombus}

--- a/enforest/scribblings/enforest.scrbl
+++ b/enforest/scribblings/enforest.scrbl
@@ -3,7 +3,7 @@
 
 @title{Enforestation with Macro Expansion}
 
-@seclink[~doc: shrubbery_doc, "top"]{Shrubbery notation} specifies
+@seclink(~doc: shrubbery_doc, "top"){Shrubbery notation} specifies
 how to parse a sequence of characters into a coarse-grained block
 structure, but it leaves the interpretation of that block structure to
 another layer of parsing---not to mention more fine-grained grouping in
@@ -18,14 +18,14 @@ although it's in many ways independent of a specific language. That's
 similar to referring to @emph{Racket expansion}, by which we do not
 necessarily mean something involving @litchar{#lang racket}.
 
-@table_of_contents[]
+@table_of_contents()
 
-@include_section["motivation.scrbl"]
-@include_section["syntactic-categories.scrbl"]
-@include_section["hierarchical-naming.scrbl"]
-@include_section["transformer.scrbl"]
-@include_section["precedence.scrbl"]
-@include_section["implicit-operator.scrbl"]
-@include_section["enforest-algorithm.scrbl"]
-@include_section["api.scrbl"]
-@include_section["example.scrbl"]
+@include_section("motivation.scrbl")
+@include_section("syntactic-categories.scrbl")
+@include_section("hierarchical-naming.scrbl")
+@include_section("transformer.scrbl")
+@include_section("precedence.scrbl")
+@include_section("implicit-operator.scrbl")
+@include_section("enforest-algorithm.scrbl")
+@include_section("api.scrbl")
+@include_section("example.scrbl")

--- a/enforest/scribblings/hierarchical-naming.scrbl
+++ b/enforest/scribblings/hierarchical-naming.scrbl
@@ -7,12 +7,12 @@ A language implemented with the Rhombus expander may have another
 dimension of name resolution that is orthogonal to different mapping
 spaces. For example, a language include a hierarchical naming strategy
 to reach a binding through sequence of identifiers separated by
-@rhombus[.], and hierarchical references might be used to reach mappings
+@rhombus(.), and hierarchical references might be used to reach mappings
 for expressions, bindings, or more. In the initial example in this
-proposal @rhombus[weather.currently_raining] is that kind of access, as
-is @rhombus[expr.macro] and @rhombus[bind.macro].
+proposal @rhombus(weather.currently_raining) is that kind of access, as
+is @rhombus(expr.macro) and @rhombus(bind.macro).
 
-The example language overloads @rhombus[.] for hierarchical namespace
+The example language overloads @rhombus(.) for hierarchical namespace
 use as well as field access, but the Rhombus expander minimizes any
 assumptions about the form of hierarchical names. A hierarchical
 reference must start with an identifier or operator that is mapped in

--- a/enforest/scribblings/motivation.scrbl
+++ b/enforest/scribblings/motivation.scrbl
@@ -35,26 +35,26 @@ to support:
     | should_take_cab(#false): #false
   )
 
-The intent here is that @rhombus[val] and @rhombus[fun] are
+The intent here is that @rhombus(val) and @rhombus(fun) are
 macro-implemented and recognize various forms of definitions, including
 simple binding, functions, and functions that have pattern-matching
-cases. The @rhombus[val] and @rhombus[function] forms are not meant to
-know about @rhombus[::] specifically; the @rhombus[::] is meant to be a
+cases. The @rhombus(val) and @rhombus(function) forms are not meant to
+know about @rhombus(::) specifically; the @rhombus(::) is meant to be a
 binding operator that checks whether the value flowing to the binding
 satisfies a predicate, and it may also associate compile-time
-information to a binding, such as the information that @rhombus[p] is a
-@rhombus[Posn] instance. The name @rhombus[Posn] works in an expression
+information to a binding, such as the information that @rhombus(p) is a
+@rhombus(Posn) instance. The name @rhombus(Posn) works in an expression
 to construct a position value, while in a binding position,
-@rhombus[Posn] works to construct a pattern-matching binding (again,
-without @rhombus[val] or @rhombus[fun] knowing anything specific about
-@rhombus[Posn]). Meanwhile, @rhombus[.], @rhombus[-], @rhombus[+],
-@rhombus[*], @rhombus[<], and @rhombus[||] are the obvious operators
-with the usual precedence. Unlike the other operators, the @rhombus[.]
+@rhombus(Posn) works to construct a pattern-matching binding (again,
+without @rhombus(val) or @rhombus(fun) knowing anything specific about
+@rhombus(Posn)). Meanwhile, @rhombus(.), @rhombus(-), @rhombus(+),
+@rhombus(*), @rhombus(<), and @rhombus(||) are the obvious operators
+with the usual precedence. Unlike the other operators, the @rhombus(.)
 operator's right-hand side is not an expression; it must always be an
-identifier. The @rhombus[weather.currently_raining] form looks like a
-use of the @rhombus[.] operator, but it's meant here to be a use of the
-namer @rhombus[weather] that is bound by @rhombus[import] and recognizes
-@rhombus[.] to access the imported @rhombus[currently_raining] binding,
+identifier. The @rhombus(weather.currently_raining) form looks like a
+use of the @rhombus(.) operator, but it's meant here to be a use of the
+namer @rhombus(weather) that is bound by @rhombus(import) and recognizes
+@rhombus(.) to access the imported @rhombus(currently_raining) binding,
 which might be a macro instead of a variable that is bound to a
 function.
 
@@ -69,10 +69,10 @@ new operators can be defined in a function-like way, like this:
   )
 
 Alternatively, operators can be defined in a more general, macro-like
-way. For example, defining @rhombus[->] as an alias for @rhombus[.]
-requires a macro, since the right-hand side of @rhombus[.] is not an
-expression. Using @rhombus[''] for ``quote'' and @rhombus[$] for ``unquote,''
-the @rhombus[->] operator might be implemented in a pattern-matching
+way. For example, defining @rhombus(->) as an alias for @rhombus(.)
+requires a macro, since the right-hand side of @rhombus(.) is not an
+expression. Using @rhombus('') for ``quote'' and @rhombus($) for ``unquote,''
+the @rhombus(->) operator might be implemented in a pattern-matching
 macro as
 
 @(rhombusblock:
@@ -82,14 +82,14 @@ macro as
     home->x + 1 // same as home.x + 1
 )
 
-The intent here is that @rhombus[expr.macro] (the @rhombus[.] there is
-like using an import, accessing the @rhombus[macro] form within an
-@rhombus[expr] group of bindings) allows a macro to consume as many
+The intent here is that @rhombus(expr.macro) (the @rhombus(.) there is
+like using an import, accessing the @rhombus(macro) form within an
+@rhombus(expr) group of bindings) allows a macro to consume as many
 terms after the operator as it wants, and the macro must return two
 values: a quoted expression for the expansion plus leftover terms for
-further expression parsing (i.e., @rhombus[tail] in the example use will
-hold @rhombus[+ 1]). Macros can work for other contexts, too, such as
-binding positions. Here's a definition that extends the @rhombus[<>]
+further expression parsing (i.e., @rhombus(tail) in the example use will
+hold @rhombus(+ 1)). Macros can work for other contexts, too, such as
+binding positions. Here's a definition that extends the @rhombus(<>)
 operator to make it work in binding positions:
 
 @(rhombusblock:
@@ -117,8 +117,8 @@ keyword arguments, for example) is likely a better choice of
 interoperability with Racket modules. The enforestation and expansion
 process here are defined in terms of the S-expression form of parsed
 shrubbery notation (really, syntax-object form, so it can include scopes
-to determine a mapping for identifiers and operators). The @rhombus[<>]
-and @rhombus[->] examples above use operator- and macro-definition forms
+to determine a mapping for identifiers and operators). The @rhombus(<>)
+and @rhombus(->) examples above use operator- and macro-definition forms
 in terms of shrubbery notation, but this proposal focused on the
 lower-level mechanisms that allow such shrubbery-native forms to be
 implemented.

--- a/enforest/scribblings/precedence.scrbl
+++ b/enforest/scribblings/precedence.scrbl
@@ -9,21 +9,21 @@ is, an operator can declare that its precedence is stronger than certain
 other operators, weaker than certain other operators, the same as
 certain other operators (implicitly including the operator itself), and
 the same as certain other operators when in a specific order (e.g.,
-@rhombus[*] is not allowed to the right of @rhombus[/]). An infix
+@rhombus(*) is not allowed to the right of @rhombus(/)). An infix
 operator's associativity is relevant only for operators at the same
 precedence (including the operator itself), as either left-associative,
 right-associative, or non-associative.
 
-Our example @rhombus[<>] definition did not specify any precedence
-relationships, so it cannot be used next to @rhombus[*]:
+Our example @rhombus(<>) definition did not specify any precedence
+relationships, so it cannot be used next to @rhombus(*):
 
 @(rhombusblock:
     1 <> 2 * 3 // not allowed
   )
 
-In this example, enforestation would report that @rhombus[<>] and
-@rhombus[*] are unrelated, so parentheses are needed somewhere. @Rhombus
-supports precedence declarations through a @rhombus[~weaker_than] keyword:
+In this example, enforestation would report that @rhombus(<>) and
+@rhombus(*) are unrelated, so parentheses are needed somewhere. @Rhombus
+supports precedence declarations through a @rhombus(~weaker_than) keyword:
 
 @(rhombusblock:
     operator (x <> y):

--- a/enforest/scribblings/syntactic-categories.scrbl
+++ b/enforest/scribblings/syntactic-categories.scrbl
@@ -8,12 +8,12 @@ different kinds of expansion contexts. The specific set of contexts
 depends on the language, and not the Rhombus expander, but here are some
 possible contexts:
 
-@itemlist[
+@itemlist(
   @item{declarations (in a module's immediate body or at the top level)},
   @item{definitions},
   @item{expressions},
-  @item{bindings (like @rhombus[match] patterns, but everywhere)}
-]
+  @item{bindings (like @rhombus(match) patterns, but everywhere)}
+)
 
 In Racket's expander, a few core contexts are reflected by
 @racket_syntax_local_context, but the Racket expander has only one kind
@@ -28,7 +28,7 @@ kinds of compile-time values for different contexts are recognized,
 but they are expected to be implemented through structure-type
 properties. A compile-time value can then implement multiple kinds of
 transformers to create a mapping that is works in multiple contexts.
-For example, the example @rhombus[<>] operator is useful in both expression
+For example, the example @rhombus(<>) operator is useful in both expression
 and binding contexts, with a suitable meaning in each context.
 
 Different contexts may also consult different mapping spaces in the
@@ -36,14 +36,14 @@ sense of @racket_provide_for_space. Contexts like declarations,
 definitions, and expressions are likely to use the default space, while
 binding, require, and provide contexts might use their own spaces. For
 example, in the prototype language supplied with this proposal,
-@rhombus[operator] and @rhombus[bind.macro] can both bind @rhombus[<>]
+@rhombus(operator) and @rhombus(bind.macro) can both bind @rhombus(<>)
 because the former binds in the default space and the latter in the
 binding space. The Rhombus expander itself is, again, parameterized over
 the way that mapping spaces are used.
 
 The relevant syntactic category for a shrubbery is determined by its
 surrounding forms, and not inherent to the shrubbery. For example,
-@rhombus[Posn(x, y)] or @rhombus[x <> y] in the example mean one thing
+@rhombus(Posn(x, y)) or @rhombus(x <> y) in the example mean one thing
 as an expression and another as a binding. Exactly where the contexts
 reside in a module depends on a specific Rhombus language that is built
 on the Rhombus expander. Meanwhile, a full Rhombus language can have

--- a/enforest/scribblings/transformer.scrbl
+++ b/enforest/scribblings/transformer.scrbl
@@ -17,7 +17,7 @@ sense.
 For an infix operator, enforestation always parses the left-hand
 argument (i.e., the part before the operator) in the same context as the
 operator's context. For example, the left-hand argument to an infix
-expression operator @rhombus[+] or @rhombus[.] is always parsed as an
+expression operator @rhombus(+) or @rhombus(.) is always parsed as an
 expression. For the right-hand (or only, in the case of prefix)
 argument, the operator's mapping selects one of two protocols:
 _automatic_, where the right-hand argument is also parsed in the same
@@ -25,25 +25,25 @@ context, or _macro_, where the operator's transformer receives the full
 sequence of terms remaining in the enclosing group. An operator using
 the macro protocol parses remaining terms as it sees fit, and then it
 returns the still-remaining terms that it does not consume. For example,
-@rhombus[+] for expressions is likely implemented as an automatic infix
+@rhombus(+) for expressions is likely implemented as an automatic infix
 operator, since both of its arguments are also expressions, while
-@rhombus[.] is likely implemented as a macro infix operator so that it's
+@rhombus(.) is likely implemented as a macro infix operator so that it's
 right-hand ``argument'' is always parsed as a field identifier. In the
-earlier @rhombus[<>] and @rhombus[->] examples, @rhombus[<>] is
+earlier @rhombus(<>) and @rhombus(->) examples, @rhombus(<>) is
 implemented as an automatic infix operator for expressions, while
-@rhombus[<>] for bindings and @rhombus[->] for expressions were
+@rhombus(<>) for bindings and @rhombus(->) for expressions were
 implemented as macro infix operators.
 
 Roughly, an operator that uses the macro protocol takes on some of the
 burden of dealing with precedence, at least for terms after the
-operator. For operators like @rhombus[.] or @rhombus[->], this is no
+operator. For operators like @rhombus(.) or @rhombus(->), this is no
 problem, because the right-hand side has a fixed shape. Other operators
 may need to call back into the enforestation algorithm, and the Rhombus
 expander provides facilities to enable that.
 
 A postfix operator is implemented as a macro infix operator that
 consumes no additional terms after the operator. For example, a postfix
-@rhombus[!] might be defined (shadowing the normal @rhombus[!] for
+@rhombus(!) might be defined (shadowing the normal @rhombus(!) for
 ``not'') as follows:
 
 @(rhombusblock:

--- a/rhombus/scribblings/annotation-macro.scrbl
+++ b/rhombus/scribblings/annotation-macro.scrbl
@@ -1,16 +1,16 @@
 #lang scribble/rhombus/manual
 @(import: "util.rhm" open)
 
-@title[~tag: "annotation-macro"]{Annotations}
+@title(~tag: "annotation-macro"){Annotations}
 
-Annotations produce @tech{static information} when used with the @rhombus[::]
+Annotations produce @tech{static information} when used with the @rhombus(::)
 binding or expression operator. Similar to binding macros, which can
 either be simple expansions or use lower-level machines, an annotation
 macro can use lower-level machinery to explicitly produce static
 information or manipulate static information produced by subannotation
 forms.
 
-The @rhombus[annotation.rule] or @rhombus[annotation.macro] form
+The @rhombus(annotation.rule) or @rhombus(annotation.macro) form
 defines an annotation. In the simplest case, the expansion of an
 annotation can be another annotation:
 
@@ -20,8 +20,8 @@ annotation can be another annotation:
     Posn(1, 2) :: AlsoPosn  // prints Posn(1, 2)
   )
 
-Note that @rhombus[annotation.rule] defines only an annotation. To make
-@rhombus[AlsoPosn] also a binding operator, use @rhombus[bind.macro],
+Note that @rhombus(annotation.rule) defines only an annotation. To make
+@rhombus(AlsoPosn) also a binding operator, use @rhombus(bind.macro),
 and so on:
 
 @(rhombusblock:
@@ -33,10 +33,10 @@ and so on:
   )
 
 To define an annotation with explicit control over the associated
-predicate, use @rhombus[annotation_ct.pack_predicate]. This
-implementation if @rhombus[IsPosn] creates a new predicate that uses
-@rhombus[is_a] with @rhombus[Posn], so it checks whether something is a
-@rhombus[Posn] instance, but it doesn't act as a @rhombus[Posn]-like
+predicate, use @rhombus(annotation_ct.pack_predicate). This
+implementation if @rhombus(IsPosn) creates a new predicate that uses
+@rhombus(is_a) with @rhombus(Posn), so it checks whether something is a
+@rhombus(Posn) instance, but it doesn't act as a @rhombus(Posn)-like
 binding form or constructor:
 
 @(rhombusblock:
@@ -48,19 +48,19 @@ binding form or constructor:
     // get_x(10)      // would be a run-time error
   )
 
-The @rhombus[annotation_ct.pack_predicate] takes an optional second
+The @rhombus(annotation_ct.pack_predicate) takes an optional second
 argument, which is static information to associate with uses of the
 annotation. Static information (the second argument to
-@rhombus[annotation_ct.pack_predicate]) is a a parenthesized sequence of
+@rhombus(annotation_ct.pack_predicate)) is a a parenthesized sequence of
 parenthesized two-group elements, where the first group in each element
 is a key and the second element is a value.
 
-A value for @rhombus[dot_ct.provider_key] should be a syntax object
+A value for @rhombus(dot_ct.provider_key) should be a syntax object
 naming a dot-provider transformer. So, if we want to define a
-@rhombus[Vector] annotation that is another view on @rhombus[Posn] where
-the ``fields'' are @rhombus[angle] and @rhombus[magnitude] instead of
-@rhombus[x] and @rhombus[y], we start with an annotation definition that
-refers to a @rhombus[vector_dot_provider] that we will define:
+@rhombus(Vector) annotation that is another view on @rhombus(Posn) where
+the ``fields'' are @rhombus(angle) and @rhombus(magnitude) instead of
+@rhombus(x) and @rhombus(y), we start with an annotation definition that
+refers to a @rhombus(vector_dot_provider) that we will define:
 
 @(rhombusblock:
     annotation.macro 'Vector':
@@ -68,11 +68,11 @@ refers to a @rhombus[vector_dot_provider] that we will define:
                                    '(($(dot_ct.provider_key), vector_dot_provider))')
   )
 
-A dot-provider transformer is defined using @rhombus[dot.macro]. A
+A dot-provider transformer is defined using @rhombus(dot.macro). A
 dot-provider transformer always receives three parts, which are the
 parsed expression to the left of the dot, the dot itself, and an
 identifier to the right of the dot. The dot provider associated with
-@rhombus[Vector] access @rhombus[angle] and @rhombus[magnitude]
+@rhombus(Vector) access @rhombus(angle) and @rhombus(magnitude)
 ``fields'' by calling helper functions:
 
 @(rhombusblock:
@@ -85,7 +85,7 @@ identifier to the right of the dot. The dot provider associated with
     fun vector_magnitude(Posn(x, y)): sqrt(x*x + y*y)
     )
 
-With those pieces in place, a binding using @rhombus[:: Vector] creates
+With those pieces in place, a binding using @rhombus(:: Vector) creates
 a dot provider:
 
 @(rhombusblock:
@@ -95,7 +95,7 @@ a dot provider:
 )
 
 A macro can explicitly associate static information with an expression
-by using @rhombus[static_info_ct.wrap]:
+by using @rhombus(static_info_ct.wrap):
 
 @(rhombusblock:
     expr.macro 'or_zero $p $tail ...':
@@ -110,26 +110,26 @@ by using @rhombus[static_info_ct.wrap]:
   )
 
 A similar effect could be acheived by expanding to
-@rhombus['($p || Posn(0,0)) :: Vector'], but for better or worse, this
-implementation of @rhombus[or_zero] omits an extra predicate on the
+@rhombus('($p || Posn(0,0)) :: Vector'), but for better or worse, this
+implementation of @rhombus(or_zero) omits an extra predicate on the
 result of the expression, and instead claims that it will always work as
-a @rhombus[Vector].
+a @rhombus(Vector).
 
 If a name is otherwise bound but has no static information associated
-with the binding, the @rhombus[static_info.macro] form can associate
-static information. In the following example, @rhombus[zero] is defined
-without a result annotation, but @rhombus[static_info.macro] is used to
-associate static information to @rhombus[zero] using
-@rhombus[expr_ct.call_result_key]. The value for
-@rhombus[expr_ct.call_result_key] should be static information itself,
-so we use @rhombus[static_info_ct.pack] to pack it from a syntax-object
+with the binding, the @rhombus(static_info.macro) form can associate
+static information. In the following example, @rhombus(zero) is defined
+without a result annotation, but @rhombus(static_info.macro) is used to
+associate static information to @rhombus(zero) using
+@rhombus(expr_ct.call_result_key). The value for
+@rhombus(expr_ct.call_result_key) should be static information itself,
+so we use @rhombus(static_info_ct.pack) to pack it from a syntax-object
 representation.
 
-@aside{The @rhombus[static_info_ct.wrap] and
- @rhombus[annotation_ct.pack_predicate] functions automatically pack for
+@aside{The @rhombus(static_info_ct.wrap) and
+ @rhombus(annotation_ct.pack_predicate) functions automatically pack for
  you, because they expect a syntax object that represents static
  information. The overall right-hand side result for
- @rhombus[static_info.macro] is similarly automatically packed.}
+ @rhombus(static_info.macro) is similarly automatically packed.}
 
 @(rhombusblock:
     fun zero(): Posn(0, 0)
@@ -139,14 +139,14 @@ representation.
     zero().magnitude  // prints 0
 )
 
-The @rhombus[static_info.macro] form expects @rhombus[''] containing an
+The @rhombus(static_info.macro) form expects @rhombus('') containing an
 identifier or operator, not a more funciton-like pattern, because it's
 mean to define a constant association between a name and static
 information.
 
 
-A dot provider like @rhombus[vector_dot_provider] normally would not be
-exposed outside of the module that implements @rhombus[Vector]. But if a
+A dot provider like @rhombus(vector_dot_provider) normally would not be
+exposed outside of the module that implements @rhombus(Vector). But if a
 dot provider is used directly, then it receives itself as the left
 argument:
 
@@ -164,6 +164,6 @@ argument:
   )
 
 A direct use like this makes sense when a dot provider is not associated
-with a run-time value. Attempting to use @rhombus[hello] in an
-expression position other than before a @rhombus[.] results in a static
+with a run-time value. Attempting to use @rhombus(hello) in an
+expression position other than before a @rhombus(.) results in a static
 error.

--- a/rhombus/scribblings/annotation-vs-bind.scrbl
+++ b/rhombus/scribblings/annotation-vs-bind.scrbl
@@ -3,18 +3,18 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "annotation-vs-bind"]{Annotations versus Binding Patterns}
+@title(~tag: "annotation-vs-bind"){Annotations versus Binding Patterns}
 
 Annotations and binding patterns serve similar and interacting purposes.
-The @rhombus[-:] and @rhombus[::] binding operators put annotations to
-work in a binding. For the other direction, the @rhombus[matching]
+The @rhombus(-:) and @rhombus(::) binding operators put annotations to
+work in a binding. For the other direction, the @rhombus(matching)
 annotation operator puts a binding form to work in a annotation.
 
-For example, suppose you want a annotation @rhombus[PersonList], which
-is a list of maps, and each map must at least relate @rhombus["name"] to
-a @rhombus[String] and @rhombus["location"] to a @rhombus[Posn]. The
-@rhombus[Map.of] annotation combination cannot express a per-key
-specialization, but the @rhombus[Map] binding pattern can.
+For example, suppose you want a annotation @rhombus(PersonList), which
+is a list of maps, and each map must at least relate @rhombus("name") to
+a @rhombus(String) and @rhombus("location") to a @rhombus(Posn). The
+@rhombus(Map.of) annotation combination cannot express a per-key
+specialization, but the @rhombus(Map) binding pattern can.
 
 @(rhombusblock:
     annotation.rule 'PersonList': 
@@ -26,8 +26,8 @@ specialization, but the @rhombus[Map] binding pattern can.
        {"name": "bob", "location": Posn(3, 4)}]
   )
 
-As another example, here’s how a @rhombus[ListOf] annotation constructor
-could be implemented if @rhombus[List.of] did not exist already:
+As another example, here’s how a @rhombus(ListOf) annotation constructor
+could be implemented if @rhombus(List.of) did not exist already:
 
 @(rhombusblock:
     annotation.macro 'ListOf ($annotation ...) $tail ...':
@@ -36,6 +36,6 @@ could be implemented if @rhombus[List.of] did not exist already:
   )
 
 At a lower level, the bridge between binding patterns and annotations is
-based on their shared use of @seclink["static-info"]{static information}
-as described in the @seclink["bind-macro-protocol"]{binding API} and the
-@seclink["annotation-macro"]{annotation API}.
+based on their shared use of @seclink("static-info"){static information}
+as described in the @seclink("bind-macro-protocol"){binding API} and the
+@seclink("annotation-macro"){annotation API}.

--- a/rhombus/scribblings/annotation.scrbl
+++ b/rhombus/scribblings/annotation.scrbl
@@ -3,20 +3,20 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "annotation"]{Annotations and the Dot Operator}
+@title(~tag: "annotation"){Annotations and the Dot Operator}
 
-Besides classes defined with @rhombus[class], a few predefined
-annotations work with the @rhombus[-:, ~bind] and @rhombus[::, ~bind]
-annotation operators, including @rhombus[Integer, ~ann] (meaning exact
-integer), @rhombus[Number, ~ann], @rhombus[String, ~ann],
-@rhombus[Keyword, ~ann], and @rhombus[Any, ~ann] (meaning any value).
+Besides classes defined with @rhombus(class), a few predefined
+annotations work with the @rhombus(-:, ~bind) and @rhombus(::, ~bind)
+annotation operators, including @rhombus(Integer, ~ann) (meaning exact
+integer), @rhombus(Number, ~ann), @rhombus(String, ~ann),
+@rhombus(Keyword, ~ann), and @rhombus(Any, ~ann) (meaning any value).
 
-The @rhombus[-:] and @rhombus[::] operators also work in expression
+The @rhombus(-:) and @rhombus(::) operators also work in expression
 positions. In that case, the assertion or check is about the expression
-on the left-hand side of @rhombus[-:] or @rhombus[::]. For @rhombus[::],
+on the left-hand side of @rhombus(-:) or @rhombus(::). For @rhombus(::),
 the left-hand expression must produce a value that satisfies the
 right-hand annotation, otherwise a run-time exception is raised. The
-@rhombus[is_a] operator takes an annotation like @rhombus[::], but it
+@rhombus(is_a) operator takes an annotation like @rhombus(::), but it
 produces a boolean result indicating whether the result of the left-hand
 expression matches the annotation.
 
@@ -28,9 +28,9 @@ expression matches the annotation.
     1 is_a Posn       // prints #false
   )
 
-When @rhombus[class] defines a new class, an annotation can be
+When @rhombus(class) defines a new class, an annotation can be
 associated with each field. When the annotation is written with
-@rhombus[::], then the annotation is checked when an instance is
+@rhombus(::), then the annotation is checked when an instance is
 created.
 
 @(rhombusblock:
@@ -41,7 +41,7 @@ created.
   )
 
 Naturally, class annotations can be used as field annotations, and then
-the @rhombus[.] operator can be chained for efficient access:
+the @rhombus(.) operator can be chained for efficient access:
 
 @(rhombusblock:
     class Line(p1 -: Posn, p2 -: Posn)
@@ -52,25 +52,25 @@ the @rhombus[.] operator can be chained for efficient access:
     l1.p2.x  // prints 3
   )
 
-More generally, @rhombus[.] access is efficient when the left-hand side
-of @rhombus[.] is an expression that can act as a @deftech{dot
+More generally, @rhombus(.) access is efficient when the left-hand side
+of @rhombus(.) is an expression that can act as a @deftech{dot
  provider}. A class name is a dot provider, and it provides access to
-field-accessor functions, as in @rhombus[Posn.x] (which doesn’t get a
-specific @rhombus[x], but produces a function that can be called on a
-@rhombus[Posn] instance to extract its @rhombus[x] field). An identifier
-that is bound using @rhombus[-:] or @rhombus[::] and a class name is
+field-accessor functions, as in @rhombus(Posn.x) (which doesn’t get a
+specific @rhombus(x), but produces a function that can be called on a
+@rhombus(Posn) instance to extract its @rhombus(x) field). An identifier
+that is bound using @rhombus(-:) or @rhombus(::) and a class name is
 also a dot provider, and it provides access to fields of a class
 instance. More generally, an annotation that is associated to a binding
-or expression with @rhombus[-:] or @rhombus[::] might make the binding
-or expression a dot provider. See @secref["static-info"] for more
+or expression with @rhombus(-:) or @rhombus(::) might make the binding
+or expression a dot provider. See @secref("static-info") for more
 information on dot providers and other static information.
 
-The @rhombus[use_static_dot] definition form binds the @rhombus[.]
+The @rhombus(use_static_dot) definition form binds the @rhombus(.)
 operator so that it works only in efficient mode with a dot provider. If
-the left-hand side of the @rhombus[.] is not a dot provider, then the
-@rhombus[.] defined by @rhombus[use_static_dot] reports a compile-time
-error. The @rhombus[use_dynamic_dot] form binds @rhombus[.] to the
-default @rhombus[.], which allows dynamic field lookup if the left-hand
+the left-hand side of the @rhombus(.) is not a dot provider, then the
+@rhombus(.) defined by @rhombus(use_static_dot) reports a compile-time
+error. The @rhombus(use_dynamic_dot) form binds @rhombus(.) to the
+default @rhombus(.), which allows dynamic field lookup if the left-hand
 side is not a dot provider.
 
 @(rhombusblock:
@@ -80,6 +80,6 @@ side is not a dot provider.
     // 1.x   // disallowed statically
   )
 
-@aside{Using @rhombus[.] to reach an imported binding, as in
- @rhombus[f2c.fahrenheit_to_celsius], is a different kind of @rhombus[.]
+@aside{Using @rhombus(.) to reach an imported binding, as in
+ @rhombus(f2c.fahrenheit_to_celsius), is a different kind of @rhombus(.)
  than the infix expression operator.}

--- a/rhombus/scribblings/bind-and-static.scrbl
+++ b/rhombus/scribblings/bind-and-static.scrbl
@@ -1,9 +1,9 @@
 #lang scribble/rhombus/manual
 
-@title[~style: symbol(toc)]{Binding Macros and Static Information}
+@title(~style: symbol(toc)){Binding Macros and Static Information}
 
-@local_table_of_contents[]
+@local_table_of_contents()
 
-@include_section["static-info.scrbl"]
-@include_section["bind-macro-protocol.scrbl"]
-@include_section["annotation-macro.scrbl"]
+@include_section("static-info.scrbl")
+@include_section("bind-macro-protocol.scrbl")
+@include_section("annotation-macro.scrbl")

--- a/rhombus/scribblings/bind-macro-protocol.scrbl
+++ b/rhombus/scribblings/bind-macro-protocol.scrbl
@@ -3,16 +3,16 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "bind-macro-protocol"]{Low-Level Binding Macros}
+@title(~tag: "bind-macro-protocol"){Low-Level Binding Macros}
 
 A binding form using the low-level protocol has three parts:
 
-@itemlist[
+@itemlist(
   
  @item{A compile-time function to report ``upward'' @tech{static
    information} about the variables that it binds. The function receives
   ``downward'' information provided by the context, such as static
-  information inferred for the right-hand side of a @rhombus[val] binding
+  information inferred for the right-hand side of a @rhombus(val) binding
   or imposed by enclosing binding forms. If a binding form has subforms,
   it can query those subforms, pushing its down information ``downward''
   and receiving the subform information ``upward''.},
@@ -30,12 +30,12 @@ A binding form using the low-level protocol has three parts:
   above). These definitions happen only after the match is successful, if
   at all, and the bindings are visible only after the matching part of the
   expansion. Also, these bindings are the ones that are affected by
-  @rhombus[forward]. The generated definitions do not need to attach
+  @rhombus(forward). The generated definitions do not need to attach
   static information reported by the first bullet's function; that
   information will be attached by the definition form that drives the
   expansion of binding forms.}
 
-]
+)
 
 The first of these functions, which produces static information, is
 always called first, and its results might be useful to the second
@@ -43,19 +43,19 @@ two. Operationally, parsing a binding form gets the first function,
 and then that function reports the other two along with the static
 information that it computes.
 
-To make binding work both in definition contexts and @rhombus[match]
+To make binding work both in definition contexts and @rhombus(match)
 search contexts, the check-generating function (second bullet above)
 must be parameterized over the handling of branches. Toward that end, it
-receives three extra arguments: the name of an @rhombus[if]-like form
-that we'll call @rhombus[IF], a @rhombus[success] form, and a
-@rhombus[failure] form. The transformer uses the given @rhombus[IF] to
-branch to a block that includes @rhombus[success] or just
-@rhombus[failure]. The @rhombus[IF] form must be used in tail position
+receives three extra arguments: the name of an @rhombus(if)-like form
+that we'll call @rhombus(IF), a @rhombus(success) form, and a
+@rhombus(failure) form. The transformer uses the given @rhombus(IF) to
+branch to a block that includes @rhombus(success) or just
+@rhombus(failure). The @rhombus(IF) form must be used in tail position
 with respect to the generated code, where the ``then'' part of an
-@rhombus[IF] is still in tail position for nesting. The transformer must
-use @rhombus[failure] and only @rhombus[failure] in the ``else'' part of
-each @rhombus[IF], and it must use @rhombus[success] exactly once within
-a ``then'' branch of one or more nested @rhombus[IF]s.
+@rhombus(IF) is still in tail position for nesting. The transformer must
+use @rhombus(failure) and only @rhombus(failure) in the ``else'' part of
+each @rhombus(IF), and it must use @rhombus(success) exactly once within
+a ``then'' branch of one or more nested @rhombus(IF)s.
 
 Unfortunately, there's one more complication. The result of a macro
 must be represented as syntax—even a binding macro—and a functions as
@@ -70,90 +70,90 @@ a match-generator and binding-generator function, plus data to be
 passed to those functions (effectively: the fused closure for those
 two functions).
 
-In full detail, a low-level pared binding result from @rhombus[ bind.macro]
+In full detail, a low-level pared binding result from @rhombus(bind.macro)
 transformer is represented as a syntax object with two parts:
 
-@itemlist[
+@itemlist(
 
  @item{The name of a compile-time function that is bound with
-  @rhombus[bind.infoer].},
+  @rhombus(bind.infoer).},
   
- @item{Data for the @rhombus[bind.infoer]-defined function, packaged as
+ @item{Data for the @rhombus(bind.infoer)-defined function, packaged as
   a single syntax object. This data might contain parsed versions of other
   binding forms, for example.}
 
-]
+)
 
 These two pieces are assembled into a parenthesized-tuple syntax object,
-and then packed with the @rhombus[bind_ct.pack] function to turn it into
+and then packed with the @rhombus(bind_ct.pack) function to turn it into
 a valid binding expansion (to distinguish the result from a macro
 expansion in the sense of producing another binding form).
 
-The function bound with @rhombus[bind.infoer] will receive two syntax
+The function bound with @rhombus(bind.infoer) will receive two syntax
 objects: a representation of ``downward'' static information and the
 parsed binding's data. The result must be a single-object tuple with
 seven parts:
 
-@itemlist[
+@itemlist(
 
  @item{A string that is used for reporting a failed match. The string is
   used as an annotation, and it should omit information that is local to
-  the binding. For example, when @rhombus[cons(x, y)] is used as a binding
+  the binding. For example, when @rhombus(cons(x, y)) is used as a binding
   pattern, a suitable annotation string might be
-  @rhombus["matching(cons(_, _))"] to phrase the binding constraint as an
+  @rhombus("matching(cons(_, _))") to phrase the binding constraint as an
   annotation and omit local variable names being bound (which should not
   be reported to the caller of a function, for example, when an argument
   value in a call of the function fails to match).},
 
  @item{An identifier that is used as a name for the input value, at least
    to the degree that the input value uses an inferred name. For
-   example, @rhombus[proc] as a binding form should cause its right-hand value
-   to use the inferred name @rhombus[proc], if it can make any use of an
+   example, @rhombus(proc) as a binding form should cause its right-hand value
+   to use the inferred name @rhombus(proc), if it can make any use of an
    inferred name.},
 
  @item{``Upward'' static information associated with the overall value for a
    successful match with the binding. This infomation is used by the
-   @rhombus[matching] annotation operator, for example, as well as propagated
+   @rhombus(matching) annotation operator, for example, as well as propagated
    outward by binding forms that correspond to composite data types.
    The information is independent of static information for individual
    names within the binding, but it should be the same as information
    for any binding that corresponds to the full matched value. For
-   example, @rhombus[Posn(x, y)] binds @rhombus[x] and @rhombus[y], and it may not have any
-   particular static information for @rhombus[x] and @rhombus[y], but a matching value
-   has static information suitable for @rhombus[Posn], anyway; so, using
-   @rhombus[p :: matching(Posn(_, _))] makes @rhombus[p] have @rhombus[Posn]
+   example, @rhombus(Posn(x, y)) binds @rhombus(x) and @rhombus(y), and it may not have any
+   particular static information for @rhombus(x) and @rhombus(y), but a matching value
+   has static information suitable for @rhombus(Posn), anyway; so, using
+   @rhombus(p :: matching(Posn(_, _))) makes @rhombus(p) have @rhombus(Posn)
    static information.},
 
  @item{A list of invdidual names that are bound by the overall binding,
    plus ``upward'' static information for each name.
-   For example, @rhombus[Posn(x, y)] as a binding pattern binds @rhombus[x] and @rhombus[y].
+   For example, @rhombus(Posn(x, y)) as a binding pattern binds @rhombus(x) and @rhombus(y).
    The final transformer function described in the third bullet above
    is responsible for actually binding each name and associating
    static information with it. One piece of static information helps
-   compose binding forms: the @rhombus[bind_ct.bind_input_key] key should be
-   mapped to @rhombus[#true] for each name whose value corresponds to the
+   compose binding forms: the @rhombus(bind_ct.bind_input_key) key should be
+   mapped to @rhombus(#true) for each name whose value corresponds to the
    binding input value, and the static information for such a name
    should otherwise match the static information reported in the
    second bullet above.},
 
  @item{The name of a compile-time function that is bound with
-   @rhombus[bind.matcher].},
+   @rhombus(bind.matcher).},
 
  @item{The name of a compile-time function that is bound with
-   @rhombus[bind.binder]},
+   @rhombus(bind.binder)},
 
- @item{Data for the @rhombus[bind.matcher]- and
-  @rhombus[bind.binder]-defined functions, packaged as a single syntax
+ @item{Data for the @rhombus(bind.matcher)- and
+  @rhombus(bind.binder)-defined functions, packaged as a single syntax
   object.}
-]
+)
 
-The functions bound with @rhombus[bind.matcher] and @rhombus[bind.binder] are called
+The functions bound with @rhombus(bind.matcher) and @rhombus(bind.binder) are called
 with a syntax-object identifier for the matcher's input plus the data
 from the sixth tuple slot. The match-building transformer in addition
-receives the @rhombus[IF] form name, a @rhombus[success] form, and a @rhombus[failure] form.
+receives the @rhombus(IF) form name, a @rhombus(success) form, and a @rhombus(failure) form.
 
-Here's a use of the low-level protocol to implement a @rhombus[fruit] pattern,
-which matches only things that are fruits according to @rhombus[is_fruit]:
+Here's a use of the low-level protocol to implement a @rhombus(fruit) pattern,
+which matches only things that are fruits according to @rhombus(is_fruit):
 
 @(rhombusblock:
     bind.macro 'fruit($id) $tail ...':
@@ -191,29 +191,29 @@ which matches only things that are fruits according to @rhombus[is_fruit]:
     // val fruit(dessert): "cookie"  // would fail with a match error
   )
 
-The @rhombus[fruit] binding form assumes (without directly checking)
+The @rhombus(fruit) binding form assumes (without directly checking)
 that its argument is an identifier, and its infoer discards static
 information. Binding forms normally need to accomodate other, nested
-binding forms, instead. A @rhombus[bind.macro] transformer with
-@rhombus[parsed_right] receives already-parsed sub-bindings as
-arguments, and the infoer function can use @rhombus[bind_ct.get_info] on
+binding forms, instead. A @rhombus(bind.macro) transformer with
+@rhombus(parsed_right) receives already-parsed sub-bindings as
+arguments, and the infoer function can use @rhombus(bind_ct.get_info) on
 a parsed binding form to call its internal infoer function. The result
 is packed static information, which can be unpacked into a tuple syntax
-object with @rhombus[bin_ct.unpack_info]. Normally,
-@rhombus[bind_ct.get_info] should be called only once to avoid
-exponential work with nested bindings, but @rhombus[bind_ct.unpack_info]
+object with @rhombus(bin_ct.unpack_info). Normally,
+@rhombus(bind_ct.get_info) should be called only once to avoid
+exponential work with nested bindings, but @rhombus(bind_ct.unpack_info)
 can used any number of times.
 
-As an example, here's an infix @rhombus[<&>] operator that takes two
+As an example, here's an infix @rhombus(<&>) operator that takes two
 bindings and makes sure a value can be matched to both. The binding
-forms on either size of @rhombus[<&>] can bind variables. The
-@rhombus[<&>] builder is responsible for binding the input name that
+forms on either size of @rhombus(<&>) can bind variables. The
+@rhombus(<&>) builder is responsible for binding the input name that
 each sub-binding expects before it deploys the corresponding builder.
 The only way to find out if a sub-binding matches is to call its
-builder, providing the same @rhombus[IF] and @rhombus[failure] that the
-original builder was given, and possibly extending the @rhombus[success]
+builder, providing the same @rhombus(IF) and @rhombus(failure) that the
+original builder was given, and possibly extending the @rhombus(success)
 form. A builder must be used in tail position, and it's
-@rhombus[success] position is a tail position.
+@rhombus(success) position is a tail position.
 
 @(rhombusblock:
     bind.macro '$a <&> $b':
@@ -258,14 +258,14 @@ form. A builder must be used in tail position, and it's
     y  // prints 1
   )
 
-One subtlety here is the syntactic category of @rhombus[IF] for a builder
-call. The @rhombus[IF] form might be a definition form, or it might be
+One subtlety here is the syntactic category of @rhombus(IF) for a builder
+call. The @rhombus(IF) form might be a definition form, or it might be
 an expression form, and a builder is expected to work in either case, so
-a builder call's category is the same as @rhombus[IF]. An @rhombus[IF]
-alternative is written as a block, as is a @rhombus[success] form, but
+a builder call's category is the same as @rhombus(IF). An @rhombus(IF)
+alternative is written as a block, as is a @rhombus(success) form, but
 the block may be inlined into a definition context.
 
-The @rhombus[<&>] infoer is able to just combine any names and
+The @rhombus(<&>) infoer is able to just combine any names and
 ``upward'' static information that receives from its argument bindings,
 and it can simply propagate ``downward'' static information. When a
 binding operator reflects a composite value with separate binding forms

--- a/rhombus/scribblings/bind-macro.scrbl
+++ b/rhombus/scribblings/bind-macro.scrbl
@@ -3,11 +3,11 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "bind-macro"]{Binding and Annotation Macros}
+@title(~tag: "bind-macro"){Binding and Annotation Macros}
 
-Macros can extend binding-position syntax, too, via @rhombus[bind.rule] and
-@rhombus[bind.macro]. In the simplest case, a binding operator is implemented
-by expanding to other binding operators, like this definition of @rhombus[$]
+Macros can extend binding-position syntax, too, via @rhombus(bind.rule) and
+@rhombus(bind.macro). In the simplest case, a binding operator is implemented
+by expanding to other binding operators, like this definition of @rhombus($)
 as a prefix operator to constrain a pattern to number inputs:
 
 @(rhombusblock:
@@ -26,12 +26,12 @@ as a prefix operator to constrain a pattern to number inputs:
 More expressive binding operators can use a lower-level protocol where a
 binding is represented by transformers that generate checking and
 binding code. It gets complicated, and it’s tied up with the propagation
-of static information, so the details are in @secref["bind-macro-protocol"].
+of static information, so the details are in @secref("bind-macro-protocol").
 After an expressive set of binding forms are implemented with the
 low-level interface, however, many others can be implemented though
 simple expansion.
 
-The @rhombus[annotation.macro] form is similar to @rhombus[bind.macro], but for
+The @rhombus(annotation.macro) form is similar to @rhombus(bind.macro), but for
 annotations. 
 
 @(rhombusblock:
@@ -43,5 +43,5 @@ annotations.
       ps[n].x
   )
 
-For details on the low-level annotation protocol, see @secref["annotation-macro"].
+For details on the low-level annotation protocol, see @secref("annotation-macro").
 

--- a/rhombus/scribblings/conditional.scrbl
+++ b/rhombus/scribblings/conditional.scrbl
@@ -3,27 +3,27 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "conditional"]{Conditionals and Pattern-Matching Dispatch}
+@title(~tag: "conditional"){Conditionals and Pattern-Matching Dispatch}
 
-The @rhombus[&&] and @rhombus[||] operators are short-circuiting ``and'' and ''or'' forms.
-As in Racket, @rhombus[||] returns the first non-@rhombus[#false] value, and @rhombus[&&]
-returns the last non-@rhombus[#false] value. 
+The @rhombus(&&) and @rhombus(||) operators are short-circuiting ``and'' and ''or'' forms.
+As in Racket, @rhombus(||) returns the first non-@rhombus(#false) value, and @rhombus(&&)
+returns the last non-@rhombus(#false) value. 
 
 @(rhombusblock:
     1 < 2 && "ok"  // prints "ok"
   )
 
-Comparison operators and @rhombus[!] (for ``not'') have higher
-precedence than @rhombus[&&] and @rhombus[||], while @rhombus[&&] has
-higher precedence than @rhombus[||]. Arithmetic operators have higher
-precedence than comparison operators, @rhombus[||], @rhombus[&&], but
-they have no precedence relative to @rhombus[!]. The @rhombus[==]
+Comparison operators and @rhombus(!) (for ``not'') have higher
+precedence than @rhombus(&&) and @rhombus(||), while @rhombus(&&) has
+higher precedence than @rhombus(||). Arithmetic operators have higher
+precedence than comparison operators, @rhombus(||), @rhombus(&&), but
+they have no precedence relative to @rhombus(!). The @rhombus(==)
 operator is numerical comparison like Racket’s @tt{=}, while
-@rhombus[===] operator is Racket’s @tt{equal?}. Comparison
+@rhombus(===) operator is Racket’s @tt{equal?}. Comparison
 operators are non-associative and have no precedence relationship with
 each other.
 
-The @rhombus[if] form expects a test expression followed by an
+The @rhombus(if) form expects a test expression followed by an
 alts-block with two @litchar{|}s. The first @litchar{|} holds the
 ``then'' branch, and the second @litchar{|} holds the ``else'' branch:
 
@@ -33,13 +33,13 @@ alts-block with two @litchar{|}s. The first @litchar{|} holds the
     | "different"
   )
 
-Although an @rhombus[if] could be nested further in the ``else'' branch
+Although an @rhombus(if) could be nested further in the ``else'' branch
 to implement an ``if'' ... ``else if'' ... ``else if'' ... combination,
-the @rhombus[cond] form supports that combination better. It expects an
+the @rhombus(cond) form supports that combination better. It expects an
 alts-block where each @litchar{|} has a test expression followed by a
-block. Evaluating the @rhombus[cond] form dispatches to the block after
-first test that produces a non-@rhombus[#false] value. The
-@rhombus[~else] keyword can be used in place of a last test.
+block. Evaluating the @rhombus(cond) form dispatches to the block after
+first test that produces a non-@rhombus(#false) value. The
+@rhombus(~else) keyword can be used in place of a last test.
 
 @(rhombusblock:
     fun fib(n):
@@ -51,23 +51,23 @@ first test that produces a non-@rhombus[#false] value. The
     fib(5) // prints 8
   )
 
-If there’s no @rhombus[~else] case and no matching case, then
-@rhombus[cond] reports an error at run time (unlike Racket, which
-returns void in that case). Note that @rhombus[~else] is a keyword, and
-not an identifier. If it were an identifier, then @rhombus[else] might
-get bound in some context to @rhombus[#false], which would be confusing.
-As another special case, @rhombus[_] is allowed in place of
-@rhombus[else]; although it is possible to bind @rhombus[_], it takes a
-specifical effort because @rhombus[_] is a binding operator.
+If there’s no @rhombus(~else) case and no matching case, then
+@rhombus(cond) reports an error at run time (unlike Racket, which
+returns void in that case). Note that @rhombus(~else) is a keyword, and
+not an identifier. If it were an identifier, then @rhombus(else) might
+get bound in some context to @rhombus(#false), which would be confusing.
+As another special case, @rhombus(_) is allowed in place of
+@rhombus(else); although it is possible to bind @rhombus(_), it takes a
+specifical effort because @rhombus(_) is a binding operator.
 
-Although @rhombus[cond] is better than @rhombus[if] for @rhombus[fib],
-the @rhombus[match] form is even better. The @rhombus[match] form
+Although @rhombus(cond) is better than @rhombus(if) for @rhombus(fib),
+the @rhombus(match) form is even better. The @rhombus(match) form
 expects an expression and then an alts-block where each @litchar{|} has
-a binding pattern followed by a block. The @rhombus[match] form
+a binding pattern followed by a block. The @rhombus(match) form
 evaluates that first expression, and dispatches to the first block whose
-pattern accepts the expression’s value. Similar to @rhombus[cond],
-@rhombus[match] supports @rhombus[~else] in place of a final binding
-pattern, but using the binding operator @rhombus[_] is more common.
+pattern accepts the expression’s value. Similar to @rhombus(cond),
+@rhombus(match) supports @rhombus(~else) in place of a final binding
+pattern, but using the binding operator @rhombus(_) is more common.
 
 @(rhombusblock:
     fun fib(n):
@@ -78,7 +78,7 @@ pattern, but using the binding operator @rhombus[_] is more common.
   )
 
 This kind of immediate pattern-matching dispatch on a function argument
-is common enough that @rhombus[fun] supports it directly, fusing the
+is common enough that @rhombus(fun) supports it directly, fusing the
 function declaration and the pattern match, like this:
 
 @(rhombusblock:
@@ -88,7 +88,7 @@ function declaration and the pattern match, like this:
     | fib(n): fib(n-1) + fib(n-2)
   )
 
-There’s no @rhombus[~else] for this fused form, but @rhombus[_, ~bind] can be
+There’s no @rhombus(~else) for this fused form, but @rhombus(_, ~bind) can be
 useful in catch-call clauses where the argument is not used. Also, the
 function name and all relevant argument positions have to be repeated in
 every case, but that’s often a readable trade-off. Match-dispatching

--- a/rhombus/scribblings/definition.scrbl
+++ b/rhombus/scribblings/definition.scrbl
@@ -5,7 +5,7 @@
 
 @title{Definitions and Classes}
 
-Besides @rhombus[val] and @rhombus[fun], @rhombus[class] is a definition
+Besides @rhombus(val) and @rhombus(fun), @rhombus(class) is a definition
 form that defines a new class. By convention, class names start with a
 capital letter.
 
@@ -13,7 +13,7 @@ capital letter.
     class Posn(x, y))
 
 A class name can be used like a function to construct an instance of the
-class. An instance expression followed by @rhombus[.] and a field name
+class. An instance expression followed by @rhombus(.) and a field name
 extracts the field value from the instance.
 
 @(rhombusblock:
@@ -24,24 +24,24 @@ extracts the field value from the instance.
     origin.x  // prints 0
   )
 
-A class name followed by @rhombus[.] and a field name gets an accessor
+A class name followed by @rhombus(.) and a field name gets an accessor
 function to extract the field value from an instance of the class:
 
 @(rhombusblock:
     Posn.x(origin)  // prints 0
     )
 
-Comparing @rhombus[Posn.x] to a function that uses @rhombus[.x] on its
-argument, the difference is that @rhombus[Posn.x] works only on
-@rhombus[Posn] instances. That constraint makes field access via
-@rhombus[Posn.x] more efficient than a generic lookup of a field with
-@rhombus[.x].
+Comparing @rhombus(Posn.x) to a function that uses @rhombus(.x) on its
+argument, the difference is that @rhombus(Posn.x) works only on
+@rhombus(Posn) instances. That constraint makes field access via
+@rhombus(Posn.x) more efficient than a generic lookup of a field with
+@rhombus(.x).
 
 An @deftech{annotation} associated with a binding or expression can make
-field access with @rhombus[.x] the same as using a class-specific
+field access with @rhombus(.x) the same as using a class-specific
 accessor. Annotations are particularly encouraged for a function
 argument that is a class instance, and the annotation is written after
-the argument name with @rhombus[-:] and the class name:
+the argument name with @rhombus(-:) and the class name:
 
 @(rhombusblock:
     fun flip(p -: Posn):
@@ -50,24 +50,24 @@ the argument name with @rhombus[-:] and the class name:
     flip(Posn(1, 2))  // prints Posn(2, 1)
     )
 
-Using @rhombus[-:] makes an assertion about values that are provided as
+Using @rhombus(-:) makes an assertion about values that are provided as
 arguments, but that assertion is not checked when the argument is
 provided. In effect, the annotation simply selects a class-specific
-field accessor for @rhombus[.x]. If @rhombus[flip] is called with
-@rhombus[0], then a run-time error will occur at the point that
-@rhombus[p.y] attempts to access the @rhombus[y] field of a
-@rhombus[Posn] instance:
+field accessor for @rhombus(.x). If @rhombus(flip) is called with
+@rhombus(0), then a run-time error will occur at the point that
+@rhombus(p.y) attempts to access the @rhombus(y) field of a
+@rhombus(Posn) instance:
 
 @(rhombusblock:«
     // flip(0)  // would be a run-time error from `.y`
   »)
 
-The @rhombus[::] binding operator is another way to annotate a variable.
-Unlike @rhombus[-:], @rhombus[::] installs a run-time check that a value
+The @rhombus(::) binding operator is another way to annotate a variable.
+Unlike @rhombus(-:), @rhombus(::) installs a run-time check that a value
 supplied for the variable satisfies its annotation. The following
-variant of the @rhombus[flip] function will report an error if its
-argument is not a @rhombus[Posn] instance, and the error is from
-@rhombus[flip] instead of delayed to the access of @rhombus[y]:
+variant of the @rhombus(flip) function will report an error if its
+argument is not a @rhombus(Posn) instance, and the error is from
+@rhombus(flip) instead of delayed to the access of @rhombus(y):
 
 @(rhombusblock:
     fun flip(p :: Posn):
@@ -76,18 +76,18 @@ argument is not a @rhombus[Posn] instance, and the error is from
     // flip(0)  // would be a run-time error from `flip`
   )
 
-A run-time check implied by @rhombus[::] can be expensive, depending on
-the annotation and context. In the case of @rhombus[flip], this check is
-unlikely to matter, but if a programmer uses @rhombus[::] everywhere to
+A run-time check implied by @rhombus(::) can be expensive, depending on
+the annotation and context. In the case of @rhombus(flip), this check is
+unlikely to matter, but if a programmer uses @rhombus(::) everywhere to
 try to get maximum checking and maximum guarantees, it’s easy to create
 expensive function boundaries. Rhombus programmers are encouraged to use
-@rhombus[-:] when the goal is to hint for better performance, and use
-@rhombus[::] only where a defensive check is needed, such as for the
+@rhombus(-:) when the goal is to hint for better performance, and use
+@rhombus(::) only where a defensive check is needed, such as for the
 arguments of an exported function.
 
-The use of @rhombus[-:] or @rhombus[::] as above is not specific to
-@rhombus[fun]. The @rhombus[-:] and @rhombus[::] binding operators work
-in any binding position, including the one for @rhombus[val]:
+The use of @rhombus(-:) or @rhombus(::) as above is not specific to
+@rhombus(fun). The @rhombus(-:) and @rhombus(::) binding operators work
+in any binding position, including the one for @rhombus(val):
 
 @(rhombusblock:
     val (flipped -: Posn):  flip(Posn(1, 2))
@@ -95,13 +95,13 @@ in any binding position, including the one for @rhombus[val]:
     flipped.x  // prints 2
     )
 
-The @rhombus[class Posn(x, y)] definition does not place any constraints
-on its @rhombus[x] and @rhombus[y] fields, so using @rhombus[Posn] as a
+The @rhombus(class Posn(x, y)) definition does not place any constraints
+on its @rhombus(x) and @rhombus(y) fields, so using @rhombus(Posn) as a
 annotation similarly does not imply any annotations on the field
-results. Instead of using just @rhombus[Posn] as a annotation, however,
-you can use @rhombus[Posn.of] followed by parentheses containing
-annotations for the @rhombus[x] and @rhombus[y] fields. More generally,
-a @rhombus[class] definition binds the name so that @rhombus[.of]
+results. Instead of using just @rhombus(Posn) as a annotation, however,
+you can use @rhombus(Posn.of) followed by parentheses containing
+annotations for the @rhombus(x) and @rhombus(y) fields. More generally,
+a @rhombus(class) definition binds the name so that @rhombus(.of)
 accesses an annotation constructor.
 
 @(rhombusblock:
@@ -112,9 +112,9 @@ accesses an annotation constructor.
     // flip_ints(Posn("a", 2))  // would be a run-time error
   )
 
-Finally, a class name like @rhombus[Posn] can also work in binding
+Finally, a class name like @rhombus(Posn) can also work in binding
 positions as a pattern-matching form. Here’s a implementation of
-@rhombus[flip] that uses pattern matching for its argument:
+@rhombus(flip) that uses pattern matching for its argument:
 
 @(rhombusblock:
     fun flip(Posn(x, y)):
@@ -124,14 +124,14 @@ positions as a pattern-matching form. Here’s a implementation of
     flip(Posn(1, 2))  // prints Posn(2, 1)
   )
 
-As a function-argument pattern, @rhombus[Posn(x, y)] both requires the
-argument to be a @rhombus[Posn] instance and binds the identifiers
-@rhombus[x] and @rhombus[y] to the values of the instance’s fields.
-There’s no need to skip the check that the argument is a @rhombus[Posn],
-because the check is anyway part of extracting @rhombus[x] and
-@rhombus[y] fields.
+As a function-argument pattern, @rhombus(Posn(x, y)) both requires the
+argument to be a @rhombus(Posn) instance and binds the identifiers
+@rhombus(x) and @rhombus(y) to the values of the instance’s fields.
+There’s no need to skip the check that the argument is a @rhombus(Posn),
+because the check is anyway part of extracting @rhombus(x) and
+@rhombus(y) fields.
 
-As you would expect, the fields in a @rhombus[Posn] binding pattern are
+As you would expect, the fields in a @rhombus(Posn) binding pattern are
 themselves patterns. Here’s a function that works only on the origin:
 
 @(rhombusblock:
@@ -143,11 +143,11 @@ themselves patterns. Here’s a function that works only on the origin:
   )
 
 Finally, a function can have a result annotation, which is written with
-@rhombus[-:] or @rhombus[::] after the parentheses for the function’s
-argument. With a @rhombus[::] result annotation, every return value from
+@rhombus(-:) or @rhombus(::) after the parentheses for the function’s
+argument. With a @rhombus(::) result annotation, every return value from
 the function is checked against the annotation. Beware that a function’s
 body does not count as being tail position when the function is declared
-with a @rhombus[::] result annotation.
+with a @rhombus(::) result annotation.
 
 @(rhombusblock:
     fun same_posn(p) -: Posn:
@@ -164,9 +164,9 @@ with a @rhombus[::] result annotation.
     // checked_same_posn(5)    // woudl be a run-time error
   )
 
-The @rhombus[def] form is a kind of do-what-I-mean form that acts like
-@rhombus[val], @rhombus[fun], or certain other definition forms
-depending on the shape of the terms after @rhombus[def]. It’s sensitive
+The @rhombus(def) form is a kind of do-what-I-mean form that acts like
+@rhombus(val), @rhombus(fun), or certain other definition forms
+depending on the shape of the terms after @rhombus(def). It’s sensitive
 to binding forms, though, so it will not treat the immediate use of a
 pattern constructor as a function definition.
 
@@ -184,12 +184,12 @@ pattern constructor as a function definition.
     pin_x  // prints 3
   )
 
-The @rhombus[let] form is like @rhombus[val], but it makes bindings
+The @rhombus(let) form is like @rhombus(val), but it makes bindings
 available only @emph{after} the definition, and it shadows any binding
 before, which is useful for binding a sequence of results to the same
-name. The @rhombus[let] form does not change the binding region of other
-definitions, so a @rhombus[def] after @rhombus[let] binds a name that is
-visible before the @rhombus[let] form.
+name. The @rhombus(let) form does not change the binding region of other
+definitions, so a @rhombus(def) after @rhombus(let) binds a name that is
+visible before the @rhombus(let) form.
 
 @(rhombusblock:
     def get_after(): after
@@ -203,12 +203,12 @@ visible before the @rhombus[let] form.
     get_after()  // prints 3
   )
 
-The identifier @rhombus[_, ~bind] is similar to @rhombus[Posn] and
-@rhombus[-:, ~bind] in the sense that it’s a binding operator. As a
-binding, @rhombus[_, ~bind] matches any value and binds no variables.
+The identifier @rhombus(_, ~bind) is similar to @rhombus(Posn) and
+@rhombus(-:, ~bind) in the sense that it’s a binding operator. As a
+binding, @rhombus(_, ~bind) matches any value and binds no variables.
 Use it as an argument name or subpattern form when you don’t need the
-corresponding argument or value, but @rhombus[_, ~bind] nested in a
-binding pattern like @rhombus[::, ~bind] can still constrain allowed
+corresponding argument or value, but @rhombus(_, ~bind) nested in a
+binding pattern like @rhombus(::, ~bind) can still constrain allowed
 values.
 
 @(rhombusblock:

--- a/rhombus/scribblings/defn-macro.scrbl
+++ b/rhombus/scribblings/defn-macro.scrbl
@@ -3,15 +3,15 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "defn-macro"]{Definition and Declaration Macros}
+@title(~tag: "defn-macro"){Definition and Declaration Macros}
 
-The @rhombus[defn.macro] form defines a definition macro. It is similar
-to @rhombus[expr.macro] in prefix form, except that the name must be an
+The @rhombus(defn.macro) form defines a definition macro. It is similar
+to @rhombus(expr.macro) in prefix form, except that the name must be an
 identifier (never an operator), and the result syntax object should
 represent a block, which is spliced into the definition context where
 the macro is used.
 
-Here’s the classic @rhombus[def_five] macro:
+Here’s the classic @rhombus(def_five) macro:
 
 
 @(rhombusblock:
@@ -25,9 +25,9 @@ Here’s the classic @rhombus[def_five] macro:
     v  // prints 5
   )
 
-Declarations macros are written with @rhombus[decl.macro], and the
-block produced by expansion can use forms like @rhombus[import] and
-@rhombus[export].
+Declarations macros are written with @rhombus(decl.macro), and the
+block produced by expansion can use forms like @rhombus(import) and
+@rhombus(export).
 
 By distinguishing between expression macros, definition macros, and
 declaration macros, Rhombus can report errors for out-of-place uses

--- a/rhombus/scribblings/expr-macro.scrbl
+++ b/rhombus/scribblings/expr-macro.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "expr-macro"]{Expression Macros}
+@title(~tag: "expr-macro"){Expression Macros}
 
 Macros extend the syntax available for expressions, bindings,
 definitions, and more. Each kind of macro extension has a different
@@ -16,7 +16,7 @@ expansion. A general form of macro is implemented with arbitrary
 compile-time computation, and it can return terms that the macro does
 not consume.
 
-For example, here's a @rhombus[thunk] macro that expects a block and
+For example, here's a @rhombus(thunk) macro that expects a block and
 wraps as a zero-argument function
 
 @(rhombusblock:
@@ -30,7 +30,7 @@ wraps as a zero-argument function
     (thunk: 1 + 3)()   // prints 4
   )
 
-The @rhombus[expr.rule] form expects @rhombus[''] to create a pattern
+The @rhombus(expr.rule) form expects @rhombus('') to create a pattern
 that matches a sequence of terms. Either the first or second term within
 the pattern is an @emph{unescaped} identifier or operator to be defined;
 conceptually, it’s unescaped because the macro matches a sequence of
@@ -39,10 +39,10 @@ in the pattern is an unescaped identifier or operator, a prefix macro is
 defined; otherwise, the second term must be unescaped, and an infix
 macro is defined.
 
-The @rhombus[expr.rule] form must be imported from
-@rhombusmodname[rhombus/macro], but @rhombus[def] behaves like
-@rhombus[expr.rule] when the part before @rhombus[:] is valid for
-@rhombus[expr.rule]:
+The @rhombus(expr.rule) form must be imported from
+@rhombusmodname(rhombus/macro), but @rhombus(def) behaves like
+@rhombus(expr.rule) when the part before @rhombus(:) is valid for
+@rhombus(expr.rule):
 
 @(rhombusblock:
     // no import needed
@@ -54,8 +54,8 @@ The @rhombus[expr.rule] form must be imported from
   )
 
 A postfix macro can be implemented as an infix operator that consumes no
-additional terms after the operator. For example, a postfix @rhombus[!]
-might be defined (shadowing the normal @rhombus[!] for ``not'') like
+additional terms after the operator. For example, a postfix @rhombus(!)
+might be defined (shadowing the normal @rhombus(!) for ``not'') like
 this:
 
 @(rhombusblock:
@@ -69,39 +69,39 @@ this:
     10! + 1 // = 3628801
   )
 
-The @rhombus[expr.rule] or @rhombus[def] form is a shorthand for a more
-general @rhombus[expr.macro] macro form. With @rhombus[expr.macro], the
-macro implementation after @rhombus[:] is compile-time code. Importing
-@rhombusmodname[rhombus/macro] imports all of the same bindings as
-@rhombus[rhombus] into the compile-time phase, in addition to making
-forms like @rhombus[expr.macro] available. Normally,
-@rhombusmodname[rhombus/macro] should be imported without a prefix, otherwise a
+The @rhombus(expr.rule) or @rhombus(def) form is a shorthand for a more
+general @rhombus(expr.macro) macro form. With @rhombus(expr.macro), the
+macro implementation after @rhombus(:) is compile-time code. Importing
+@rhombusmodname(rhombus/macro) imports all of the same bindings as
+@rhombus(rhombus) into the compile-time phase, in addition to making
+forms like @rhombus(expr.macro) available. Normally,
+@rhombusmodname(rhombus/macro) should be imported without a prefix, otherwise a
 prefix would have to be used for all Rhombus forms in compile-time
-code—even for things like @rhombus[values] and @rhombus['']. In addition,
-a macro defined with @rhombus[expr.macro] receives all remaining terms
+code—even for things like @rhombus(values) and @rhombus(''). In addition,
+a macro defined with @rhombus(expr.macro) receives all remaining terms
 in the enclosing group as input, and it must return two values: the
 expanded expression and the remaining terms that have not been consumed.
 
-For example, the @rhombus[!] macro can be equivalently written like this:
+For example, the @rhombus(!) macro can be equivalently written like this:
 
 @(rhombusblock:
     expr.macro '$a ! $tail ...':
       values('factorial($a)', '$tail ...')
   )
 
-Since an @rhombus[expr.macro] implementation can use arbitrary
+Since an @rhombus(expr.macro) implementation can use arbitrary
 compile-time code, it can inspect the input syntax objects in more way
 than just pattern matching. However, already-parsed terms will be
-opaque. When the macro transformer for @rhombus[!] is called,
-@rhombus[a] will be bound to a syntax object representing a parsed
+opaque. When the macro transformer for @rhombus(!) is called,
+@rhombus(a) will be bound to a syntax object representing a parsed
 Rhombus expression, as opposed to an unparsed shrubbery. Currently,
 there’s no way for a transformer to inspect a parsed Rhombus expression
 (except by escaping to Racket). When the parsed expression is injected
 back into an unparsed shrubbery, as happens in
-@rhombus['factorial($a)'], it will later simply parse as itself.
+@rhombus('factorial($a)'), it will later simply parse as itself.
 
-Changing the @rhombus[tail] pattern to @rhombus[(tail :: Term)] would
-disable the special treatment of @rhombus[..., ~bind] at the end of a
+Changing the @rhombus(tail) pattern to @rhombus((tail :: Term)) would
+disable the special treatment of @rhombus(..., ~bind) at the end of a
 pattern and template sequence and reify the tail as a fresh list---so
 don't do this:
 
@@ -113,18 +113,18 @@ don't do this:
     0 ! ! ! ! ! ! ! ! ! ! ! !
 )
 
-Note that the @rhombus[..., ~bind] operator is not treated specially
+Note that the @rhombus(..., ~bind) operator is not treated specially
 at the end of the pattern of a rule macro, because there’s implicitly
-a @rhombus[$tail ..., ~bind] added to the end of every rule-macro
+a @rhombus($tail ..., ~bind) added to the end of every rule-macro
 pattern.
 
 Whether pattern-based or not, an infix-operator macro’s left-hand input
 is parsed. A prefix or infix macro’s right-hand input is not parsed by
 default. To trigger parsing for a right-hand argument, include
-@rhombus[~parsed_right] as a declaration at the start of the macro body.
-Often, in that case, you might as well use @rhombus[operator], but
+@rhombus(~parsed_right) as a declaration at the start of the macro body.
+Often, in that case, you might as well use @rhombus(operator), but
 macros provide control over evaluator order. For example, this
-@rhombus[+<=] operator is like @rhombus[+], but evaluates its right-hand
+@rhombus(+<=) operator is like @rhombus(+), but evaluates its right-hand
 side before it’s left-hand side:
 
 @(rhombusblock:
@@ -136,19 +136,19 @@ side before it’s left-hand side:
     // (1+"oops") +<= (2+"ouch")  // would complain about "ouch", not "oops"
   )
 
-Declaring @rhombus[~parsed_right] affects a @rhombus[expr.macro] macro
+Declaring @rhombus(~parsed_right) affects a @rhombus(expr.macro) macro
 in a second way: the macro will receive only the left (if any) and right
 arguments, and will not receieve or return the tail of the ennclosing
-group. In other words, declaring @rhombus[~parse_right] uses the same
+group. In other words, declaring @rhombus(~parse_right) uses the same
 argument and return protocol as a rule-based macro, but the template
 part can be implemented by arbitrary compile-time expressions.
 
-In the same way that @rhombus[operator] supports operators that are both
-prefix and infix, you can use an alt-block with @rhombus[expr.rule] or
-@rhombus[expr.macro] to create a prefix-and-infix macro. Furthermore, an
-@rhombus[expr.rule] or @rhombus[expr.macro] form can have multiple
+In the same way that @rhombus(operator) supports operators that are both
+prefix and infix, you can use an alt-block with @rhombus(expr.rule) or
+@rhombus(expr.macro) to create a prefix-and-infix macro. Furthermore, an
+@rhombus(expr.rule) or @rhombus(expr.macro) form can have multiple
 prefix blocks or multiple infix blocks, where the each block’s pattern
 is tried in order; in that case, only the first prefix block (if any)
 and first infix block (if any) can have precedence and associativity
 declarations that apply to all cases, and none of the cases can use
-@rhombus[~parsed_right].
+@rhombus(~parsed_right).

--- a/rhombus/scribblings/for.scrbl
+++ b/rhombus/scribblings/for.scrbl
@@ -3,73 +3,73 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "for"]{Iteration}
+@title(~tag: "for"){Iteration}
 
 Rhombus support a proper implementation of tail-call handling (i.e.,
 tail calls do not extend the continuation), so looping can be written as
 a recursive function. Nevertheless, a looping construct is convenient
 and useful for writing many kinds of iterations.
 
-The @rhombus[for] form supports iteration over @deftech{sequences},
-which includes lists, arrays, and maps. In the body of a @rhombus[for]
-form, each @rhombus[~each] clause binds to an element of a sequence for
+The @rhombus(for) form supports iteration over @deftech{sequences},
+which includes lists, arrays, and maps. In the body of a @rhombus(for)
+form, each @rhombus(~each) clause binds to an element of a sequence for
 each iteration. The length of the sequence determines the number of
-iterations. The @rhombus[..] operator creates a sequence of integers
+iterations. The @rhombus(..) operator creates a sequence of integers
 from a starting integer (inclusive) to an ending integer (exclusive):
 
-@demo[
+@demo(
   for:
     ~each i: 1..4
     displayln(i)
-]
+)
 
-If a @rhombus[for] body includes multiple @rhombus[~each] clauses, they
-are nested. That is, for each element of the first @rhombus[~each] clause,
-all elements are used for the second @rhombus[~each] clause, and so on.
+If a @rhombus(for) body includes multiple @rhombus(~each) clauses, they
+are nested. That is, for each element of the first @rhombus(~each) clause,
+all elements are used for the second @rhombus(~each) clause, and so on.
 
-@demo[
+@demo(
   for:
     ~each friend: ["Alice", "Bob", "Carol"]
     ~each say: ["Hello", "Goodbye"]
     displayln(say +& ", " +& friend +& "!")
-]
+)
 
-An advantage of having @rhombus[~each] clauses in the body of
-@rhombus[for], instead of putting them before the body as in many other
+An advantage of having @rhombus(~each) clauses in the body of
+@rhombus(for), instead of putting them before the body as in many other
 languages, is that definitions or expressions can be written among
-@rhombus[~each] clauses.
+@rhombus(~each) clauses.
 
-@demo[
+@demo(
   for:
     ~each friend: ["Alice", "Bob", "Carol"]
     val dear_friend: "dear " +& friend
     ~each say: ["Hello", "Goodbye"]
     displayln(say +& ", " +& dear_friend +& "!")
-]
+)
 
-To draw elements from sequences in parallel, use @rhombus[~and]
-instead of @rhombus[~each] for every additional sequence.
+To draw elements from sequences in parallel, use @rhombus(~and)
+instead of @rhombus(~each) for every additional sequence.
 
-@demo[
+@demo(
   for:
     ~each friend: ["Alice", "Bob", "Carol"]
     ~and  index: 1..4
     displayln(index +& ". " +& friend)
-]
+)
 
-In this latest example, the sequence for @rhombus[index] could be
-@rhombus[1..] to avoid needing the length of the list for
-@rhombus[friend]. When @rhombus[..] has no second argument, it creates
-an infinite sequence of integers, and when @rhombus[for] iterates over
+In this latest example, the sequence for @rhombus(index) could be
+@rhombus(1..) to avoid needing the length of the list for
+@rhombus(friend). When @rhombus(..) has no second argument, it creates
+an infinite sequence of integers, and when @rhombus(for) iterates over
 sequences in parallel, it stops when the shortest sequence stops.
 
-The @rhombus[for] form acts as a comprehension form when a
-@deftech{folder} is specified before the @rhombus[for] body block.
-@rhombus[List, ~folder] serves as a folder to generate a list,
-accumulating the values produced by each iteration of the @rhombus[for]
+The @rhombus(for) form acts as a comprehension form when a
+@deftech{folder} is specified before the @rhombus(for) body block.
+@rhombus(List, ~folder) serves as a folder to generate a list,
+accumulating the values produced by each iteration of the @rhombus(for)
 body.
 
-@demo[
+@demo(
   for List:
     ~each i: 1..4
     "number " +& i,
@@ -77,47 +77,47 @@ body.
     ~each i: [1, 2]
     ~each j: ["a", "b", "c"]
     [i, j]
-]
+)
 
-@rhombus[Map, ~folder] works as a folder where the body of the
-@rhombus[for] form must produce two values for each iteration: a key and
+@rhombus(Map, ~folder) works as a folder where the body of the
+@rhombus(for) form must produce two values for each iteration: a key and
 a value.
 
-@demo[
+@demo(
   for Map:
     ~each friend: ["alice", "bob", "carol"]
     ~and  index: 1..
     values(index, friend)
-]
+)
 
-The @rhombus[values, ~folder] folder implements the general case, where
-@rhombus[values] is followed by a parenthesized sequence of identifiers
-with initial values, the @rhombus[for] body can refer to those
+The @rhombus(values, ~folder) folder implements the general case, where
+@rhombus(values) is followed by a parenthesized sequence of identifiers
+with initial values, the @rhombus(for) body can refer to those
 identifiers to get values from the previous iteration (or the initial
-values in the case of the first iteration), and the @rhombus[for] body
+values in the case of the first iteration), and the @rhombus(for) body
 returns as many values as identifiers to provide new values for the
 identifiers.
 
-@demo[
+@demo(
   fun sum(l -: List):
     for values(sum = 0):
       ~each i: l
       sum+i,
   sum([2, 3, 4])
-]
+)
 
-In the same way that a @rhombus[List, ~ann] annotation specializes
+In the same way that a @rhombus(List, ~ann) annotation specializes
 element access via @litchar{[}...@litchar{]}, it also specializes how
-@rhombus[~each] within @rhombus[for] iterates through a list. In the
-following example, @rhombus[ll] is annotated as a list of lists, so both
+@rhombus(~each) within @rhombus(for) iterates through a list. In the
+following example, @rhombus(ll) is annotated as a list of lists, so both
 the outer and inner iterations are specialized---although that
 specialization is visible only as a change in performance, if at all.
 
-@demo[
+@demo(
   fun sum2d(ll -: List.of(List.of(Number))):
     for values(sum = 0):
       ~each l: ll
       ~each i: l
       sum+i,
   sum2d([[1], [2, 3, 4], [5, 6, 7], [8, 9]])
-]
+)

--- a/rhombus/scribblings/function.scrbl
+++ b/rhombus/scribblings/function.scrbl
@@ -5,7 +5,7 @@
 
 @title{Function Expressions}
 
-The @rhombus[fun] form works in an expression position as λ. Just like
+The @rhombus(fun) form works in an expression position as λ. Just like
 @tt{function} in JavaScript, the expression variant omits a function
 name.
 
@@ -18,5 +18,5 @@ name.
   )
 
 Naturally, keyword and optional arguments (as described in the
-@seclink["keyword-arg"]{next section}) work with @rhombus[fun]
+@seclink("keyword-arg"){next section}) work with @rhombus(fun)
 expressions, too.

--- a/rhombus/scribblings/keyword-argument.scrbl
+++ b/rhombus/scribblings/keyword-argument.scrbl
@@ -3,11 +3,11 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "keyword-arg"]{Keyword and Optional Arguments}
+@title(~tag: "keyword-arg"){Keyword and Optional Arguments}
 
-A function argument can be made optional by using @rhombus[=] after the
+A function argument can be made optional by using @rhombus(=) after the
 argument’s pattern and providing a default-value expression after
-@rhombus[=]:
+@rhombus(=):
 
 @(rhombusblock:
     fun scale(Posn(x, y), factor = 1):
@@ -20,7 +20,7 @@ argument’s pattern and providing a default-value expression after
 By-keyword arguments are often useful for functions that have multiple
 optional arguments. A keyword argument is indicated by prefixing a
 formal or actual argument with a shrubbery keyword, which is written
-with a leading @litchar{~}, and then starting a block with @rhombus[:].
+with a leading @litchar{~}, and then starting a block with @rhombus(:).
 
 @(rhombusblock:
     fun transform(Posn(x, y),
@@ -36,16 +36,16 @@ with a leading @litchar{~}, and then starting a block with @rhombus[:].
 
 Since a keyword by itself is not allowed as an expression or pattern,
 there is no possibility that a keyword will be inadvertently treated as
-an actual argument or binding pattern by itself. The @rhombus[keyword]
+an actual argument or binding pattern by itself. The @rhombus(keyword)
 form turns a keyword into an expression that produces the keyword, as in
-@rhombus[keyword(~scale)]. The @rhombus[symbol] form similarly turns an
-identifier into a symbol, as in @rhombus[symbol(x)].
+@rhombus(keyword(~scale)). The @rhombus(symbol) form similarly turns an
+identifier into a symbol, as in @rhombus(symbol(x)).
 
-@aside{The keyword prefix and @rhombus[=] for default values are not
- binding operators. They are specific to the syntax of @rhombus[fun].}
+@aside{The keyword prefix and @rhombus(=) for default values are not
+ binding operators. They are specific to the syntax of @rhombus(fun).}
 
 If an argument name is the same as its keyword (just without the
-@litchar{~}), then the @rhombus[:] argument name can be omitted. That
+@litchar{~}), then the @rhombus(:) argument name can be omitted. That
 only works for an argument that would otherwise be just an identifier
 and maybe a default value, because keywords don’t work as variable names
 in binding patterns.

--- a/rhombus/scribblings/list.scrbl
+++ b/rhombus/scribblings/list.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "list"]{Lists}
+@title(~tag: "list"){Lists}
 
 A @litchar{[}...@litchar{]} form as an expression creates a list:
 
@@ -12,7 +12,7 @@ A @litchar{[}...@litchar{]} form as an expression creates a list:
     [0, "apple", Posn(1, 2)] // prints [0, "apple", Posn(1, 2)]
   )
 
-You can also use the @rhombus[List] constructor, which takes any number of
+You can also use the @rhombus(List) constructor, which takes any number of
 arguments:
 
 @(rhombusblock:
@@ -23,8 +23,8 @@ A list is a ``linked list,'' in the sense that getting the @math{n}th element
 takes @math{O(n)} time, and adding to the front takes constant time. A
 list is immutable.
 
-@rhombus[List, ~ann] works as an annotation with @rhombus[-:, ~bind] and
-@rhombus[::, ~bind]:
+@rhombus(List, ~ann) works as an annotation with @rhombus(-:, ~bind) and
+@rhombus(::, ~bind):
 
 @(rhombusblock:
     fun
@@ -38,7 +38,7 @@ list is immutable.
   )
 
 As pattern, @litchar{[}...@litchar{]} matches a list, and list elements
-can be matched with specific subpatterns. The @rhombus[List, ~bind] binding
+can be matched with specific subpatterns. The @rhombus(List, ~bind) binding
 operator works the same in bindings, too.
 
 @(rhombusblock:
@@ -50,7 +50,7 @@ operator works the same in bindings, too.
   )
 
 The last element in a @litchar{[}...@litchar{]} binding pattern can be
-@rhombus[...], which means zero or more repetitions of the preceding
+@rhombus(...), which means zero or more repetitions of the preceding
 pattern.
 
 @(rhombusblock:
@@ -63,12 +63,12 @@ pattern.
     starts_milk(["apple", "coffee", "banana"])  // prints #false
   )
 
-Each variable in a pattern preceding @rhombus[...] is bound as a
+Each variable in a pattern preceding @rhombus(...) is bound as a
 @tech{repetition}, which cannot be used like a plain variable.
 Instead, a repetition variable must be used in an expression form that
-supports using repetitions, typically with before @rhombus[...]. For
-example, a @litchar{[}...@litchar{]} or @rhombus[List] expression (as
-opposed to binding) supports @rhombus[...] in place of a last element,
+supports using repetitions, typically with before @rhombus(...). For
+example, a @litchar{[}...@litchar{]} or @rhombus(List) expression (as
+opposed to binding) supports @rhombus(...) in place of a last element,
 in which case the preceding element form is treated as a repetition
 that supplies the tail of the new list.
 
@@ -86,7 +86,7 @@ that supplies the tail of the new list.
 When @litchar{[}...@litchar{]} appears after an expression, then instead
 of forming a list, it accesses an element of an @tech{map} value.
 Lists are maps that are indexed by natural numbers starting with
-@rhombus[0]:
+@rhombus(0):
 
 @(rhombusblock:
     val groceries: ["apple", "banana", "milk"]
@@ -96,11 +96,11 @@ Lists are maps that are indexed by natural numbers starting with
   )
 
 Indexing with @litchar{[}...@litchar{]} is sensitive to binding-based
-static information in the same way as @rhombus[.]. For example, a
+static information in the same way as @rhombus(.). For example, a
 function’s argument can use a binding pattern that indicates a list of
-@rhombus[Posn]s, and then @rhombus[.] can be used after
+@rhombus(Posn)s, and then @rhombus(.) can be used after
 @litchar{[}...@litchar{]} to efficiently access a field of a
-@rhombus[Posn] instance:
+@rhombus(Posn) instance:
 
 @(rhombusblock:
     fun nth_x([p -: Posn, ...], n):
@@ -109,7 +109,7 @@ function’s argument can use a binding pattern that indicates a list of
     nth_x([Posn(1, 2), Posn(3, 4), Posn(5, 6)], 1) // prints 3
   )
 
-An equivalent way to write @rhombus[nth_x] is with the @rhombus[List.of]
+An equivalent way to write @rhombus(nth_x) is with the @rhombus(List.of)
 annotation constructor. It expects an annotation that every element of
 the list must satisfy:
 
@@ -118,9 +118,9 @@ the list must satisfy:
       ps[n].x
   )
 
-The @rhombus[nth_x] function could have been written as follows, but
+The @rhombus(nth_x) function could have been written as follows, but
 unlike the previous versions (where the relevant list existed as an
-argument), this one creates a new intermediate list of @rhombus[x]
+argument), this one creates a new intermediate list of @rhombus(x)
 elements:
 
 @(rhombusblock:

--- a/rhombus/scribblings/macro.rhm
+++ b/rhombus/scribblings/macro.rhm
@@ -12,21 +12,21 @@ export:
 
 fun make_macro_eval():
   val macro_eval: manual.make_rhombus_eval()
-  @examples[
+  @examples(
     ~eval: macro_eval,
     ~hidden: #true,
     import: rhombus/macro open
-  ]
+  )
   macro_eval
 
 fun make_for_meta_eval():
   val meta_eval: manual.make_rhombus_eval()
-  @examples[
+  @examples(
     ~eval: meta_eval,
     ~hidden: #true,
     import: 
       rhombus/macro open
       for_meta:
         rhombus open
-  ]
+  )
   meta_eval

--- a/rhombus/scribblings/map.scrbl
+++ b/rhombus/scribblings/map.scrbl
@@ -3,13 +3,13 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "map"]{Arrays and Maps}
+@title(~tag: "map"){Arrays and Maps}
 
-The @rhombus[Array] constructor is similar to @rhombus[List], but it
+The @rhombus(Array) constructor is similar to @rhombus(List), but it
 creates an array, which has a fixed length at the time that it’s created
 and offers constant-time access to any element of the array. Like a
 list, and array is a map. Unlike a list, an array is mutable, so
-@litchar{[}...@litchar{]} for indexing can be combined with @rhombus[:=]
+@litchar{[}...@litchar{]} for indexing can be combined with @rhombus(:=)
 for assignment.
 
 @(rhombusblock:
@@ -20,15 +20,15 @@ for assignment.
     buckets          // prints Array1, 5, 3, 4)
   )
 
-@rhombus[Array] is also an annotation and a binding contructor,
-analogous to @rhombus[List], and @rhombus[Array.of] is an annotation
-constructor. The @rhombus[Array] binding and expression constructors do
-not support @rhombus[..., ~bind].
+@rhombus(Array) is also an annotation and a binding contructor,
+analogous to @rhombus(List), and @rhombus(Array.of) is an annotation
+constructor. The @rhombus(Array) binding and expression constructors do
+not support @rhombus(..., ~bind).
 
-The @rhombus[Map] constructor creates an immutable mapping of arbitrary
+The @rhombus(Map) constructor creates an immutable mapping of arbitrary
 keys to values. The term @deftech{map} is meant to be generic, and
-@rhombus[Map] as a constructor just uses a default implementation of
-maps. The @rhombus[Map] constructor can be used like a function, in
+@rhombus(Map) as a constructor just uses a default implementation of
+maps. The @rhombus(Map) constructor can be used like a function, in
 which case it accepts keys alternating with values:
 
 @(rhombusblock:«
@@ -39,9 +39,9 @@ which case it accepts keys alternating with values:
     // neighborhood["clara"]  // would be a run-time error
   »)
 
-Curly braces @litchar["{"]...@litchar["}"] can be used as a shorthand
-for writing @rhombus[Map($$(@elem{...}))]. Within curly braces, the key and value
-are joined by @rhombus[:]. (If a key expression needs to use @rhombus[:]
+Curly braces @litchar("{")...@litchar("}") can be used as a shorthand
+for writing @rhombus(Map($$(@elem{...}))). Within curly braces, the key and value
+are joined by @rhombus(:). (If a key expression needs to use @rhombus(:)
 itself, the expression will have to be in parentheses.)
 
 @(rhombusblock:
@@ -50,7 +50,7 @@ itself, the expression will have to be in parentheses.)
     neighborhood["alice"]       // prints Posn(4, 5)
   )
 
-To functionally extend a map, use the @rhombus[++] append operator:
+To functionally extend a map, use the @rhombus(++) append operator:
 
 @(rhombusblock:
     val new_neighborhood: neighborhood ++ {"alice": Posn(40, 50)}
@@ -58,23 +58,23 @@ To functionally extend a map, use the @rhombus[++] append operator:
     neighborhood["alice"]     // prints Posn(4, 5)
   )
 
-When @rhombus[++] is used with a left-hand side that is statically known
+When @rhombus(++) is used with a left-hand side that is statically known
 to be the default implementation of maps, and when the right-hand
 argument is an immediate map construction with a single element, then
-the use of @rhombus[++] is compiled as an efficient single-key update of
-the map. Whether optimized or general, the @rhombus[++] operator will
-only combine certain compatible kinds of maps. For example, @rhombus[++]
+the use of @rhombus(++) is compiled as an efficient single-key update of
+the map. Whether optimized or general, the @rhombus(++) operator will
+only combine certain compatible kinds of maps. For example, @rhombus(++)
 will append lists and combine default-implementation maps, but it will
 not combine two vectors or combine a list and a default-implementation
 map with keys and values.
 
-@rhombus[Map] or its curly-braces shorthand is also an annotation and a
+@rhombus(Map) or its curly-braces shorthand is also an annotation and a
 binding constructor. As an annotation or binding constructor,
-@rhombus[Map] refers to map values genercially, and not to a specific
+@rhombus(Map) refers to map values genercially, and not to a specific
 implementation. For example, a list can be passed to a function that
-expects a @rhombus[Map] argument.
+expects a @rhombus(Map) argument.
 
-In a binding use of @rhombus[Map], the key positions are @emph{expressions},
+In a binding use of @rhombus(Map), the key positions are @emph{expressions},
 not @emph{bindings}. The binding matches an input that includes the keys, and
 each corresponding value is matched to the value binding pattern.
 
@@ -84,7 +84,7 @@ each corresponding value is matched to the value binding pattern.
     alice_home(neighborhood)  // prints Posn(4, 5)
   )
 
-The @rhombus[Map.of] annotation constructor takes two annotations, one
+The @rhombus(Map.of) annotation constructor takes two annotations, one
 for keys and one for values:
 
 @(rhombusblock:
@@ -95,16 +95,16 @@ for keys and one for values:
     locale("alice", neighborhood)  // prints "4, 5"
   )
 
-Unlike @rhombus[.], indexed access via @litchar{[}...@litchar{]} works
+Unlike @rhombus(.), indexed access via @litchar{[}...@litchar{]} works
 even without static information to say that the access will succeed.
 Still, static information can select a more specific and potentially
-fast indexing operator. For example, @rhombus[buckets[0]] above
+fast indexing operator. For example, @rhombus(buckets[0]) above
 statically resolves to the use of array lookup, instead of going through
 a generic function for maps at run time.
 
-The @rhombus[make_map] function works similarly to the @rhombus[Map]
+The @rhombus(make_map) function works similarly to the @rhombus(Map)
 constructor, but it creates a mutable map. A mutable map can be updated
-using @litchar{[}...@litchar{]} with @rhombus[:=] just like an array.
+using @litchar{[}...@litchar{]} with @rhombus(:=) just like an array.
 
 @(rhombusblock:
     val locations: make_map("alice", Posn(4, 5),

--- a/rhombus/scribblings/module.scrbl
+++ b/rhombus/scribblings/module.scrbl
@@ -17,9 +17,9 @@ module, then its value gets printed out.
     "Hello, world!"  // prints "Hello, world!", including the quotes
   )
 
-The ways to define names in a module include @rhombus[val] and @rhombus[fun].
-The @rhombus[val] form defines an immutable variable, and it expects an
-identifier to define followed by a block. The @rhombus[fun] form defines
+The ways to define names in a module include @rhombus(val) and @rhombus(fun).
+The @rhombus(val) form defines an immutable variable, and it expects an
+identifier to define followed by a block. The @rhombus(fun) form defines
 a function when it see an identifier, parentheses, and then a block.
 
 @(rhombusblock:
@@ -35,7 +35,7 @@ a function when it see an identifier, parentheses, and then a block.
 
 @aside{If you have installed the @pkg{shrubbery-rhombus-0} package, then
  the interactions window in DrRacket will work to call
- @rhombus[fahrenheit_to_celsius]. In interactions, a single input line is
+ @rhombus(fahrenheit_to_celsius). In interactions, a single input line is
  accepted as complete as long as it's openers and closers are balanced,
  and as long as it doesn't contain @litchar{:} or @litchar{;} outside of
  an opener--closer pair. A blank line terminates multi-line input. For
@@ -44,10 +44,10 @@ a function when it see an identifier, parentheses, and then a block.
  its own line.}
 
 A Rhombus module can export definitions to other modules using
-@rhombus[export], and it can import other modules using
-@rhombus[import]. The @litchar{#lang rhombus} line is a kind of
-@rhombus[import] already, so normally more @rhombus[import]s are written
-at the top of a module, and then @rhombus[export]s, and then the
+@rhombus(export), and it can import other modules using
+@rhombus(import). The @litchar{#lang rhombus} line is a kind of
+@rhombus(import) already, so normally more @rhombus(import)s are written
+at the top of a module, and then @rhombus(export)s, and then the
 definitions.
 
 @(rhombusblock:
@@ -76,8 +76,8 @@ definitions.
 Unlike Racket, imported bindings must accessed using a prefix name and
 then @litchar{.}, at least by default. The prefix is inferred from a module
 path by taking its last component and removing any extension, so
-that’s why the import of @rhombus["f2c.rhm"] leads to the @rhombus[f2c] prefix. To
-supply an explicit prefix, use the @rhombus[as, ~impmod] modifier:
+that’s why the import of @rhombus("f2c.rhm") leads to the @rhombus(f2c) prefix. To
+supply an explicit prefix, use the @rhombus(as, ~impmod) modifier:
 
 @(rhombusblock:
     import:
@@ -85,7 +85,7 @@ supply an explicit prefix, use the @rhombus[as, ~impmod] modifier:
 
     convert.fahrenheit_to_celsius(convert.fahrenheit_freezing))
 
-Use the @rhombus[open, ~impmod] modifier to import without a prefix, but
+Use the @rhombus(open, ~impmod) modifier to import without a prefix, but
 this kind of ``namespace dumping'' is considered bad style in most
 cases:
 
@@ -107,10 +107,10 @@ prefix:
     )
 
 @aside{The use of @litchar{.} with an import name as a hierarchical reference is not
-the same as the @rhombus[.] operator described in the next section. We stick with @litchar{/}
+the same as the @rhombus(.) operator described in the next section. We stick with @litchar{/}
 for module paths to avoid overloading @litchar{.} further.}
 
-There’s a lot more to the syntax or @rhombus[import] and
-@rhombus[export] for renaming, re-exporting, and so on. See the
-documentation of @rhombus[import] and @rhombus[export] for more
+There’s a lot more to the syntax or @rhombus(import) and
+@rhombus(export) for renaming, re-exporting, and so on. See the
+documentation of @rhombus(import) and @rhombus(export) for more
 information.

--- a/rhombus/scribblings/more-arguments.scrbl
+++ b/rhombus/scribblings/more-arguments.scrbl
@@ -5,12 +5,12 @@
 
 @title{More Function Arguments}
 
-In the same way that @rhombus[..., ~bind] can be used in a list
-binding pattern to create a repetition, @rhombus[..., ~bind] can be
+In the same way that @rhombus(..., ~bind) can be used in a list
+binding pattern to create a repetition, @rhombus(..., ~bind) can be
 used after the last argument in a function declaration to bind
-repetitions. And just like @rhombus[...] can be used at the end of a
+repetitions. And just like @rhombus(...) can be used at the end of a
 list expression to add the repetition's element to the end of the
-list, @rhombus[...] can be used at the end of a function-call
+list, @rhombus(...) can be used at the end of a function-call
 expression to use the repetition's elements as the last arguments to
 the function.
 

--- a/rhombus/scribblings/multiple-value.scrbl
+++ b/rhombus/scribblings/multiple-value.scrbl
@@ -3,9 +3,9 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "multiple-values"]{Multiple Values}
+@title(~tag: "multiple-values"){Multiple Values}
 
-The @rhombus[values] form returns multiple values:
+The @rhombus(values) form returns multiple values:
 
 @(rhombusblock:
     values(1, "apple") // prints 1 and "apple"
@@ -14,7 +14,7 @@ The @rhombus[values] form returns multiple values:
 When an expression in a module body returns multiple values, each one is
 printed, the same as in @litchar{#lang racket}.
 
-When the @rhombus[val] binding form is followed by parentheses with @math{N}
+When the @rhombus(val) binding form is followed by parentheses with @math{N}
 groups, then the right-hand side should produce @math{N} values, and each
 value is matched against the corresponding group.
 
@@ -25,9 +25,9 @@ value is matched against the corresponding group.
     s  // prints "apple"
   )
 
-A definition binding with with @rhombus[val] or @rhombus[def] can also
-use @rhombus[values] in the outermost pattern, and that’s the same as
-not writing @rhombus[values], but makes the receiver and sender side
+A definition binding with with @rhombus(val) or @rhombus(def) can also
+use @rhombus(values) in the outermost pattern, and that’s the same as
+not writing @rhombus(values), but makes the receiver and sender side
 look more the same:
 
 @(rhombusblock:
@@ -38,6 +38,6 @@ look more the same:
   )
 
 As in Racket, multiple values are not a tuple value. They must be
-specifically received as values. The @rhombus[values] binding pattern
+specifically received as values. The @rhombus(values) binding pattern
 works only with definition forms that recognize it, and not, for
 example, as a function argument.

--- a/rhombus/scribblings/mutable-var.scrbl
+++ b/rhombus/scribblings/mutable-var.scrbl
@@ -3,10 +3,10 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "mutable-vars"]{Mutable Variables}
+@title(~tag: "mutable-vars"){Mutable Variables}
 
 Variables are immutable unless they are declared with the
-@rhombus[mutable] binding operator. The @rhombus[:=] infix operator
+@rhombus(mutable) binding operator. The @rhombus(:=) infix operator
 assigns to a mutable variable while also returning the variable’s new
 value.
 
@@ -26,6 +26,6 @@ value.
     // f = 5 // would be an error: f is not mutable
   )
 
-@aside{The @rhombus[:=] operator should also cooperate with @rhombus[.]
- when a class field is declared @rhombus[mutable], but that’s not yet
+@aside{The @rhombus(:=) operator should also cooperate with @rhombus(.)
+ when a class field is declared @rhombus(mutable), but that’s not yet
  implemented.}

--- a/rhombus/scribblings/notation.scrbl
+++ b/rhombus/scribblings/notation.scrbl
@@ -6,7 +6,7 @@
 @title{Notation}
 
 This is a summary of
-@seclink[~doc: [symbol(lib), "shrubbery/scribblings/shrubbery.scrbl"], "top"]{Shrubbery notation}
+@seclink(~doc: [symbol(lib), "shrubbery/scribblings/shrubbery.scrbl"], "top"){Shrubbery notation}
 as used for Rhombus.
 
 @aside{If you install @tt{https://github.com/racket/rhombus-prototype.git},
@@ -14,7 +14,7 @@ as used for Rhombus.
   for this part) to see how example shrubberies parse into an
   S-expression representation. Unfortunately, it needs a development
   version of Racket right now, so you may need to install a
-  @hyperlink["https://snapshot.racket-lang.org/"]{snapshot build}.}
+  @hyperlink("https://snapshot.racket-lang.org/"){snapshot build}.}
 
 Numbers are decimal, either integer or floating-point, or they’re
 hexadecimal integers written with @litchar{0x}:
@@ -42,7 +42,7 @@ character that is not numeric.
 These characters are used for shrubbery structure and are
 mostly not available for use in operators:
 
-@verbatim[~indent: 2]|{
+@verbatim(~indent: 2)|{
 ( ) [ ] { } '   ; ,   : |   « »  \   " ~  # @
 }|
 
@@ -103,8 +103,8 @@ ends @litchar{|} (much less commonly), or that starts @litchar{|}. You
 can think of a more-indented @litchar{|} as being preceded implicitly by
 a @litchar{:} at the end of the previous line. A @litchar{|} counts as
 being indented by half a column, so the @litchar{|}s below are indented
-even when they are written right under @rhombus[if], @rhombus[match], or
-@rhombus[cond]:
+even when they are written right under @rhombus(if), @rhombus(match), or
+@rhombus(cond):
 
 @(rhombusblock:
     begin:
@@ -211,7 +211,7 @@ required to delimit a block using @litchar{«} just after @litchar{:} or
 parentheses work just as well, but the `match` example above illustrates
 a rare case where @litchar{«} and @litchar{»} would be needed to fit on
 a single line. Without @litchar{«} and @litchar{»}, the following form
-would put @rhombus[x + zero] insinde the definition of @rhombus[zero]:
+would put @rhombus(x + zero) insinde the definition of @rhombus(zero):
 
 @(rhombusblock:
     match x | 0: def zero:« x »; x + zero | n: n + 1)

--- a/rhombus/scribblings/operator.scrbl
+++ b/rhombus/scribblings/operator.scrbl
@@ -3,9 +3,9 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "operator"]{Operators}
+@title(~tag: "operator"){Operators}
 
-The @rhombus[operator] form defines a prefix or infix operator for
+The @rhombus(operator) form defines a prefix or infix operator for
 expressions, similar to a function definition:
 
 @(rhombusblock:
@@ -30,7 +30,7 @@ an identifier:
     10 mod 3  // prints 1
   )
 
-The @rhombus[operator] form must be followed by parentheses and then a
+The @rhombus(operator) form must be followed by parentheses and then a
 block. Inside the parentheses, there must be exactly two or three terms,
 and the next-to-last term must be an operator or identifier to define.
 The arguments can be described by binding patterns, but in that case,
@@ -60,8 +60,8 @@ arguments:
   )
 
 Operator precedence is declared in relationship to other operators when
-the operator is defined. With no precedence defined, @rhombus[<>] cannot
-appear near an arithmetic operator like @rhombus[*]:
+the operator is defined. With no precedence defined, @rhombus(<>) cannot
+appear near an arithmetic operator like @rhombus(*):
 
 @(rhombusblock:
     // 1 <> 2 * 3  // would be a syntax error
@@ -69,19 +69,19 @@ appear near an arithmetic operator like @rhombus[*]:
   )
 
 The initially defined operators mostly have the usual precedence:
-@rhombus[*] and @rhombus[/] are stronger than @rhombus[+] and
-@rhombus[-], while @rhombus[+] and @rhombus[-] have the same predence
-and are left-associative. The @rhombus[*] and @rhombus[/] operator have
-the same precedence as long as @rhombus[*] appears only to the left of
-@rhombus[/],
+@rhombus(*) and @rhombus(/) are stronger than @rhombus(+) and
+@rhombus(-), while @rhombus(+) and @rhombus(-) have the same predence
+and are left-associative. The @rhombus(*) and @rhombus(/) operator have
+the same precedence as long as @rhombus(*) appears only to the left of
+@rhombus(/),
 
-A precedence declaration in @rhombus[operator] takes the form of keyword
+A precedence declaration in @rhombus(operator) takes the form of keyword
 blocks at the start of the operator’s body. The possible keyword options
-for prefix operators are @rhombus[~weaker_than],
-@rhombus[~stronger_than], @rhombus[~same_as], or
-@rhombus[~same_as_on_left]. For infix operators, those options apply, as
-well as @rhombus[~same_as_on_right] and @rhombus[~associativity].
-Operators listed with keywords like @rhombus[~weaker_than] can be
+for prefix operators are @rhombus(~weaker_than),
+@rhombus(~stronger_than), @rhombus(~same_as), or
+@rhombus(~same_as_on_left). For infix operators, those options apply, as
+well as @rhombus(~same_as_on_right) and @rhombus(~associativity).
+Operators listed with keywords like @rhombus(~weaker_than) can be
 grouped on lines however is convenient.
 
 @(rhombusblock:
@@ -95,8 +95,8 @@ grouped on lines however is convenient.
     1 <> 2 <> 3 // prints Posn(1, Posn(2, 3))
   )
 
-Use the keyword @rhombus[~other] in @rhombus[~weaker_than],
-@rhombus[~stronger_than], or @rhombus[~same_as] to declare a precedence
+Use the keyword @rhombus(~other) in @rhombus(~weaker_than),
+@rhombus(~stronger_than), or @rhombus(~same_as) to declare a precedence
 relationship for operators not otherwise mentioned.
 
 An operator can be exported the same as identifiers:
@@ -107,7 +107,7 @@ An operator can be exported the same as identifiers:
   )
 
 On the import side, to refer to an operator that has a prefix, put the
-operator after @rhombus[.] in parentheses:
+operator after @rhombus(.) in parentheses:
 
 @(rhombusblock:
     import:
@@ -118,9 +118,9 @@ operator after @rhombus[.] in parentheses:
 
 If the point of an operator is terseness, an import prefix may defeat
 the point. Using a library that supplies operators may be one reason to
-import with a leading @rhombus[=] to avoid a prefix on the imports. To
+import with a leading @rhombus(=) to avoid a prefix on the imports. To
 selectively make an operator accessible without it import’s prefix, use
-the @rhombus[expose] import modifier:
+the @rhombus(expose) import modifier:
 
 @(rhombusblock:
     import:

--- a/rhombus/scribblings/overview.scrbl
+++ b/rhombus/scribblings/overview.scrbl
@@ -1,27 +1,27 @@
 #lang scribble/rhombus/manual
 
-@title[~style: symbol(toc)]{Rhombus Overview}
+@title(~style: symbol(toc)){Rhombus Overview}
 
-@local_table_of_contents[]
+@local_table_of_contents()
 
-@include_section["notation.scrbl"]
-@include_section["module.scrbl"]
-@include_section["definition.scrbl"]
-@include_section["annotation.scrbl"]
-@include_section["function.scrbl"]
-@include_section["keyword-argument.scrbl"]
-@include_section["conditional.scrbl"]
-@include_section["multiple-value.scrbl"]
-@include_section["mutable-var.scrbl"]
-@include_section["operator.scrbl"]
-@include_section["list.scrbl"]
-@include_section["map.scrbl"]
-@include_section["set.scrbl"]
-@include_section["more-arguments.scrbl"]
-@include_section["for.scrbl"]
-@include_section["syntax.scrbl"]
-@include_section["expr-macro.scrbl"]
-@include_section["defn-macro.scrbl"]
-@include_section["bind-macro.scrbl"]
-@include_section["annotation-vs-bind.scrbl"]
-@include_section["syntax-class.scrbl"]
+@include_section("notation.scrbl")
+@include_section("module.scrbl")
+@include_section("definition.scrbl")
+@include_section("annotation.scrbl")
+@include_section("function.scrbl")
+@include_section("keyword-argument.scrbl")
+@include_section("conditional.scrbl")
+@include_section("multiple-value.scrbl")
+@include_section("mutable-var.scrbl")
+@include_section("operator.scrbl")
+@include_section("list.scrbl")
+@include_section("map.scrbl")
+@include_section("set.scrbl")
+@include_section("more-arguments.scrbl")
+@include_section("for.scrbl")
+@include_section("syntax.scrbl")
+@include_section("expr-macro.scrbl")
+@include_section("defn-macro.scrbl")
+@include_section("bind-macro.scrbl")
+@include_section("annotation-vs-bind.scrbl")
+@include_section("syntax-class.scrbl")

--- a/rhombus/scribblings/ref-annotation.scrbl
+++ b/rhombus/scribblings/ref-annotation.scrbl
@@ -3,80 +3,80 @@
 
 @title{Annotations}
 
-@doc[
+@doc(
   operator (expr :: annotation) :: annotation
-]{
+){
 
- Checks that the value of @rhombus[expr] satisifies
- @rhombus[annotation], and returns the value if so.
+ Checks that the value of @rhombus(expr) satisifies
+ @rhombus(annotation), and returns the value if so.
 
-@examples[
+@examples(
   [1, 2, 3] :: List
-]
+)
 
 }
 
-@doc[
+@doc(
   bind.rule '$binding :: $annotation'
-]{
+){
 
- Binds the same as @rhombus[binding], but first checks that the value to
- be bound satisfies @rhombus[annotation].
+ Binds the same as @rhombus(binding), but first checks that the value to
+ be bound satisfies @rhombus(annotation).
 
-@examples[
+@examples(
   val x :: List: [1, 2, 3]
-]
+)
 
 }
 
-@doc[
+@doc(
   annotation.rule 'Any'
-]{
+){
 
   Matches any value.
 
 }
 
-@doc[
+@doc(
   operator (arg -: annotation) :: annotation
-]{
+){
 
  Associates static information to the overall expression the same as
- @rhombus[::], but performs no run-time check on the value of
- @rhombus[expr].
+ @rhombus(::), but performs no run-time check on the value of
+ @rhombus(expr).
 
-@examples[
+@examples(
   [1, 2, 3] -: List,
   "oops" -: List
-]
+)
 
 }
 
-@doc[
+@doc(
   bind.rule '$binding -: $annotation'
-]{
+){
 
- Associates static information to @rhombus[binding] the same as
- @rhombus[::, ~bind], but performs no run-time check.
+ Associates static information to @rhombus(binding) the same as
+ @rhombus(::, ~bind), but performs no run-time check.
 
-@examples[
+@examples(
   val x -: List: [1, 2, 3],
   val x -: List: "oops"
-]
+)
 
 }
 
 
-@doc[
+@doc(
   expr.rule '$expr is_a $annotation'
-]{
+){
 
- Produces @rhombus[#true] if the value of @rhombus[expr]
- satisfies @rhombus[annotation], @rhombus[#false] otherwise.
+ Produces @rhombus(#true) if the value of @rhombus(expr)
+ satisfies @rhombus(annotation), @rhombus(#false) otherwise.
 
-@examples[
+@examples(
   [1, 2, 3] is_a List,
   "oops" is_a List
-]
+)
 
 }

--- a/rhombus/scribblings/ref-array.scrbl
+++ b/rhombus/scribblings/ref-array.scrbl
@@ -4,61 +4,61 @@
 @title{Arrays}
 
 An expression followed by a square-bracketed sequence of expressions
-is parsed as an implicit use of the @rhombus[#{#%ref}] form, which is
+is parsed as an implicit use of the @rhombus(#{#%ref}) form, which is
 normally bound to implement an array reference or assignment, as well
 as other operations.
 
-@doc[
+@doc(
   expr.macro '#{#%ref} $expr[$at_expr]',
   expr.macro '#{#%ref} $expr[$at_expr] := $rhs_expr',
-]{
+){
 
-Without @rhombus[:=], accesses the element of the map, array, list, or
-string produced by @rhombus[expr] at the index or key produced by
-@rhombus[at_expr].
+Without @rhombus(:=), accesses the element of the map, array, list, or
+string produced by @rhombus(expr) at the index or key produced by
+@rhombus(at_expr).
 
-With @rhombus[:=], a mutable array, map, or set element is assigned to
-the value produced by @rhombus[rhs_expr], and the expression result is
-@rhombus[#void].
+With @rhombus(:=), a mutable array, map, or set element is assigned to
+the value produced by @rhombus(rhs_expr), and the expression result is
+@rhombus(#void).
 
 }
 
-@doc[
+@doc(
   fun Array(v :: Any, ...) :: Array
-]{
+){
 
  Constructs a mutable array containing given arguments.
 
-@examples[
+@examples(
   val a: Array(1, 2, 3),
   a,
   a[0],
   a[0] := 0,
   a
-]
+)
 
 }
 
-@doc[
+@doc(
   bind.macro 'Array($binding, ...)'
-]{
+){
 
- Matches an array with as many elements as @rhombus[binding]s, where
- each element matches its corresponding @rhombus[binding].
+ Matches an array with as many elements as @rhombus(binding)s, where
+ each element matches its corresponding @rhombus(binding).
 
-@examples[
+@examples(
   val Array(1, x, y): Array(1, 2, 3),
   y
-]
+)
 
 }
 
-@doc[
+@doc(
   annotation.macro 'Array',
   annotation.macro 'Array.of($annotation)',
-]{
+){
 
- Matches any array in the form without @rhombus[of]. The @rhombus[of]
- variant matches an array whose elements satisfy @rhombus[annotation].
+ Matches any array in the form without @rhombus(of). The @rhombus(of)
+ variant matches an array whose elements satisfy @rhombus(annotation).
 
 }

--- a/rhombus/scribblings/ref-begin-meta.scrbl
+++ b/rhombus/scribblings/ref-begin-meta.scrbl
@@ -5,17 +5,17 @@
 
 @title{For-Meta Sequences}
 
-@doc[
+@doc(
   defn.macro 'begin_for_meta:
                 $body
                 ...'
-]{
+){
 
- The same as the @rhombus[body] sequence, but shifted to one phase
- greater. Defintions inside a @rhombus[begin_for_meta] block can be
+ The same as the @rhombus(body) sequence, but shifted to one phase
+ greater. Defintions inside a @rhombus(begin_for_meta) block can be
  referenced in macro implements, for example.
 
-@examples[
+@examples(
   ~eval: macro.make_for_meta_eval(),
   begin_for_meta:
     syntax.class Arithmetic
@@ -24,4 +24,6 @@
   expr.macro 'right_operand $(exp :: Arithmetic)':
     values(exp.y, ''),
   right_operand 1 + 2
-]}
+)
+
+}

--- a/rhombus/scribblings/ref-begin.scrbl
+++ b/rhombus/scribblings/ref-begin.scrbl
@@ -3,22 +3,22 @@
 
 @title{Begin}
 
-@doc[
+@doc(
   decl.macro 'begin:
                 $body
                 ...'
-]{
+){
 
- Returns the result of the @rhombus[body] block, which may include local
+ Returns the result of the @rhombus(body) block, which may include local
  definitions.
 
-@examples[
+@examples(
   begin:
     1
     2,
   begin:
     val one: 1
     one + one
-]
+)
 
 }

--- a/rhombus/scribblings/ref-boolean.scrbl
+++ b/rhombus/scribblings/ref-boolean.scrbl
@@ -3,52 +3,52 @@
 
 @title{Booleans}
 
-@doc[
+@doc(
   annotation.macro 'Boolean'
-]{
+){
 
-  Matches @rhombus[#true] or @rhombus[#false]
+  Matches @rhombus(#true) or @rhombus(#false)
 
 }
 
-@doc[
+@doc(
   expr.macro '$expr || $expr'
-]{
+){
 
- Produces the value of the first @rhombus[expr] if it is
- non-@rhombus[#false], otherwise produces the value(s) of the second
- @rhombus[expr].
+ Produces the value of the first @rhombus(expr) if it is
+ non-@rhombus(#false), otherwise produces the value(s) of the second
+ @rhombus(expr).
 
- The second @rhombus[expr] is evaluated in tail position with respect to
- the @rhombus[||] form.
+ The second @rhombus(expr) is evaluated in tail position with respect to
+ the @rhombus(||) form.
 
 }
 
-@doc[
+@doc(
   expr.macro '$expr && $expr'
-]{
+){
 
- Produces @rhombus[#false] if the the value of the first @rhombus[expr]
- is @rhombus[#false], otherwise produces the value(s) of the second
- @rhombus[expr].
+ Produces @rhombus(#false) if the the value of the first @rhombus(expr)
+ is @rhombus(#false), otherwise produces the value(s) of the second
+ @rhombus(expr).
 
- The second @rhombus[expr] is evaluated in tail position with respect to
- the @rhombus[&&] form.
+ The second @rhombus(expr) is evaluated in tail position with respect to
+ the @rhombus(&&) form.
 
 }
 
-@doc[
+@doc(
   operator (! v):: Boolean
-]{
+){
 
- Returns @rhombus[#true] if @rhombus[v] is @rhombus[#false],
- @rhombus[#false] otherwise.
+ Returns @rhombus(#true) if @rhombus(v) is @rhombus(#false),
+ @rhombus(#false) otherwise.
 
 
-@examples[
+@examples(
   !#false,
   !#true,
   !"false"
-]
+)
 
 }

--- a/rhombus/scribblings/ref-class.scrbl
+++ b/rhombus/scribblings/ref-class.scrbl
@@ -3,33 +3,33 @@
 
 @title{Classes}
 
-@doc[
+@doc(
   ~literal: ::,
   defn.macro 'class $identifier($field, ...)',
   
   grammar field:
     $identifier
     $identifier :: $annotation
-]{
+){
 
- Binds @rhombus[identifier] as a class name, which serves several roles:
+ Binds @rhombus(identifier) as a class name, which serves several roles:
 
-@itemlist[
+@itemlist(
 
  @item{a constructor function, which takes as many arguments as the
-   supplied @rhombus[field]s and returns an instance of the class;},
+   supplied @rhombus(field)s and returns an instance of the class;},
 
  @item{an annotation, which is satisfied by any instance of the class;},
 
  @item{a pattern constructor, which takes as many patterns as the
-   supplied @rhombus[field]s and matches an instance of the class where the
+   supplied @rhombus(field)s and matches an instance of the class where the
    fields match the corresponding patterns;},
 
- @item{a dot povider to access accessor functions @rhombus[identifier.field]},
+ @item{a dot povider to access accessor functions @rhombus(identifier.field)},
 
- @item{an annotation constructor @rhombus[identifier.of], which takes as
-   many annotation arguments as supplied @rhombus[field]s.}
+ @item{an annotation constructor @rhombus(identifier.of), which takes as
+   many annotation arguments as supplied @rhombus(field)s.}
 
-]
+)
 
 }

--- a/rhombus/scribblings/ref-cond.scrbl
+++ b/rhombus/scribblings/ref-cond.scrbl
@@ -3,19 +3,19 @@
 
 @title{Conditionals}
 
-@doc[
+@doc(
   decl.macro 'if $test_expr
               | $then_body
                 ...
               | $else_body
                 ...'
-]{
+){
 
- If @rhombus[test_expr] produces a true value (which is value other than
- @rhombus[#false]), returns the result of the @rhombus[then_body] clause,
- otherwise returns the result of the @rhombus[else_body] clause.
+ If @rhombus(test_expr) produces a true value (which is value other than
+ @rhombus(#false)), returns the result of the @rhombus(then_body) clause,
+ otherwise returns the result of the @rhombus(else_body) clause.
 
-@examples[
+@examples(
   if #true
   | "yes"
   | "no",
@@ -23,11 +23,11 @@
   | val yep: "yes"
     yep
   | "no"
-]
+)
 
 }
 
-@doc[
+@doc(
   decl.macro 'cond
               | $clause_test_expr:
                   $clause_result_body
@@ -41,15 +41,15 @@
               | ~else:
                   $clause_result_body
                   ...'
-]{
+){
 
- Tries the @rhombus[clause_test_expr]s in sequence, and as soon as one
- produces a non-@rhombus[#false] value, returns the result of the
- corresponding @rhombus[clause_result_body] block. The keyword
- @rhombus[~else] can be used as a synonym for @rhombus[#true] in the last
+ Tries the @rhombus(clause_test_expr)s in sequence, and as soon as one
+ produces a non-@rhombus(#false) value, returns the result of the
+ corresponding @rhombus(clause_result_body) block. The keyword
+ @rhombus(~else) can be used as a synonym for @rhombus(#true) in the last
  clause.
 
- If no @rhombus[clause_test_expr] produces a true value and there is no
- @rhombus[~else] clause, a run-time exception is raised.
+ If no @rhombus(clause_test_expr) produces a true value and there is no
+ @rhombus(~else) clause, a run-time exception is raised.
 
 }

--- a/rhombus/scribblings/ref-def.scrbl
+++ b/rhombus/scribblings/ref-def.scrbl
@@ -3,72 +3,72 @@
 
 @title{Definitions}
 
-@doc[
+@doc(
   defn.macro 'val $binding:
                 $body
                 ...'
-]{
+){
 
- Binds the identifiers of @rhombus[binding] to the value of the
- @rhombus[body] sequence. The @rhombus[body] itself can include
+ Binds the identifiers of @rhombus(binding) to the value of the
+ @rhombus(body) sequence. The @rhombus(body) itself can include
  definitions, and its normally it ends with an expression to provide the
  result value.
 
- A @rhombus[binding] can be just an identifier, or it can be constructed
- with a binding operator, such as a pattern form or @rhombus[::] for
+ A @rhombus(binding) can be just an identifier, or it can be constructed
+ with a binding operator, such as a pattern form or @rhombus(::) for
  annotations.
 
-@examples[
+@examples(
   val pi: 3.14,
   pi
-]
+)
 
-@examples[
+@examples(
   ~label: #false,
   val pi:
     val tau: 6.28
     tau/2,
   pi
-]
+)
 
-@examples[
+@examples(
   ~label: #false,
   val [x, y, z]: [1+2, 3+4, 5+6],
   y
-]
+)
 
-@examples[
+@examples(
   ~label: #false,
   val ns :: List: [1+2, 3+4, 5+6],
   ns
-]
+)
 
 }
 
 
-@doc[
+@doc(
   defn.macro 'let $binding:
                 $body
                 ...'
-]{
+){
 
- Like @rhombus[val], but for bindings that become visible only after the
- @rhombus[let] form within its definition context. The @rhombus[let] form
+ Like @rhombus(val), but for bindings that become visible only after the
+ @rhombus(let) form within its definition context. The @rhombus(let) form
  cannot be used in a top-level context outside of a module or local block.
 
-@examples[
+@examples(
   begin:
     let v: 1
     fun get_v(): v
     let v: v+1
     [get_v(), v]
-]
+)
 
 }
 
 
 
-@doc[
+@doc(
   defn.macro 'def $binding:
                 $body
                 ...',
@@ -89,11 +89,11 @@
   grammar identifier_or_operator:
     $identifier
     $operator
-]{
+){
 
- Like @rhombus[val], @rhombus[def], or @rhombus[expr.rule], depending on
- the form. The @rhombus[fun]-like form matches only if
- @rhombus[identifier] is not bound as a pattern operator.
+ Like @rhombus(val), @rhombus(def), or @rhombus(expr.rule), depending on
+ the form. The @rhombus(fun)-like form matches only if
+ @rhombus(identifier) is not bound as a pattern operator.
 
 }
 

--- a/rhombus/scribblings/ref-defn-macro.scrbl
+++ b/rhombus/scribblings/ref-defn-macro.scrbl
@@ -11,24 +11,24 @@
 
 @title{Definition Macros}
 
-@doc[
+@doc(
   defn.macro '«defn.macro '$identifier_or_operator $pattern ...':
                  $body
                  ...»',
   grammar identifier_or_operator:
     $identifier
     $operator,
-]{
+){
 
- Defines @rhombus[identifier] or @rhombus[operator] as a macro that can
- be used in a definition context, where the compile-time @rhombus[body]
+ Defines @rhombus(identifier) or @rhombus(operator) as a macro that can
+ be used in a definition context, where the compile-time @rhombus(body)
  block returns the expansion result. The macro pattern is matched to an
  entire group in a definition context.
 
  The expansion result must be a parenthesized block, and the groups of
  the block are inlined in place of the definition-macro use.
 
-@examples[
+@examples(
   ~eval: macro_eval,
   defn.macro 'enum:
                 $(id :: Group)
@@ -48,11 +48,11 @@
     b
     c,
   b
-]
+)
 
 }
 
-@doc[
+@doc(
   defn.macro '«defn.sequence_macro '$identifier_or_operator $pattern ...
                                       $pattern
                                       ...':
@@ -61,9 +61,9 @@
   grammar identifier_or_operator:
     $identifier
     $operator,
-]{
+){
 
- Similar to @rhombus[defn.macro], but defines a macro for a definition
+ Similar to @rhombus(defn.macro), but defines a macro for a definition
  context that is matched against all of the remiaining groups in the
  context, so the pattern is a block pattern.
 
@@ -71,7 +71,7 @@
  splice in place of the sequence-macro use, and a parenthesized block of
  groups that represent the tail of the definition context that was not consumed.
 
-@examples[
+@examples(
   ~eval: macro_eval,
   defn.sequence_macro 'reverse_defns
                        $defn1
@@ -84,7 +84,7 @@
     def seq_x: seq_y+1
     def seq_y: 10
     seq_x
-]
+)
 }
 
-@«macro.close_eval»[macro_eval]
+@«macro.close_eval»(macro_eval)

--- a/rhombus/scribblings/ref-dot.scrbl
+++ b/rhombus/scribblings/ref-dot.scrbl
@@ -3,22 +3,22 @@
 
 @title{Dot}
 
-@doc[
+@doc(
   expr.macro '$target . $identifier'
-]{
+){
 
- Accesses a component of @rhombus[target], either statically or
- dyanamically. The access is static when @rhombus[target] is a @tech{dot
+ Accesses a component of @rhombus(target), either statically or
+ dyanamically. The access is static when @rhombus(target) is a @tech{dot
   provider}.
 
 }
 
 
-@doc[
+@doc(
   defn.macro 'use_static_dot'
-]{
+){
 
- (Re-)defines @rhombus[.] so that it accesses a component of a target
+ (Re-)defines @rhombus(.) so that it accesses a component of a target
  only when the access can be resolved statically.
 
 }

--- a/rhombus/scribblings/ref-equal.scrbl
+++ b/rhombus/scribblings/ref-equal.scrbl
@@ -3,78 +3,78 @@
 
 @title{Equality}
 
-@doc[
+@doc(
   operator ((v1 :: Any) == (v1 :: Any)) :: Boolean
-]{
+){
 
- Reports whether @rhombus[v1] and @rhombus[v2] are equal, which includes
+ Reports whether @rhombus(v1) and @rhombus(v2) are equal, which includes
  recursively comparing elements of compound data structures. Two numbers
- are @rhombus[==] only if they are both exact or both inexact. Two mutable
- values are @rhombus[==] only if they the same object (i.e., mutating one
+ are @rhombus(==) only if they are both exact or both inexact. Two mutable
+ values are @rhombus(==) only if they the same object (i.e., mutating one
  has the same effect as mutating the other).
 
-@examples[
+@examples(
   "apple" == "apple",
   [1, 2, 3] == 1,
   [1, "apple", {"alice": 97}] == [1, "apple", {"alice": 97}],
   1 == 1.0
-]
+)
 
 }
 
-@doc[
+@doc(
   operator ((v1 :: Any) === (v1 :: Any)) :: Boolean
-]{
+){
 
- Reports whether @rhombus[v1] and @rhombus[v2] are the same object.
- Being the @emph{same} is weakly defined, but only @rhombus[==] values
+ Reports whether @rhombus(v1) and @rhombus(v2) are the same object.
+ Being the @emph{same} is weakly defined, but only @rhombus(==) values
  can possibly be the same object, and mutable values are the same only if
  modifying one has the same effect as modifying the other. Interned
- values like symbols are @rhombus[===] when they are @rhombus[==].
+ values like symbols are @rhombus(===) when they are @rhombus(==).
 
-@examples[
+@examples(
   symbol(apple) === symbol(apple),
   symbol(apple) === symbol(banana),
-]
+)
 
 }
 
-@doc[
+@doc(
   operator ((x :: Number) .= (y :: Number)) :: Boolean
-]{
+){
 
- Reports whether @rhombus[x] and @rhombus[y] are numerically equal,
+ Reports whether @rhombus(x) and @rhombus(y) are numerically equal,
  where inexact numbers are effectively coerced to exact for comparisions
  to exact numbers.
 
-@examples[
+@examples(
   1 .= 1,
   1 .= 2,
   1.0 .= 1
-]
+)
 
 }
 
-@doc[
+@doc(
   operator ((v1 :: Any) != (v1 :: Any)) :: Boolean
-]{
+){
 
- Equvalent to @rhombus[!(v1 == v2)].
+ Equvalent to @rhombus(!(v1 == v2)).
 
-@examples[
+@examples(
   "apple" != "apple"
-]
+)
 
 }
 
 
-@doc[
+@doc(
   expr.macro '='
-]{
+){
 
- The @rhombus[=] operator is not bound as an expression or binding
+ The @rhombus(=) operator is not bound as an expression or binding
  operator. It is used as a syntactic delimiter by various forms, such as
- in @rhombus[fun] when specifying the default value for an optional
+ in @rhombus(fun) when specifying the default value for an optional
  argument.
 
 }

--- a/rhombus/scribblings/ref-eval.scrbl
+++ b/rhombus/scribblings/ref-eval.scrbl
@@ -3,37 +3,37 @@
 
 @title{Eval}
 
-@doc[
+@doc(
   fun eval(seq :: Syntax)
-]{
+){
 
-  Evaluates a term, group, or multi-group sequence @rhombus[seq] in the
+  Evaluates a term, group, or multi-group sequence @rhombus(seq) in the
   current namespace.
 
 }
 
 
-@doc[
+@doc(
   fun make_rhombus_namespace() :: Namespace
-]{
+){
 
- Creates a fresh namespace with @rhombusmodname[rhombus] imported.
+ Creates a fresh namespace with @rhombusmodname(rhombus) imported.
 
 }
 
-@doc[
+@doc(
   fun make_rhombus_empty_namespace() :: Namespace
-]{
+){
 
- Creates a fresh namespace with the @rhombusmodname[rhombus] module
+ Creates a fresh namespace with the @rhombusmodname(rhombus) module
  attached, but not imported.
 
 }
 
-@doc[
+@doc(
   fun current_namespace() :: Namespace,
   fun current_namespace(ns :: Namespace) :: #!void
-]{
+){
 
  A @tech{parameter} for the current namespace.
 

--- a/rhombus/scribblings/ref-export.scrbl
+++ b/rhombus/scribblings/ref-export.scrbl
@@ -3,7 +3,7 @@
 
 @title{Export}
 
-@doc[
+@doc(
   decl.macro 'export:
                 $export_item ... :
                   $export_modifier
@@ -19,7 +19,7 @@
   grammar identifier_or_operator:
     $identifier
     $operator,
-]{
+){
 
  Exports from the enclosing module.
 

--- a/rhombus/scribblings/ref-expr-macro.scrbl
+++ b/rhombus/scribblings/ref-expr-macro.scrbl
@@ -11,7 +11,7 @@
 
 @title{Expression Macros}
 
-@doc[
+@doc(
   defn.macro '«expr.rule $rule_pattern:
                  '$template'»',
   defn.macro '«expr.rule
@@ -27,41 +27,41 @@
   grammar term_pattern:
     $term_identifier
     ($term_identifier :: $syntax_class)
-]{
+){
 
- Defines @rhombus[identifier] or @rhombus[operator] as a pattern-based
- macro whose expansion is described by a @rhombus[template] that can
- refer to pattern variables bound in the @rhombus[rule_pattern]. A
- @rhombus[rule_pattern] is matched to a portion of its enclosing group,
+ Defines @rhombus(identifier) or @rhombus(operator) as a pattern-based
+ macro whose expansion is described by a @rhombus(template) that can
+ refer to pattern variables bound in the @rhombus(rule_pattern). A
+ @rhombus(rule_pattern) is matched to a portion of its enclosing group,
  and need not extend to the end of the group to match.
 
- Each @rhombus[rule_pattern] starts with @rhombus['']. Within
- @rhombus[''], either the first term is an identifier or operator to be
- defined as a prefix macro, or a single @rhombus[$, ~bind] escape is
+ Each @rhombus(rule_pattern) starts with @rhombus(''). Within
+ @rhombus(''), either the first term is an identifier or operator to be
+ defined as a prefix macro, or a single @rhombus($, ~bind) escape is
  followed by the identifier or operator to be defined as an infix macro.
 
  Using @litchar{|} alternatives, a single definition can have any number
  of prefix and infix variants (presumably) distinguished by patterns that
  are tried in order.
 
- The body after each @rhombus[rule_pattern] must be an immediate
- @rhombus[''] template, and any @rhombus[$] escape within the template can
+ The body after each @rhombus(rule_pattern) must be an immediate
+ @rhombus('') template, and any @rhombus($) escape within the template can
  only refer to an input pattern variable. More general compile-time
- expressions are not allowed, and @rhombus[expr.macro] must be used
+ expressions are not allowed, and @rhombus(expr.macro) must be used
  instead.
 
-@examples[
+@examples(
   ~eval: macro_eval,
   expr.rule 'thunk: $body':
     'fun (): $body',
   thunk: "ok",
   (thunk: "ok")()
-]
+)
 
 }
 
 
-@doc[
+@doc(
   defn.macro 'expr.macro $rule_pattern:
                 $body
                 ...',
@@ -70,34 +70,34 @@
                   $body
                   ...
               | ...',
-]{
+){
 
- Like @rhombus[expr.rule], but
+ Like @rhombus(expr.rule), but
 
-@itemlist[
+@itemlist(
   
   @item{with arbitrary compile-time code in the body after each
-   @rhombus[rule_pattern],},
+   @rhombus(rule_pattern),},
   
-  @item{each @rhombus[rule_pattern] is matched to the entire remainder
+  @item{each @rhombus(rule_pattern) is matched to the entire remainder
    of a group where the macro is used; and},
 
   @item{a body returns value values: an expansion for the consumed part
    of the input group, and a tail for the unconsumed part.}
 
-]
+)
 
 }
 
-@doc[
+@doc(
   val expr_ct.call_result_key
-]{
+){
 
- Provided @rhombus[for_meta, ~impmod], a value that can be used to
+ Provided @rhombus(for_meta, ~impmod), a value that can be used to
  associate static information with an expression that describes the
  result value if the expression is used as a function to call.
 
 }
 
 
-@«macro.close_eval»[macro_eval]
+@«macro.close_eval»(macro_eval)

--- a/rhombus/scribblings/ref-for.scrbl
+++ b/rhombus/scribblings/ref-for.scrbl
@@ -3,7 +3,7 @@
 
 @title{Iteration}
 
-@doc[
+@doc(
   decl.macro 'for:
                 $clause_or_body
                 ...
@@ -24,46 +24,46 @@
     ~break $expr
     ~final $expr
     $body
-]{
+){
 
- Iterates as determined by @rhombus[~each] and @rhombus[~and] clauses
- among the @rhombus[clause_or_body]s. An @rhombus[~and] clause is allowed
- only immediately after a @rhombus[~each] or @rhombus[~and] clause, and a
- group of clauses starting with @rhombus[~each] (with zero or more
- @rhombus[~and] clauses) forms one layer of iteration; each subsequent
+ Iterates as determined by @rhombus(~each) and @rhombus(~and) clauses
+ among the @rhombus(clause_or_body)s. An @rhombus(~and) clause is allowed
+ only immediately after a @rhombus(~each) or @rhombus(~and) clause, and a
+ group of clauses starting with @rhombus(~each) (with zero or more
+ @rhombus(~and) clauses) forms one layer of iteration; each subsequent
  part of the body is evaluated once per iteration, and additional
- @rhombus[~each] groups form nested iterations.
+ @rhombus(~each) groups form nested iterations.
 
- The block for a @rhombus[~each] or @rhombus[~and] clause must produce
+ The block for a @rhombus(~each) or @rhombus(~and) clause must produce
  a @tech{sequence}. Each element of that sequence is bound in turn to the
- @rhombus[binding] variables of the @rhombus[~each] or @rhombus[~and]
+ @rhombus(binding) variables of the @rhombus(~each) or @rhombus(~and)
  clause. If a sequence can has multiple values as its elements (for
  example, a map as a sequence has a key and value for each element), then
- @rhombus[binding] can be a @rhombus[values, ~bind] pattern or just a
+ @rhombus(binding) can be a @rhombus(values, ~bind) pattern or just a
  prenthesized sequence of bindings to receive a matcging number of element
  values.
 
  When multiple sequences are used in one iteration layer, iteration
  stops as soon as one of the sequences in the layer is exhausted.
 
- A @rhombus[~when] or @rhombus[~unless] clause short-circuits one
- iteration of the @rhombus[for] body, skipping remining expressions
- (including nested iterations) when the subsequent @rhombus[expr]
- produces @rhombus[#false] for @rhombus[~when] or a true value for
- @rhombus[~unless]. A @rhombus[~break] clause short-circuits the current
- iteration and all would-be remaining iterations of the @rhombus[for]
- form when its @rhombus[expr] produces a true value. A @rhombus[~final]
- clause is similar to @rhombus[~when], but it allows one iteration to
+ A @rhombus(~when) or @rhombus(~unless) clause short-circuits one
+ iteration of the @rhombus(for) body, skipping remining expressions
+ (including nested iterations) when the subsequent @rhombus(expr)
+ produces @rhombus(#false) for @rhombus(~when) or a true value for
+ @rhombus(~unless). A @rhombus(~break) clause short-circuits the current
+ iteration and all would-be remaining iterations of the @rhombus(for)
+ form when its @rhombus(expr) produces a true value. A @rhombus(~final)
+ clause is similar to @rhombus(~when), but it allows one iteration to
  complete before skipping the reminaing iterations.
 
- If a @rhombus[folder] is specified, it determines how each result of
- the last @rhombus[body] is combined to produce a result of the overall
- @rhombus[for] expression, otherwise the result of the last
- @rhombus[body] is ignored and the @rhombus[for] expression's value is
- @rhombus[#void]. Example folders include @rhombus[List, ~folder],
- @rhombus[Map, ~folder], and @rhombus[values, ~folder].
+ If a @rhombus(folder) is specified, it determines how each result of
+ the last @rhombus(body) is combined to produce a result of the overall
+ @rhombus(for) expression, otherwise the result of the last
+ @rhombus(body) is ignored and the @rhombus(for) expression's value is
+ @rhombus(#void). Example folders include @rhombus(List, ~folder),
+ @rhombus(Map, ~folder), and @rhombus(values, ~folder).
 
-@examples[
+@examples(
   for:
     ~each v: ["a", "b", "c"]
     displayln(v),
@@ -115,26 +115,26 @@
   for Map:
     ~each i: 0..3
     values(i, i +& "!")
-]
+)
 
 }
 
 
-@doc[
+@doc(
   expr.macro '$n_expr .. $m_expr',
   expr.macro '$n_expr ..'
-]{
+){
 
- If @rhombus[n_expr] produces an integer @rhombus[n, ~var] and
- @rhombus[m_expr] (when supplied) produces an integer @rhombus[m, ~var],
- returns a sequence containing the integers from @rhombus[n, ~var]
- (inclusive) to @rhombus[m, ~var] (exclusive). If @rhombus[m_expr] is not
+ If @rhombus(n_expr) produces an integer @rhombus(n, ~var) and
+ @rhombus(m_expr) (when supplied) produces an integer @rhombus(m, ~var),
+ returns a sequence containing the integers from @rhombus(n, ~var)
+ (inclusive) to @rhombus(m, ~var) (exclusive). If @rhombus(m_expr) is not
  specified, the result is an infinite sequence that contains all integers
- starting from @rhombus[n, ~var].
+ starting from @rhombus(n, ~var).
 
- The @rhombus[..]'s precedence is lower than the arithmetic operators
- @rhombus[+], @rhombus[-], @rhombus[*], and @rhombus[/]. In particular,
- @rhombus[n_expr..1+m_expr] creates a sequence that includes
- @rhombus[m, ~var] for many forms @rhombus[m_expr].
+ The @rhombus(..)'s precedence is lower than the arithmetic operators
+ @rhombus(+), @rhombus(-), @rhombus(*), and @rhombus(/). In particular,
+ @rhombus(n_expr..1+m_expr) creates a sequence that includes
+ @rhombus(m, ~var) for many forms @rhombus(m_expr).
 
 }

--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -1,16 +1,16 @@
 #lang scribble/rhombus/manual
 @(import: "common.rhm" open)
 
-@(val dots: @rhombus[..., ~bind])
-@(val dots_expr: @rhombus[...])
+@(val dots: @rhombus(..., ~bind))
+@(val dots_expr: @rhombus(...))
 
 @title{Functions}
 
 An expression followed by a parenthesized sequence of expressions is
-parsed as an implicit use of the @rhombus[#{#%call}] form, which is
+parsed as an implicit use of the @rhombus(#{#%call}) form, which is
 normally bound to implement function calls.
 
-@doc[
+@doc(
   expr.macro '#{#%call} $fun_expr ($arg, ..., $maybe_rest)',
 
   grammar arg:
@@ -20,18 +20,18 @@ normally bound to implement function calls.
   grammar maybe_rest:
     $repetition $$(@litchar{,}) $$(dots_expr)
     $$("ϵ")
-]{
+){
 
-  A function call. Each @rhombus[arg_expr] alone is a by-position
-  argument, and each @rhombus[keyword: arg_expr] combination is a
+  A function call. Each @rhombus(arg_expr) alone is a by-position
+  argument, and each @rhombus(keyword: arg_expr) combination is a
   by-keyword argument. If the argument sequence ends with @dots_expr,
   the then the elements of the preceding @tech{repetition} are used as
   additional by-position arguments, in order after the
-  @rhombus[arg_expr] arguments.
+  @rhombus(arg_expr) arguments.
 
 }
 
-@doc[
+@doc(
   defn.macro 'fun $identifier($kwopt_binding, ..., $maybe_rest) $maybe_result_annotation:
                 $body
                 ...',
@@ -65,48 +65,48 @@ normally bound to implement function calls.
   grammar maybe_rest:
     $binding $$(@litchar{,}) $$(dots)
     $$("ϵ")
-]{
+){
 
- Binds @rhombus[identifier] as a function, or when @rhombus[identifier]
+ Binds @rhombus(identifier) as a function, or when @rhombus(identifier)
  is not supplied, serves as an expression that produces a function value.
 
-@examples[
+@examples(
   fun f(x):
     x+1,
   f(0),
-]
+)
 
-@examples[
+@examples(
   ~label: #false,
   val identity: fun (x): x,
   identity(1),
-]
+)
 
-@examples[
+@examples(
   ~label: #false,
   fun curried_add(x):
     fun(y):
       x + y,
   curried_add(1)(2)
-]
+)
 
  When @litchar{|} is not used, then arguments can have keywords and/or
  default values. Bindings for earlier arguments are visible in each
- @rhombus[default_expr], but not bindings for later arguments;
+ @rhombus(default_expr), but not bindings for later arguments;
  accordingly, matching actions are interleaved with binding effects (such
  as rejecting a non-matching argument) left-to-right, except that the
- result of a @rhombus[default_expr] is subject to the same constraints
+ result of a @rhombus(default_expr) is subject to the same constraints
  imposed by annotations and patterns for its argument as an explicitly
  supplied argument would be.
 
-@examples[
+@examples(
   fun f(x, y = x+1):
     [x, y],
   f(0),
   f(0, 2),
-]
+)
 
-@examples[
+@examples(
   ~label: #false,
   fun transform([x, y],
                 ~scale: factor = 1,
@@ -116,35 +116,35 @@ normally bound to implement function calls.
   transform([1, 2]),
   transform([1, 2], ~dx: 7),
   transform([1, 2], ~dx: 7, ~scale: 2)
-]
+)
 
  When alternatives are specified with multiple @litchar{|} clauses, the
  alternatives are tried in order when the function is called. The
  alternatives can differ by number of arguments as well as annotations
  and binding patterns.
 
-@examples[
+@examples(
   fun | hello(name):
           "Hello, " +& name
       | hello(first, last):
           hello(first +& " " +& last),
   hello("World"),
   hello("Inigo", "Montoya"),
-]
+)
 
-@examples[
+@examples(
   ~label: #false,
   fun | is_passing(n :: Number): n >= 70
       | is_passing(pf :: Boolean): pf,
   is_passing(80) && is_passing(#true)
-]
+)
 
-When a @rhombus[rest] is specified as @rhombus[binding $$(@litchar{,}) $$(dots)],
+When a @rhombus(rest) is specified as @rhombus(binding $$(@litchar{,}) $$(dots)),
 then the function alternative accepts any number of additional
-argument, and each variable in @rhombus[binding] is bound to a
+argument, and each variable in @rhombus(binding) is bound to a
 repetition for all additional arguments, instead of a single argument.
 
-@examples[
+@examples(
   ~label: #false,
   fun
   | is_sorted([]): #true
@@ -153,11 +153,11 @@ repetition for all additional arguments, instead of a single argument.
       head <= next && is_sorted([next, tail, ...]),
   is_sorted([1, 2, 3, 3, 5]),
   is_sorted([1, 2, 9, 3, 5])
-]
+)
 
 }
 
-@doc[
+@doc(
   defn.macro 'operator ($opname $binding) $maybe_result_annotation:
                 $body
                 ...',
@@ -171,11 +171,11 @@ repetition for all additional arguments, instead of a single argument.
               | ($binding $opname $binding) $maybe_result_annotation:
                   $body
                   ...',
-]{
+){
 
- Binds @rhombus[opname] as an operator, either prefix or infix. The
- @rhombus[maybe_result_annotation] parts are the same as in
- @rhombus[fun] definitions.
+ Binds @rhombus(opname) as an operator, either prefix or infix. The
+ @rhombus(maybe_result_annotation) parts are the same as in
+ @rhombus(fun) definitions.
 
  When an operator definition includes both a prefix and infix variant
  with @litchar{|}, the variants can be in either order.

--- a/rhombus/scribblings/ref-import.scrbl
+++ b/rhombus/scribblings/ref-import.scrbl
@@ -3,7 +3,7 @@
 
 @title{Import}
 
-@doc[
+@doc(
   decl.macro 'import:
                 $import_clause
                 ...',
@@ -31,56 +31,56 @@
     $identifier
     $identifier / $collection_module_path
 
-]{
+){
 
  Imports into the enclosing module.
 
- The @rhombus[import_clause] variant @rhombus[module_path] or
- @rhombus[module_path: modifier; ...] are the canonical forms. The other
- @rhombus[import_clause] forms are converted into a canonical form:
+ The @rhombus(import_clause) variant @rhombus(module_path) or
+ @rhombus(module_path: modifier; ...) are the canonical forms. The other
+ @rhombus(import_clause) forms are converted into a canonical form:
 
-@itemlist[
+@itemlist(
 
- @item{@rhombus[module_path modifier] is the same as
-   @rhombus[module_path: modifier], where @rhombus[modifier] might include
+ @item{@rhombus(module_path modifier) is the same as
+   @rhombus(module_path: modifier), where @rhombus(modifier) might include
    a block argument. This form is handy when only one modifier is needed.},
 
- @item{@rhombus[module_path modifier: modifier; ...] is the same as
-   @rhombus[module_path: modifier; modifier; ...] where the initial
-   @rhombus[modifier] does not accept a block argument. This form is
-   especially handy when the initial @rhombus[modifier] is @rhombus[open]
-   or @rhombus[as $$(@rhombus[identifier,~var])] and additional modifiers
+ @item{@rhombus(module_path modifier: modifier; ...) is the same as
+   @rhombus(module_path: modifier; modifier; ...) where the initial
+   @rhombus(modifier) does not accept a block argument. This form is
+   especially handy when the initial @rhombus(modifier) is @rhombus(open)
+   or @rhombus(as $$(@rhombus(identifier,~var))) and additional modifiers
    are needed.},
 
- @item{@rhombus[modifier: import_clause; ....] is the same as the
-   sequence of @rhombus[import_clause]s with @rhombus[modifier] add to the
-   @emph{end} of each @rhombus[import_clause]. This form is especialy handy
-   when @rhombus[modifier] is @rhombus[for_meta].}
+ @item{@rhombus(modifier: import_clause; ....) is the same as the
+   sequence of @rhombus(import_clause)s with @rhombus(modifier) add to the
+   @emph{end} of each @rhombus(import_clause). This form is especialy handy
+   when @rhombus(modifier) is @rhombus(for_meta).}
 
-]
+)
 
- By default, each clause with a @rhombus[module_path] binds a prefix
- name that is derived from the @rhombus[module_path]'s last element.
+ By default, each clause with a @rhombus(module_path) binds a prefix
+ name that is derived from the @rhombus(module_path)'s last element.
  Imports from the module are then accessed using the prefix, @litchar{.},
  and the provided-provided name.
 
- A @rhombus[module_path] clause can be be adjusted through one or more
- @rhombus[import_modifier]s. The set of modifiers is extensible, but
- includes @rhombus[as, ~impmod], @rhombus[rename, ~impmod], and
- @rhombus[expose, ~impmod].
+ A @rhombus(module_path) clause can be be adjusted through one or more
+ @rhombus(import_modifier)s. The set of modifiers is extensible, but
+ includes @rhombus(as, ~impmod), @rhombus(rename, ~impmod), and
+ @rhombus(expose, ~impmod).
 
- A @rhombus[module_path] references a module in one of several possible
+ A @rhombus(module_path) references a module in one of several possible
  forms:
 
- @itemlist[
+ @itemlist(
 
- @item{@rhombus[collection_module_path]: refers to an installed
-   collection library, where the @rhombus[/] operator acts as a path
-   separator. Each @rhombus[identifier] in the path is constrained to
-   contain only characters allowed in a @rhombus[string] module path, with
+ @item{@rhombus(collection_module_path): refers to an installed
+   collection library, where the @rhombus(/) operator acts as a path
+   separator. Each @rhombus(identifier) in the path is constrained to
+   contain only characters allowed in a @rhombus(string) module path, with
    the additional constraint that @litchar{.} is disallowed.},
 
- @item{@rhombus[string]: refers to a module using @rhombus[string] as a
+ @item{@rhombus(string): refers to a module using @rhombus(string) as a
    relative path. The string can contain only the characters
    @litchar{a}-@litchar{z}, @litchar{A}-@litchar{Z},
    @litchar{0}-@litchar{9}, @litchar{-}, @litchar{+}, @litchar{_}, and
@@ -89,101 +89,101 @@
    digits must form a number that is not the ASCII value of a letter,
    digit, @litchar{-}, @litchar{+}, or @litchar{_}.},
 
- @item{@rhombus[lib(string)]: refers to an installed collection library,
-   where @rhombus[string] is the library name. The same constraints apply
-   to @rhombus[string] as when @rhombus[string] is used as a relative path
+ @item{@rhombus(lib(string)): refers to an installed collection library,
+   where @rhombus(string) is the library name. The same constraints apply
+   to @rhombus(string) as when @rhombus(string) is used as a relative path
    by itself, with the additional constraint that @litchar{.} and
    @litchar{..} directory indicators are disallowed.},
 
- @item{@rhombus[file(string)]: refers to a file through a
-   platform-specific path with no constraints on @rhombus[string].}
+ @item{@rhombus(file(string)): refers to a file through a
+   platform-specific path with no constraints on @rhombus(string).}
  
-]
+)
 
 }
 
-@doc[
+@doc(
   imp.modifier 'as $identifier'
-]{
+){
 
- Modifies an @rhombus[import] clause to bind the prefix
- @rhombus[identifier], used to access non-exposed imports, instead of
+ Modifies an @rhombus(import) clause to bind the prefix
+ @rhombus(identifier), used to access non-exposed imports, instead of
  inferring a prefix identifier from the module name.
 
 }
 
-@doc[
+@doc(
   imp.modifier 'open'
-]{
+){
 
- Modifies an @rhombus[import] clause so that no prefix (normally based on the
+ Modifies an @rhombus(import) clause so that no prefix (normally based on the
  module name) is bound, so all imports are exposed.
 
 }
 
-@doc[
+@doc(
   imp.modifier 'expose:
                   $identifier ...
                   ...'
-]{
+){
 
- Modifies an @rhombus[import] clause so that the listed
- @rhombus[identifier]s are imported without a prefix. The exose
+ Modifies an @rhombus(import) clause so that the listed
+ @rhombus(identifier)s are imported without a prefix. The exose
  identifiers remain accessible though the import's prefix, too.
 
 }
 
-@doc[
+@doc(
   imp.modifier 'rename:
                   $identifier as $local_identifier
                   ...'
-]{
+){
 
- Modifies an @rhombus[import] clause so that @rhombus[local_identifier]
- is used in place of the imported identifier name @rhombus[identifier].
- The new name @rhombus[local_identifier] applies to modifiers after the
- @rhombus[rename] modifier.
+ Modifies an @rhombus(import) clause so that @rhombus(local_identifier)
+ is used in place of the imported identifier name @rhombus(identifier).
+ The new name @rhombus(local_identifier) applies to modifiers after the
+ @rhombus(rename) modifier.
   
 }
 
-@doc[
+@doc(
   imp.modifier 'only:
                   $identifier ...
                   ...'
-]{
+){
 
- Modifies an @rhombus[import] clause so that only the listed
- @rhombus[identifier]s are imported.
+ Modifies an @rhombus(import) clause so that only the listed
+ @rhombus(identifier)s are imported.
 
 }
 
-@doc[
+@doc(
   imp.modifier 'except:
                   $identifier ...
                   ...'
-]{
+){
 
- Modifies an @rhombus[import] clause so that the listed
- @rhombus[identifier]s are @emph{not} imported.
+ Modifies an @rhombus(import) clause so that the listed
+ @rhombus(identifier)s are @emph{not} imported.
 
 }
 
-@doc[
+@doc(
   imp.modifier 'for_meta',
   imp.modifier 'for_meta phase'
-]{
+){
 
- Modifies an @rhombus[import] clause so that the imports are shifted by
- @rhombus[phase] levels, where @rhombus[phase] defaults to @rhombus[1].
+ Modifies an @rhombus(import) clause so that the imports are shifted by
+ @rhombus(phase) levels, where @rhombus(phase) defaults to @rhombus(1).
 
 }
 
-@doc[
+@doc(
   imp.modifier 'for_label'
-]{
+){
 
- Modifies an @rhombus[import] clause so that only the imports that would
- be at phase @rhombus[0] are imported, and they are imported instead to
+ Modifies an @rhombus(import) clause so that only the imports that would
+ be at phase @rhombus(0) are imported, and they are imported instead to
  the label phase.
 
 }

--- a/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/scribblings/ref-io.scrbl
@@ -3,27 +3,27 @@
 
 @title{Input and Output}
 
-@doc[
+@doc(
   fun print(v, out = current_output_port()) :: Void
-]{
+){
 
- Prints @rhombus[v] to @rhombus[out].
+ Prints @rhombus(v) to @rhombus(out).
 
 }
 
-@doc[
+@doc(
   fun println(v, out = current_output_port()) :: Void
-]{
+){
 
- Prints @rhombus[v] to @rhombus[out], then prints a newline.
+ Prints @rhombus(v) to @rhombus(out), then prints a newline.
 
 }
 
-@doc[
+@doc(
   fun display(v, out = current_output_port()) :: Void
-]{
+){
 
- Displays @rhombus[v] to @rhombus[out].
+ Displays @rhombus(v) to @rhombus(out).
 
  Strings, symbols, and keywords display as their character content. A
  byte string displays as its raw byte content. Any other kind of value
@@ -31,19 +31,19 @@
 
 }
 
-@doc[
+@doc(
   fun displayln(v, out = current_output_port()) :: Void
-]{
+){
 
- Displays @rhombus[v] to @rhombus[out] like @rhombus[display], then
+ Displays @rhombus(v) to @rhombus(out) like @rhombus(display), then
  prints a newline.
 
 }
 
-@doc[
+@doc(
   fun current_output_port(),
   fun current_output_port(out),
-]{
+){
 
  A parameter for the current output port.
 

--- a/rhombus/scribblings/ref-list.scrbl
+++ b/rhombus/scribblings/ref-list.scrbl
@@ -1,24 +1,24 @@
 #lang scribble/rhombus/manual
 @(import: "common.rhm" open)
 
-@(val dots: @rhombus[..., ~bind])
-@(val dots_expr: @rhombus[...])
+@(val dots: @rhombus(..., ~bind))
+@(val dots_expr: @rhombus(...))
 
 @title{Lists}
 
 Lists can be constructed using the syntax
-@rhombus[[$$(@rhombus[expr, ~var]), ...]], which creates list containing the values of the
-@rhombus[expr, ~var]s as elements. More precisely, a use of square
+@rhombus([$$(@rhombus(expr, ~var)), ...]), which creates list containing the values of the
+@rhombus(expr, ~var)s as elements. More precisely, a use of square
 brackets without a preceding expression implicitly uses the
-@rhombus[#{#%array}] form, which (despite its name) is normally bound to
+@rhombus(#{#%array}) form, which (despite its name) is normally bound to
 construct a list.
 
 A list works with map-referencing square brackets to access a list
 element by position (in time proportional to the position) via
-@rhombus[#{#%ref}]. A list also works with the @rhombus[++] operator
+@rhombus(#{#%ref}). A list also works with the @rhombus(++) operator
 to append lists.
 
-@doc[
+@doc(
   fun List(v :: Any, ...) :: List,
   fun List(v :: Any, ..., repetition, dots) :: List,
   expr.macro '#{#%array} [$v_expr]',
@@ -26,60 +26,60 @@ to append lists.
 
   grammar dots:
     $$(dots_expr)
-]{
+){
 
- Constructs a list of the given @rhombus[v]s values or results of
- the @rhombus[v_expr]s expressions.
+ Constructs a list of the given @rhombus(v)s values or results of
+ the @rhombus(v_expr)s expressions.
  
  When @dots_expr appears at the end, the preceding position is a
  @tech{repetition} position, and all elements of the repetition are
  included in order at the end of the list.
 
-@examples[
+@examples(
   val lst: List(1, 2, 3),
   lst,
   lst[0],
   lst ++ [4, 5]
-]
+)
 
 }
 
-@doc[
+@doc(
   bind.macro 'List($binding, ...)',
   bind.macro 'List($binding, ..., $dots)',
   grammar dots:
     $$(dots)
-]{
+){
 
- Matches a list with as many elements as @rhombus[binding]s, or if
- @rhombus[dots] is included, at least as many elements as
- @rhombus[binding]s before the last one, and then them last one is
+ Matches a list with as many elements as @rhombus(binding)s, or if
+ @rhombus(dots) is included, at least as many elements as
+ @rhombus(binding)s before the last one, and then them last one is
  matched against the rest of the list.
 
-@examples[
+@examples(
   val List(1, x, y): [1, 2, 3],
   y,
   val List(1, x, ...): [1, 2, 3],
   [x, ...]
-]
+)
 
 }
 
-@doc[
+@doc(
   annotation.macro 'List',
   annotation.macro 'List.of($annotation)',
-]{
+){
 
- Matches any list in the form without @rhombus[of]. The @rhombus[of]
- variant matches a list whose elements satisfy @rhombus[annotation].
+ Matches any list in the form without @rhombus(of). The @rhombus(of)
+ variant matches a list whose elements satisfy @rhombus(annotation).
 
 }
 
-@doc[
+@doc(
   folder.macro 'List'
-]{
+){
 
- A @tech{folder} used with @rhombus[for], accumulates each result of a
- @rhombus[for] body into a result list.
+ A @tech{folder} used with @rhombus(for), accumulates each result of a
+ @rhombus(for) body into a result list.
 
 }

--- a/rhombus/scribblings/ref-macro.scrbl
+++ b/rhombus/scribblings/ref-macro.scrbl
@@ -1,21 +1,21 @@
 #lang scribble/rhombus/manual
 @(import: "common.rhm" open)
 
-@title[~style: symbol(toc)]{Macros}
+@title(~style: symbol(toc)){Macros}
 
-@docmodule[rhombus/macro]
+@docmodule(rhombus/macro)
 
 Simple pattern-based expression macros can be written using
-@rhombus[def] without imorting any additional libraries besides
-@rhombusmodname[rhombus], but implementing others forms of macros requires
-using the @rhombusmodname[rhombus/macro] module (usually with no prefix).
+@rhombus(def) without imorting any additional libraries besides
+@rhombusmodname(rhombus), but implementing others forms of macros requires
+using the @rhombusmodname(rhombus/macro) module (usually with no prefix).
 
-The @rhombusmodname[rhombus/macro] module provides bindings like
-@rhombus[expr.macro], and it also re-exports all of
-@rhombusmodname[rhombus] @rhombus[for_meta] for use in compile-time
+The @rhombusmodname(rhombus/macro) module provides bindings like
+@rhombus(expr.macro), and it also re-exports all of
+@rhombusmodname(rhombus) @rhombus(for_meta) for use in compile-time
 expressions.
 
-@local_table_of_contents[]
+@local_table_of_contents()
 
-@include_section["ref-expr-macro.scrbl"]
-@include_section["ref-defn-macro.scrbl"]
+@include_section("ref-expr-macro.scrbl")
+@include_section("ref-defn-macro.scrbl")

--- a/rhombus/scribblings/ref-map.scrbl
+++ b/rhombus/scribblings/ref-map.scrbl
@@ -4,128 +4,128 @@
 @title{Maps}
 
 Immutable maps can be constructed using the syntax
-@rhombus[{$$(@rhombus[key_expr, ~var]): $$(@rhombus[value_expr, ~var]), ...}],
-which creates a map from the values of the @rhombus[key_expr, ~var]s to
-the corresponding values of the @rhombus[value_expr, ~var]s. Note
+@rhombus({$$(@rhombus(key_expr, ~var)): $$(@rhombus(value_expr, ~var)), ...}),
+which creates a map from the values of the @rhombus(key_expr, ~var)s to
+the corresponding values of the @rhombus(value_expr, ~var)s. Note
 that using @litchar{,} in place of @litchar{:} creates a set with
 separate values, instead of a key--value mapping. More precisely, a
 use of curly braces with no preceding expression is parsed as an
-implicit use of the @rhombus[#{#%set}] form.
+implicit use of the @rhombus(#{#%set}) form.
 
 To access a mapping, use square brackets after a map expression with an
 expression for the key within square brackets. Mutable maps can be
-updated with a combination of square brackets and the @rhombus[:=]
+updated with a combination of square brackets and the @rhombus(:=)
 operator. These uses of square brackets are implemented by
-@rhombus[#{#%ref}].
+@rhombus(#{#%ref}).
 
-@doc[
+@doc(
   expr.macro '#{#%set} {$key_expr: $val_expr, ...}',
   expr.macro '#{#%set} {$elem_expr, ...}',
-]{
+){
 
  Constructs either a map or a set, depending on whether
- @rhombus[key_expr] and @rhombus[val_expr] are provided or
- @rhombus[elem_expr] is provided.
+ @rhombus(key_expr) and @rhombus(val_expr) are provided or
+ @rhombus(elem_expr) is provided.
 
 }
 
-@doc[
+@doc(
   fun Map(key :: Any, value:: Any, ...) :: Map
-]{
+){
 
  Constructs an immutable map containing given keys mapped to the given
- values, equivalent to using @rhombus[{key: value, ...}]. The number of
- arguments to @rhombus[Map] must be even with keys and values
+ values, equivalent to using @rhombus({key: value, ...}). The number of
+ arguments to @rhombus(Map) must be even with keys and values
  interleaved.
 
-@examples[
+@examples(
   val m: Map("x", 1, "y", 2),
   m,
   m["x"]
-]
+)
 
 }
 
-@doc[
+@doc(
   bind.macro 'Map($key_expr, $binding, ...)'
-]{
+){
 
- Matches a map the keys computed by @rhombus[key_expr] to values that
- match the corresponding @rhombus[binding]s.
+ Matches a map the keys computed by @rhombus(key_expr) to values that
+ match the corresponding @rhombus(binding)s.
 
-@examples[
+@examples(
   val Map("x", x, "y", y): {"x": 1, "y": 2},
   y
-]
+)
 
 }
 
-@doc[
+@doc(
   annotation.macro 'Map',
   annotation.macro 'Map.of($key_annotation, $value_annotation)',
-]{
+){
 
- Matches any map in the form without @rhombus[of]. The @rhombus[of]
- variant matches a map whose keys satisfy @rhombus[key_annotation]
- and whose values satisfy @rhombus[value_annotation].
+ Matches any map in the form without @rhombus(of). The @rhombus(of)
+ variant matches a map whose keys satisfy @rhombus(key_annotation)
+ and whose values satisfy @rhombus(value_annotation).
 
 }
 
-@doc[
+@doc(
   folder.macro 'Map'
-]{
+){
 
- A @tech{folder} used with @rhombus[for], expects two results from a
- @rhombus[for] body, and accumulates them into a map using the first
+ A @tech{folder} used with @rhombus(for), expects two results from a
+ @rhombus(for) body, and accumulates them into a map using the first
  result as a key and the second result as a value.
 
 }
 
-@doc[
+@doc(
   fun make_map(key :: Any, value:: Any, ...) :: Map
-]{
+){
 
- Similar to @rhombus[Map] as a constructor, but creates a mutable map
- that can be updated using @rhombus[=].
+ Similar to @rhombus(Map) as a constructor, but creates a mutable map
+ that can be updated using @rhombus(=).
 
-@examples[
+@examples(
   val m: make_map("x", 1, "y", 2),
   m,
   m["x"],
   m["x"] := 0,
   m
-]
+)
 
 }
 
 
-@doc[
+@doc(
   operator ((v1 :: Map) ++ (v2 :: Map)) :: Map,
   operator ((v1 :: Set) ++ (v2 :: Set)) :: Set,
   operator ((v1 :: List) ++ (v2 :: List)) :: List,
   operator ((v1 :: String) ++ (v2 :: String)) :: String,
-]{
+){
 
- Appends @rhombus[v1] and @rhombus[v2] to create a new map, set, list, or
- string. In the case of maps, mappings for keys in @rhombus[v2] replace
- ones that exist already in @rhombus[v1]. In the case of sets, the new
- set has all of the elements of @rhombus[v1] and @rhombus[v2].
- In the case of lists and strings, the elements of @rhombus[v1] appear
- first in the result followed by the elements of @rhombus[v2].
+ Appends @rhombus(v1) and @rhombus(v2) to create a new map, set, list, or
+ string. In the case of maps, mappings for keys in @rhombus(v2) replace
+ ones that exist already in @rhombus(v1). In the case of sets, the new
+ set has all of the elements of @rhombus(v1) and @rhombus(v2).
+ In the case of lists and strings, the elements of @rhombus(v1) appear
+ first in the result followed by the elements of @rhombus(v2).
 
  The combination
- @rhombus[$$(@rhombus(map_expr, ~var)) ++ {$$(@rhombus(key_expr, ~var)): $$(@rhombus(value_expr, ~var))}]
+ @rhombus($$(@rhombus(map_expr, ~var)) ++ {$$(@rhombus(key_expr, ~var)): $$(@rhombus(value_expr, ~var))})
  is recognized by the compiler and turned into an efficient functional update of the
- map produced by @rhombus[map_expr], as opposed to creating an intermediate map.
+ map produced by @rhombus(map_expr), as opposed to creating an intermediate map.
  Set update is handled similarly.
 
-@examples[
+@examples(
   val m: {"x": 1, "y": 2},
   m ++ {"x": 0},
   m,
   {1, 2, 3} ++ {"four", "five"},
   [1, 2, 3] ++ [4, 5],
   "hello" ++ " " ++ "world"
-]
+)
 
 }

--- a/rhombus/scribblings/ref-match.scrbl
+++ b/rhombus/scribblings/ref-match.scrbl
@@ -3,7 +3,7 @@
 
 @title{Matching}
 
-@doc[
+@doc(
   decl.macro 'match $target_expr
               | $binding:
                   $result_body
@@ -17,46 +17,46 @@
               | ~else:
                   $result_body
                   ...'
-]{
+){
 
- Tries matching the result of @rhombus[target_expr] against each
- @rhombus[binding] in sequence, and as soon as one matches, returns the
- result of the corresponding @rhombus[result_body] block. The keyword
- @rhombus[~else] can be used as a synonym for @rhombus[_, ~bind] (which matches
+ Tries matching the result of @rhombus(target_expr) against each
+ @rhombus(binding) in sequence, and as soon as one matches, returns the
+ result of the corresponding @rhombus(result_body) block. The keyword
+ @rhombus(~else) can be used as a synonym for @rhombus(_, ~bind) (which matches
  any value without binding any identifiers) in the last clause.
 
- Typically, a @rhombus[binding] imposes requires on a value and binds
+ Typically, a @rhombus(binding) imposes requires on a value and binds
  some number of identifiers as a result of a successful match. For
- example, a literal number works as a @rhombus[binding] pattern, but it
- binds zero identifiers. An identifier as a @rhombus[binding] pattern
+ example, a literal number works as a @rhombus(binding) pattern, but it
+ binds zero identifiers. An identifier as a @rhombus(binding) pattern
  matches any value and binds the identifier the the matching value. A
- list form is a @rhombus[binding] pattern with subpatterns as its
+ list form is a @rhombus(binding) pattern with subpatterns as its
  elements, and it matches a list with the right number of elements that
- match match the corresponding pattern. The set of @rhombus[binding]
+ match match the corresponding pattern. The set of @rhombus(binding)
  forms is extensible, so it cannot be completely enumerated here.
 
- If no @rhombus[target_expr] produces a true value and there is no
- @rhombus[~else] clause, a run-time exception is raised.
+ If no @rhombus(target_expr) produces a true value and there is no
+ @rhombus(~else) clause, a run-time exception is raised.
 
-@examples[
+@examples(
   match 1+2
   | 3: "three"
   | ~else: "not three",
   match [1+2, 3+4]
   | [x, y]: x+y
-]
+)
 
 }
 
-@doc[
+@doc(
   bind.macro '_'
-]{
+){
 
  Matches any value without binding any identifiers.
 
-@examples[
+@examples(
   match 1+2
   | 0: "zero"
   | _: "nonzero"
-]
+)
 }

--- a/rhombus/scribblings/ref-mutable.scrbl
+++ b/rhombus/scribblings/ref-mutable.scrbl
@@ -3,31 +3,31 @@
 
 @title{Mutable Variables and Assignment}
 
-@doc[
+@doc(
   bind.macro 'mutable $identifier'
-]{
+){
 
- Binds @rhombus[identifier] so that its vaue can be changed using
- @rhombus[:=].
+ Binds @rhombus(identifier) so that its vaue can be changed using
+ @rhombus(:=).
 
- No static information is associated with @rhombus[identifier], even if
+ No static information is associated with @rhombus(identifier), even if
  a surrounding binding pattern would otherwise associate static
  information with it.
 
 }
 
-@doc[
+@doc(
   expr.macro '$identifier := $expr'
-]{
+){
 
- Changes the value of @rhombus[identifier] to the result of
- @rhombus[expr]. The @rhombus[identifier] must be bound with
- @rhombus[mutable, ~bind].
+ Changes the value of @rhombus(identifier) to the result of
+ @rhombus(expr). The @rhombus(identifier) must be bound with
+ @rhombus(mutable, ~bind).
 
-@examples[
+@examples(
   val mutable count: 0,
   count := count + 1,
   count
-]
+)
 
 }

--- a/rhombus/scribblings/ref-number.scrbl
+++ b/rhombus/scribblings/ref-number.scrbl
@@ -3,55 +3,55 @@
 
 @title{Numbers}
 
-@doc[
+@doc(
   annotation.macro 'Number'
-]{
+){
 
   Matches any number.
 
 }
 
-@doc[
+@doc(
   annotation.macro 'Integer'
-]{
+){
 
   Matches exact integers.
 
 }
 
-@doc[
+@doc(
   operator ((x :: Number) + (y :: Number)) :: Number,
   operator ((x :: Number) - (y :: Number)) :: Number,
   operator ((x :: Number) * (y :: Number)) :: Number,
   operator ((x :: Number) / (y :: Number)) :: Number
-]{
+){
 
  The usual arithmetic operators with the usual precedence, except that
- @rhombus[/] does not have the same precedence as @rhombus[*] when it
- appears to the right of @rhombus[*].
+ @rhombus(/) does not have the same precedence as @rhombus(*) when it
+ appears to the right of @rhombus(*).
 
-@examples[
+@examples(
   1+2,
   3-4,
   5*6,
   8/2,
   1+2*3
-]
+)
 
 }
 
-@doc[
+@doc(
   operator ((x :: Number) > (y :: Number)) :: Boolean,
   operator ((x :: Number) >= (y :: Number)) :: Boolean,
   operator ((x :: Number) < (y :: Number)) :: Boolean,
   operator ((x :: Number) <= (y :: Number)) :: Boolean
-]{
+){
 
  The usual comparsion operators.
 
-@examples[
+@examples(
   1 < 2,
   3 >= 3.0
-]
+)
 
 }

--- a/rhombus/scribblings/ref-parameter.scrbl
+++ b/rhombus/scribblings/ref-parameter.scrbl
@@ -6,15 +6,15 @@
 For now, let's just say that a Rhombus @deftech{parameter} is a Racket
 parameter.
 
-@doc[
+@doc(
   decl.macro 'parameterize {$parameter_expr: $val_body, ...}:
                 $body
                 ...'
-]{
+){
 
- Returns the result of the @rhombus[body] block as evaluated in a
+ Returns the result of the @rhombus(body) block as evaluated in a
  fresh parameterization that binds the @tech{parameter} produced by
- each @rhombus[parameter_expr] to the value produced by the
- corresponding @rhombus[val_body] block.
+ each @rhombus(parameter_expr) to the value produced by the
+ corresponding @rhombus(val_body) block.
 
 }

--- a/rhombus/scribblings/ref-repetition.scrbl
+++ b/rhombus/scribblings/ref-repetition.scrbl
@@ -1,8 +1,8 @@
 #lang scribble/rhombus/manual
 @(import: "common.rhm" open)
 
-@(val dots: @rhombus[..., ~bind])
-@(val dots_expr: @rhombus[...])
+@(val dots: @rhombus(..., ~bind))
+@(val dots_expr: @rhombus(...))
 
 @title{Repetitions}
 
@@ -10,12 +10,12 @@ A @deftech{repetition} represents a sequence of values and can be used
 in designated repetition positions (in much the same way that
 expressions appear in expression positions and bindings in binding
 positions). For example, a repetition can be used at the end of a list
-with @rhombus[...] after it.
+with @rhombus(...) after it.
 
-@doc[
+@doc(
   bind.macro '...',
   expr.macro '...'
-]{
+){
 
 The @dots ``binding'' form or @dots_expr
 ``expression'' form is not really allowed as an binding or expression,
@@ -24,18 +24,18 @@ otherwise be allowed.
 
 In a binding-like position, @dots tends to change a
 nearby binding into a @tech{repetition} binding. For example, in
-@rhombus[fun($$(@rhombus[x, ~var]), $$(dots)): $$(@rhombus[body, ~var])],
-the @dots causes @rhombus[x, ~var] to be bound to a
+@rhombus(fun($$(@rhombus(x, ~var)), $$(dots)): $$(@rhombus(body, ~var))),
+the @dots causes @rhombus(x, ~var) to be bound to a
 repetition.
 
 In an expression-like position, @dots tends to change a
 nearby expression position into a @tech{repetition} position, which is
 a place where a repetition binding or operator can be used. For
-example, the list expression @rhombus[[$$(@rhombus[x, ~var]), $$(dots_expr)]]
-has @rhombus[x, ~var] in a repetition position, which would make sense
-as part of the @rhombus[body, ~var] of
-@rhombus[fun($$(@rhombus[x, ~var]), $$(dots)): $$(@rhombus[body, ~var])],
-since @rhombus[x, ~var] is bound there as a repetition.
+example, the list expression @rhombus([$$(@rhombus(x, ~var)), $$(dots_expr)])
+has @rhombus(x, ~var) in a repetition position, which would make sense
+as part of the @rhombus(body, ~var) of
+@rhombus(fun($$(@rhombus(x, ~var)), $$(dots)): $$(@rhombus(body, ~var))),
+since @rhombus(x, ~var) is bound there as a repetition.
 
 Function arguments, list patterns, and syntax patterns are among the
 places that recognize @dots to create repetition

--- a/rhombus/scribblings/ref-set.scrbl
+++ b/rhombus/scribblings/ref-set.scrbl
@@ -4,56 +4,56 @@
 @title{Sets}
 
 Immutable sets can be constructed using the syntax
-@rhombus[{$$(@rhombus[val_expr, ~var]), ...}],
-which creates a set containing the values of the @rhombus[value_expr, ~var]s.
+@rhombus({$$(@rhombus(val_expr, ~var)), ...}),
+which creates a set containing the values of the @rhombus(value_expr, ~var)s.
 More precisely, a use of curly braces with no preceding expression is
-parsed as an implicit use of the @rhombus[#{#%set}] form.
+parsed as an implicit use of the @rhombus(#{#%set}) form.
 
 To check for membership in a set, use square brackets after a map
 expression with an expression for a value, and the result is a boolean
 indicating whether the value is in the set. Mutable sets can be updated
-with a combination of square brackets and the @rhombus[:=] operator, where
-a @rhombus[#false] result on the right-hand side of @rhombus[:=] removes an
+with a combination of square brackets and the @rhombus(:=) operator, where
+a @rhombus(#false) result on the right-hand side of @rhombus(:=) removes an
 element from a set, and any other right-hand side result causes the value
 to be included in the set. These uses of square brackets are implemented by
-@rhombus[#{#%ref}].
+@rhombus(#{#%ref}).
 
-@doc[
+@doc(
   fun Set(value:: Any, ...) :: Map
-]{
+){
 
  Constructs an immutable set containing given values, equivalent to
- using @rhombus[{value, ...}].
+ using @rhombus({value, ...}).
 
-@examples[
+@examples(
   val s: Set("x", 1, "y", 2),
   s,
   s["x"],
   s[1],
   s[42]
-]
+)
 
 }
 
-@doc[
+@doc(
   annotation.macro 'Set',
   annotation.macro 'Set.of($annotation)',
-]{
+){
 
- Matches any set in the form without @rhombus[of]. The @rhombus[of]
- variant matches a set whose values satisfy @rhombus[annotation].
+ Matches any set in the form without @rhombus(of). The @rhombus(of)
+ variant matches a set whose values satisfy @rhombus(annotation).
 
 }
 
 
-@doc[
+@doc(
   fun make_set(value:: Any, ...) :: Map
-]{
+){
 
- Similar to @rhombus[Set] as a constructor, but creates a mutable set
- that can be updated using @rhombus[:=].
+ Similar to @rhombus(Set) as a constructor, but creates a mutable set
+ that can be updated using @rhombus(:=).
 
-@examples[
+@examples(
   val m: make_set("x", 1, "y", 2),
   m,
   m["x"],
@@ -61,6 +61,6 @@ to be included in the set. These uses of square brackets are implemented by
   m,
   m["x"] := #true,
   m
-]
+)
 
 }

--- a/rhombus/scribblings/ref-string.scrbl
+++ b/rhombus/scribblings/ref-string.scrbl
@@ -4,28 +4,28 @@
 @title{Strings}
 
 
-@doc[
+@doc(
   annotation.macro 'String'
-]{
+){
 
   Matches strings.
 
 }
 
-@doc[
+@doc(
   operator (v1 +& v2) :: String
-]{
+){
 
- Coerces @rhombus[v1] and @rhombus[v2] to a string, then appends the strings.
+ Coerces @rhombus(v1) and @rhombus(v2) to a string, then appends the strings.
 
- The string for of a value is the same way that @rhombus[display] would
+ The string for of a value is the same way that @rhombus(display) would
  print it, which means that strings, symbols, and keywords print as their
  character content.
 
-@examples[
+@examples(
   "hello" +& "world",
   "it goes to " +& 11,
   "the list " +& [1, 2, 3] +& " has " +& 3 +& " elements"
-]
+)
 
 }

--- a/rhombus/scribblings/ref-stxobj.scrbl
+++ b/rhombus/scribblings/ref-stxobj.scrbl
@@ -3,83 +3,83 @@
     "common.rhm" open 
     "macro.rhm")
 
-@title[~tag: "stxobj"]{Syntax Objects}
+@title(~tag: "stxobj"){Syntax Objects}
 
 Syntax objects can be constructed using the expression syntax
-@rhombus['$$(@rhombus[term, ~var]) ...; ...'], which creates
-a syntax object quoting the @rhombus[term, ~var]s. When a single
-@rhombus[term, ~var] is present, the result is a single-term syntax
-object. When a single @rhombus[$$(@rhombus[term, ~var]) ...]
-group is present with multiple @rhombus[term,~var]s, the result is
+@rhombus('$$(@rhombus(term, ~var)) ...; ...'), which creates
+a syntax object quoting the @rhombus(term, ~var)s. When a single
+@rhombus(term, ~var) is present, the result is a single-term syntax
+object. When a single @rhombus($$(@rhombus(term, ~var)) ...)
+group is present with multiple @rhombus(term,~var)s, the result is
 a group syntax object. The general case is a multi-group syntax
 object.
 
-@examples[
+@examples(
   '1',
   'pi',
   '1 + 2',
   '1 + 2
    3 + 4',
-]
+)
 
-A @rhombus[$] as a @rhombus[term,~var] escapes a following expression
-whose value replaces the @rhombus[$] term and expression. The value is
+A @rhombus($) as a @rhombus(term,~var) escapes a following expression
+whose value replaces the @rhombus($) term and expression. The value is
 normally a syntax objects, but other kinds of values are coerced to a
-syntax object. Nested @rhombus[''] forms are allowed around @rhombus[$]
-and do @emph{not} change whether the @rhombus[$] escapes.
+syntax object. Nested @rhombus('') forms are allowed around @rhombus($)
+and do @emph{not} change whether the @rhombus($) escapes.
 
-@examples[
+@examples(
   'x $(if #true | 'y' | 'why') z',
   'x $(1 + 2) z',
   '« x '$(1 + 2)' z »'
-]
+)
 
 As a binding form,
-@rhombus['$$(@rhombus[term, ~var]) ...; ...'] matches a syntax
-object consistent with @rhombus[term,~var]s. A @rhombus[$, ~bind] within
-@rhombus[form] escapes to an binding that is matched against the
+@rhombus('$$(@rhombus(term, ~var)) ...; ...') matches a syntax
+object consistent with @rhombus(term,~var)s. A @rhombus($, ~bind) within
+@rhombus(form) escapes to an binding that is matched against the
 corresponding portion of a candidate syntax object. Ellipses, etc.
 
-@examples[
+@examples(
   match '1 + 2'
   | '$n + $m': [n, m]
-]
+)
 
 
-@doc[
+@doc(
   annotation.macro 'Syntax'
-]{
+){
 
   Matches syntax objects.
 
 }
 
-@doc[
+@doc(
   expr.macro '$ $expr'
-]{
+){
 
- Only allowed within a @rhombus[''] form, escapes so that the value of
- @rhombus[expr] is used in place of the @rhombus[$] form.
+ Only allowed within a @rhombus('') form, escapes so that the value of
+ @rhombus(expr) is used in place of the @rhombus($) form.
 
 }
 
 
-@doc[
+@doc(
   bind.macro '$ $identifier',
   bind.macro '$ ($identifier :: $syntax_class)',
-]{
+){
 
- Only allowed within a @rhombus['', ~bind] binding pattern, escapes so that
- @rhombus[identifier] is bound to the corresponding portion of the syntax
- object that matches the @rhombus['', ~bind] form.
+ Only allowed within a @rhombus('', ~bind) binding pattern, escapes so that
+ @rhombus(identifier) is bound to the corresponding portion of the syntax
+ object that matches the @rhombus('', ~bind) form.
 
- The @rhombus[syntax_class] can be @rhombus[Term, ~stxclass], @rhombus[Id, ~stxclass],
- or @rhombus[Group, ~stxclass], among other built-in classes, or it can be a class defined
- with @rhombus[syntax.class].
+ The @rhombus(syntax_class) can be @rhombus(Term, ~stxclass), @rhombus(Id, ~stxclass),
+ or @rhombus(Group, ~stxclass), among other built-in classes, or it can be a class defined
+ with @rhombus(syntax.class).
 
 }
 
-@doc[
+@doc(
   syntax.class Term,
   syntax.class Id,
   syntax.class Op,
@@ -88,23 +88,23 @@ corresponding portion of a candidate syntax object. Ellipses, etc.
   syntax.class Group,
   syntax.class Multi,
   syntax.class Block,
-]{
+){
 
  Syntax classes, all of which imply a single-term match except for
- @rhombus[Group, ~stxclass], @rhombus[Multi, ~stxclass], and
- @rhombus[Block, ~stxclass].
+ @rhombus(Group, ~stxclass), @rhombus(Multi, ~stxclass), and
+ @rhombus(Block, ~stxclass).
 
- The @rhombus[Group, ~stxclass] syntax class can be used only for a
+ The @rhombus(Group, ~stxclass) syntax class can be used only for a
  pattern identifier that is the sole term of its group in a pattern. The
  identifier is bound to a match for the entire group as a group syntax
  object.
 
- The @rhombus[Multi, ~stxclass] syntax class can be used only for a
+ The @rhombus(Multi, ~stxclass) syntax class can be used only for a
  pattern identifier that is the sole term where a sequence of groups is
  allowed, such as in the body of a block. The identifier is bound to a
  match for the entire sequence of groups.
 
- The @rhombus[Block, ~stxclass] syntax class can be used only for a
+ The @rhombus(Block, ~stxclass) syntax class can be used only for a
  pattern identifier that is the sole term of a block. The identifier is
  bound to a match for the entire block as a single term (i.e., as a
  single-term syntax object that has a block term, and not as a
@@ -113,24 +113,24 @@ corresponding portion of a candidate syntax object. Ellipses, etc.
 }
 
 
-@doc[
+@doc(
   expr.macro '«literal_syntax '$term ...; ...'»',
   expr.macro 'literal_syntax ($term ..., ...)'
-]{
+){
 
- Similar to a plain @rhombus[''] form, but @rhombus[$] escapes or
- @rhombus[...] and @rhombus[......] repetition forms are not recognizes
- in the @rhombus[term]s, so that the @rhombus[term]s are all treated as
+ Similar to a plain @rhombus('') form, but @rhombus($) escapes or
+ @rhombus(...) and @rhombus(......) repetition forms are not recognizes
+ in the @rhombus(term)s, so that the @rhombus(term)s are all treated as
  literal terms to be quoted.
 
- There's no difference in result between using @rhombus[''] or
- @rhombus[()] after @rhombus[literal_syntax]---only a difference in
+ There's no difference in result between using @rhombus('') or
+ @rhombus(()) after @rhombus(literal_syntax)---only a difference in
  notation used to describe the syntax object, such as using @litchar{;}
  versus @litchar{,} to separate groups.
 
-@examples[
+@examples(
   literal_syntax 'x',
   literal_syntax (x),
   literal_syntax '1 ... 2',
   literal_syntax '$ $ $'
-]}
+)}

--- a/rhombus/scribblings/ref-syntax-class.scrbl
+++ b/rhombus/scribblings/ref-syntax-class.scrbl
@@ -3,12 +3,12 @@
     "common.rhm" open 
     "macro.rhm")
 
-@(val dots: @rhombus[..., ~bind])
+@(val dots: @rhombus(..., ~bind))
 @(def list(x, ...): [x, ...])
 
 @title{Syntax Classes}
 
-@doc[
+@doc(
   defn.macro '«syntax.class $name:
                 $maybe_description
                 pattern
@@ -31,59 +31,59 @@
     [$identifier_maybe_rep, $ellipsis],
   grammar ellipsis:
     $$(dots)
-]{
+){
 
  Defines a syntax class that can be used in syntax patterns with
- @rhombus[::]. The @rhombus[pattern] subform is optional in the sense
+ @rhombus(::). The @rhombus(pattern) subform is optional in the sense
  that pattern alternatives can be inlined directly in the
- @rhombus[syntax.class] form (but the @rhombus[pattern] subform makes
+ @rhombus(syntax.class) form (but the @rhombus(pattern) subform makes
  room for additional subforms in the future). 
 
- The optional @rhombus[description] subform can be used before @rhombus[pattern] 
+ The optional @rhombus(description) subform can be used before @rhombus(pattern) 
  to define the description of the syntax class. This description is used to 
  produce clearer error messages when a term is rejected by the syntax class. 
  It takes a block whose result must evaluate to a string or 
- @rhombus[#false]. (Setting a description to @rhombus[#false] is equivalent
+ @rhombus(#false). (Setting a description to @rhombus(#false) is equivalent
  to not specifying a description at all and will mean the error message is not
  customized.)
 
- When a variable @rhombus[id, ~var] is bound through a
- @seclink["stxobj"]{syntax pattern} with
- @rhombus[$($$(@rhombus[id, ~var]) :: $$(@rhombus[stx_class_id, ~var]))],
+ When a variable @rhombus(id, ~var) is bound through a
+ @seclink("stxobj"){syntax pattern} with
+ @rhombus($($$(@rhombus(id, ~var)) :: $$(@rhombus(stx_class_id, ~var)))),
  it matches a syntax object that matches any of the
- @rhombus[syntax_pattern]s in the definition of
- @rhombus[stx_class_id ,~var], where the @rhombus[syntax_pattern]s are tried
+ @rhombus(syntax_pattern)s in the definition of
+ @rhombus(stx_class_id ,~var), where the @rhombus(syntax_pattern)s are tried
  first to last. A pattern variable that is included in all of the
- @rhombus[syntax_pattern]s is an attribute of the syntax class, which is
- accessed from a binding @rhombus[id, ~var] using dot notation. For
- example, if the pattern variable is @rhombus[attr_id, ~var], its value is
- accessed from @rhombus[id, ~var] using
- @list[@rhombus[id, ~var], @rhombus[.], @rhombus[attr_id, ~var]]. To use an attribute
+ @rhombus(syntax_pattern)s is an attribute of the syntax class, which is
+ accessed from a binding @rhombus(id, ~var) using dot notation. For
+ example, if the pattern variable is @rhombus(attr_id, ~var), its value is
+ accessed from @rhombus(id, ~var) using
+ @list(@rhombus(id, ~var), @rhombus(.), @rhombus(attr_id, ~var)). To use an attribute
  within a template, parentheses are needed around the variable name,
- @rhombus[.], and attribute name to group them together if the variable
- name is preceded by a @rhombus[$] escape:
- @rhombus[$($$(@list[@rhombus[id, ~var], @rhombus[.], @rhombus[attr_id, ~var]]))].
+ @rhombus(.), and attribute name to group them together if the variable
+ name is preceded by a @rhombus($) escape:
+ @rhombus($($$(@list(@rhombus(id, ~var), @rhombus(.), @rhombus(attr_id, ~var))))).
 
  A variable bound with a syntax class (within a syntax pattern) can be
  used without dot notation. In that case, the result is a sequence of
  syntax objects corresponding to the entire match of a
- @rhombus[syntax_pattern], as opposed to an individual attributes within
- the match. Use @rhombus[...] after a @rhombus[$]-escaped reference to
+ @rhombus(syntax_pattern), as opposed to an individual attributes within
+ the match. Use @rhombus(...) after a @rhombus($)-escaped reference to
  the variable in a syntax template.
 
-Within a @rhombus[clause], custom attributes of a syntax class can be
-defined within a @rhombus[pattern_body], which is a mixture of
-expressions, definitions, and @rhombus[~attr] forms. An
-@rhombus[~attr] form is a definition, but it also creates a custom
-attribute named by an @rhombus[identifier] and at a repetition depth
+Within a @rhombus(clause), custom attributes of a syntax class can be
+defined within a @rhombus(pattern_body), which is a mixture of
+expressions, definitions, and @rhombus(~attr) forms. An
+@rhombus(~attr) form is a definition, but it also creates a custom
+attribute named by an @rhombus(identifier) and at a repetition depth
 determined by surrounding @(dots). The value of the right-hand side
-@rhombus[body] sequence must be nested lists corresponding to the
+@rhombus(body) sequence must be nested lists corresponding to the
 repetition depth, with syntax objects as the most nested value (so,
 just a syntax object for repetition depth 0 when not @(dots) are used
 on the left-hand side). Variables bound by the pattern are available
-for use in @rhombus[pattern_body].
+for use in @rhombus(pattern_body).
 
-@examples[
+@examples(
   ~eval: macro.make_for_meta_eval(),
   begin_for_meta:
     syntax.class Arithmetic
@@ -114,4 +114,6 @@ for use in @rhombus[pattern_body].
   expr.macro 'average $(e :: NTerms)':
     values(e.average, ''),
   average ~two 24 42
-]}
+)
+
+}

--- a/rhombus/scribblings/ref-values.scrbl
+++ b/rhombus/scribblings/ref-values.scrbl
@@ -3,39 +3,39 @@
 
 @title{Multiple Values}
 
-@doc[
+@doc(
   fun values(v, ...)
-]{
+){
 
- Returns the @rhombus[v]s as multiple result values.
+ Returns the @rhombus(v)s as multiple result values.
 
- If only one @rhombus[v] is provided, the result is the same as just
- @rhombus[v]. Any other number of values must be received by a context
+ If only one @rhombus(v) is provided, the result is the same as just
+ @rhombus(v). Any other number of values must be received by a context
  that is expecting multiple values, such as with a
- @rhombus[values, ~bind] binding pattern.
+ @rhombus(values, ~bind) binding pattern.
 
 }
 
-@doc[
+@doc(
   bind.macro 'values($binding, ...)'
-]{
+){
 
  Matches multiple result values corresponding to the number of
- @rhombus[binding]s, where each result matches the corresponing
- @rhombus[binding].
+ @rhombus(binding)s, where each result matches the corresponing
+ @rhombus(binding).
 
 }
 
-@doc[
+@doc(
   folder.macro 'values($identifier = $expr, ...)'
-]{
+){
 
- A @tech{folder} used with @rhombus[for], expects as many results from a
- @rhombus[for] body as @rhombus[identifier]s. For the first iteration of
- the @rhombus[for] body, each @rhombus[identifier]'s value is the result
- of the corresponding @rhombus[expr]. The results of a @rhombus[for] body
- for one iteration then serve as the values of the @rhombus[identifier]s
- for the next iteration. The values of the whole @rhombus[for] expression
- are the final values of the @rhombus[identifier]s.
+ A @tech{folder} used with @rhombus(for), expects as many results from a
+ @rhombus(for) body as @rhombus(identifier)s. For the first iteration of
+ the @rhombus(for) body, each @rhombus(identifier)'s value is the result
+ of the corresponding @rhombus(expr). The results of a @rhombus(for) body
+ for one iteration then serve as the values of the @rhombus(identifier)s
+ for the next iteration. The values of the whole @rhombus(for) expression
+ are the final values of the @rhombus(identifier)s.
 
 }

--- a/rhombus/scribblings/ref-void.scrbl
+++ b/rhombus/scribblings/ref-void.scrbl
@@ -3,10 +3,10 @@
 
 @title{Void}
 
-@doc[
+@doc(
   annotation.macro 'Void'
-]{
+){
 
-  Matches @rhombus[#void].
+  Matches @rhombus(#void).
 
 }

--- a/rhombus/scribblings/reference.scrbl
+++ b/rhombus/scribblings/reference.scrbl
@@ -1,45 +1,45 @@
 #lang scribble/rhombus/manual
 
-@title[~style: symbol(toc)]{Core Rhombus Reference}
+@title(~style: symbol(toc)){Core Rhombus Reference}
 
-@docmodule[rhombus]
+@docmodule(rhombus)
 
-@local_table_of_contents[]
+@local_table_of_contents()
 
-@include_section["ref-def.scrbl"]
-@include_section["ref-import.scrbl"]
-@include_section["ref-export.scrbl"]
-@include_section["ref-function.scrbl"]
-@include_section["ref-class.scrbl"]
-@include_section["ref-mutable.scrbl"]
+@include_section("ref-def.scrbl")
+@include_section("ref-import.scrbl")
+@include_section("ref-export.scrbl")
+@include_section("ref-function.scrbl")
+@include_section("ref-class.scrbl")
+@include_section("ref-mutable.scrbl")
 
-@include_section["ref-repetition.scrbl"]
+@include_section("ref-repetition.scrbl")
 
-@include_section["ref-cond.scrbl"]
-@include_section["ref-match.scrbl"]
-@include_section["ref-for.scrbl"]
-@include_section["ref-begin.scrbl"]
-@include_section["ref-parameter.scrbl"]
+@include_section("ref-cond.scrbl")
+@include_section("ref-match.scrbl")
+@include_section("ref-for.scrbl")
+@include_section("ref-begin.scrbl")
+@include_section("ref-parameter.scrbl")
 
-@include_section["ref-boolean.scrbl"]
-@include_section["ref-number.scrbl"]
-@include_section["ref-string.scrbl"]
-@include_section["ref-list.scrbl"]
-@include_section["ref-array.scrbl"]
-@include_section["ref-map.scrbl"]
-@include_section["ref-set.scrbl"]
-@include_section["ref-void.scrbl"]
+@include_section("ref-boolean.scrbl")
+@include_section("ref-number.scrbl")
+@include_section("ref-string.scrbl")
+@include_section("ref-list.scrbl")
+@include_section("ref-array.scrbl")
+@include_section("ref-map.scrbl")
+@include_section("ref-set.scrbl")
+@include_section("ref-void.scrbl")
 
-@include_section["ref-equal.scrbl"]
-@include_section["ref-dot.scrbl"]
-@include_section["ref-values.scrbl"]
-@include_section["ref-annotation.scrbl"]
-@include_section["ref-stxobj.scrbl"]
-@include_section["ref-syntax-class.scrbl"]
-@include_section["ref-macro.scrbl"]
-@include_section["ref-begin-meta.scrbl"]
+@include_section("ref-equal.scrbl")
+@include_section("ref-dot.scrbl")
+@include_section("ref-values.scrbl")
+@include_section("ref-annotation.scrbl")
+@include_section("ref-stxobj.scrbl")
+@include_section("ref-syntax-class.scrbl")
+@include_section("ref-macro.scrbl")
+@include_section("ref-begin-meta.scrbl")
 
-@include_section["ref-io.scrbl"]
+@include_section("ref-io.scrbl")
 
-@include_section["ref-eval.scrbl"]
+@include_section("ref-eval.scrbl")
 

--- a/rhombus/scribblings/rhombus.scrbl
+++ b/rhombus/scribblings/rhombus.scrbl
@@ -3,10 +3,10 @@
 @title{Rhombus Prototype}
 
 This is the experimental Rhombus prototype using
-@seclink[~doc: [symbol(lib), "shrubbery/scribblings/shrubbery.scrbl"], "top"]{Shrubbery notation}.
+@seclink(~doc: [symbol(lib), "shrubbery/scribblings/shrubbery.scrbl"], "top"){Shrubbery notation}.
 
-@table_of_contents[]
+@table_of_contents()
 
-@include_section["overview.scrbl"]
-@include_section["bind-and-static.scrbl"]
-@include_section["reference.scrbl"]
+@include_section("overview.scrbl")
+@include_section("bind-and-static.scrbl")
+@include_section("reference.scrbl")

--- a/rhombus/scribblings/set.scrbl
+++ b/rhombus/scribblings/set.scrbl
@@ -3,16 +3,16 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "set"]{Sets}
+@title(~tag: "set"){Sets}
 
-When @litchar["{"]...@litchar["}"] is used with elements that do not
-have @rhombus[:], then @litchar["{"]...@litchar["}"] creates a set. (If
-a set-element expression uses @rhombus[:], then it will need to be in
+When @litchar("{")...@litchar("}") is used with elements that do not
+have @rhombus(:), then @litchar("{")...@litchar("}") creates a set. (If
+a set-element expression uses @rhombus(:), then it will need to be in
 parentheses to avoid being parsed as a key–value pair.) A set can serve
 as a map, where the set's elements act as keys and each key's value is
-@rhombus[#true]. There's a @rhombus[Set] constructor that's analogous to
-@rhombus[Map], but @rhombus[Set] accepts just values to include in the
-set. The @rhombus[++] operator effectively unions sets.
+@rhombus(#true). There's a @rhombus(Set) constructor that's analogous to
+@rhombus(Map), but @rhombus(Set) accepts just values to include in the
+set. The @rhombus(++) operator effectively unions sets.
 
 @(rhombusblock:
     val friends: {"alice", "bob", "carol"}
@@ -27,7 +27,7 @@ set. The @rhombus[++] operator effectively unions sets.
     friends["david"]      // prints #false
   )
 
-@rhombus[Set.of] and @rhombus[make_set] work as you'd expect. When
-@litchar{[}...@litchar{]} with @rhombus[:=] is used to modify a mutable
+@rhombus(Set.of) and @rhombus(make_set) work as you'd expect. When
+@litchar{[}...@litchar{]} with @rhombus(:=) is used to modify a mutable
 set, the ``key'' is removed from the set if the assigned value is
-@rhombus[#false], otherwise the ``key'' is added to the set.
+@rhombus(#false), otherwise the ``key'' is added to the set.

--- a/rhombus/scribblings/static-info.scrbl
+++ b/rhombus/scribblings/static-info.scrbl
@@ -5,14 +5,14 @@
 
 @(def meta(s): italic(s))
 
-@title[~tag: "static-info"]{Static information: Dot Providers and More}
+@title(~tag: "static-info"){Static information: Dot Providers and More}
 
 A binding or an expression can have associated @deftech{static
  information} that is used to enable, reject, or resolve certain
 expression forms. For example, an expression can be used to the left of
-a @rhombus[.] only when it has static information to specify how a field
-name after @rhombus[.] resolves to an field accessor. See the
-@secref["annotation"] for an overview of static information and its
+a @rhombus(.) only when it has static information to specify how a field
+name after @rhombus(.) resolves to an field accessor. See the
+@secref("annotation") for an overview of static information and its
 role.
 
 @section{Representing static information}
@@ -26,73 +26,73 @@ generality.
 The prototype implementation of Rhombus currently uses five built-in
 static-information keys:
 
-@itemlist[
+@itemlist(
 
-  @item{@rhombus[dot_ct.provider_key] --- names a compile-time function
-   that macro-expands any use of @rhombus[.] after @meta{E}. For example,
-   assuming a @rhombus[class Posn(x, y)] declaration, @rhombus[p :: Posn]
-   associates @rhombus[dot_ct.provider_key] with uses of @rhombus[p] to
-   expand @rhombus[p.x] and @rhombus[p.y] to field accesses. An expression
+  @item{@rhombus(dot_ct.provider_key) --- names a compile-time function
+   that macro-expands any use of @rhombus(.) after @meta{E}. For example,
+   assuming a @rhombus(class Posn(x, y)) declaration, @rhombus(p :: Posn)
+   associates @rhombus(dot_ct.provider_key) with uses of @rhombus(p) to
+   expand @rhombus(p.x) and @rhombus(p.y) to field accesses. An expression
    is a @tech{dot provider} when it has static information mapped by
-   @rhombus[dot_ct.provider_key].},
+   @rhombus(dot_ct.provider_key).},
 
-  @item{@rhombus[expr_ct.call_result_key] --- provides static information
+  @item{@rhombus(expr_ct.call_result_key) --- provides static information
    to be attached to a function-call expression where the function position
    is @meta{E}. (The arguments in the call do not matter.) For example,
-   @rhombus[class Posn(x, y)] associates @rhombus[expr_ct.call_result_key]
-   with @rhombus[Posn] itself, and the associated value is static
-   information with @rhombus[dot_ct.provider_key]. So, @rhombus[Posn(1, 2)]
-   gets @rhombus[dot_ct.provider_key] that makes @rhombus[Posn(1, 2).x]
-   select the @rhombus[1].},
+   @rhombus(class Posn(x, y)) associates @rhombus(expr_ct.call_result_key)
+   with @rhombus(Posn) itself, and the associated value is static
+   information with @rhombus(dot_ct.provider_key). So, @rhombus(Posn(1, 2))
+   gets @rhombus(dot_ct.provider_key) that makes @rhombus(Posn(1, 2).x)
+   select the @rhombus(1).},
 
-  @item{@rhombus[expr_ct.ref_result_key] --- provides static information to be
+  @item{@rhombus(expr_ct.ref_result_key) --- provides static information to be
    attached to a @litchar{[}...@litchar{]} map reference where E is to the left
    of the @litchar{[}...@litchar{]}. (The index expression inside @litchar{[}...@litchar{]} does
-   not matter.) For example @rhombus[ps :: List.of(Posn)] associates
-   @rhombus[expr_ct.ref_result_key] to @rhombus[ps], where the associated value
-   includes is static information with @rhombus[dot_ct.provider_key]. So,
-   @rhombus[ps[i].x] is allowed an selects an @rhombus[x] field from the @rhombus[Posn]
-   instance produced by @rhombus[ps[i]].},
+   not matter.) For example @rhombus(ps :: List.of(Posn)) associates
+   @rhombus(expr_ct.ref_result_key) to @rhombus(ps), where the associated value
+   includes is static information with @rhombus(dot_ct.provider_key). So,
+   @rhombus(ps[i].x) is allowed an selects an @rhombus(x) field from the @rhombus(Posn)
+   instance produced by @rhombus(ps[i]).},
 
-  @item{@rhombus[expr_ct.map_ref_key] and @rhombus[expr_ct.map_set_key] --- names a form to
+  @item{@rhombus(expr_ct.map_ref_key) and @rhombus(expr_ct.map_set_key) --- names a form to
    use for a @litchar{[}...@litchar{]} map reference or assignment where E is to
    the left of the @litchar{[}...@litchar{]}. (The index expression inside
-   @litchar{[}...@litchar{]} does not matter.) For example @rhombus[p :: Array] associates
-   @rhombus[expr_ct.map_ref] to @rhombus[p] so that @rhombus[p[i]] uses an array-specific
-   referencing operation, and it associates @rhombus[expr_ct.map_ref] to
-   @rhombus[p] so that @rhombus[p[i] = n] uses an array-specific assignment operation.}
+   @litchar{[}...@litchar{]} does not matter.) For example @rhombus(p :: Array) associates
+   @rhombus(expr_ct.map_ref) to @rhombus(p) so that @rhombus(p[i]) uses an array-specific
+   referencing operation, and it associates @rhombus(expr_ct.map_ref) to
+   @rhombus(p) so that @rhombus(p[i] = n) uses an array-specific assignment operation.}
 
-]
+)
 
-In addition, a @rhombus[class] declaration generates a fresh key for each
+In addition, a @rhombus(class) declaration generates a fresh key for each
 every field in the declared class. The value to be associated
-with the key is analogous to @rhombus[expr_ct.call_result_key] or
-@rhombus[expr_ct.ref_result_key], but for references to the field through @rhombus[.]
-or through an accessor function like @rhombus[Posn.x].
+with the key is analogous to @rhombus(expr_ct.call_result_key) or
+@rhombus(expr_ct.ref_result_key), but for references to the field through @rhombus(.)
+or through an accessor function like @rhombus(Posn.x).
 
 Static information is associated to a binding through a binding
 operator/macro, and it can be associated to an expression through a
 binding or through an expression operator/macro that adds static
 information to its parsed form (i.e., expansion). For example, the
-@rhombus[::] operator associates static information through an annotation. An
+@rhombus(::) operator associates static information through an annotation. An
 annotation pairs a predicate with a set of static information to
 associate with any variable that is bound with the annotation. That's
-why a binding @rhombus[p :: Posn] makes every @rhombus[p] a dot provider: the annotation
-@rhombus[Posn] indicates that every binding with the annotation gets a dot
-provider to access @rhombus[x] and @rhombus[y]. When @rhombus[::] is used in an expression,
+why a binding @rhombus(p :: Posn) makes every @rhombus(p) a dot provider: the annotation
+@rhombus(Posn) indicates that every binding with the annotation gets a dot
+provider to access @rhombus(x) and @rhombus(y). When @rhombus(::) is used in an expression,
 then static information indicated by the annotation is similarly
-associated with the overall @rhombus[::] expression, which is why
-@rhombus[(e :: Posn)] is a dot provider for any expression @rhombus[e]. Function-call forms
+associated with the overall @rhombus(::) expression, which is why
+@rhombus((e :: Posn)) is a dot provider for any expression @rhombus(e). Function-call forms
 and map-reference forms similarly attach static information to
 their parsed forms, sometimes, based on static information attached to
 the first subexpression.
 
 Note that static information is associated with an expression, not a
-value. So, if @rhombus[Posn] is passed as an argument to a function (instead
+value. So, if @rhombus(Posn) is passed as an argument to a function (instead
 of being called directly as a constructor), then the function
 ultimately receives a value and knows nothing of the expression that
 generated the value. That is, no part of the function's implementation
-can take advantage of the fact that directly calling @rhombus[Posn] would have
+can take advantage of the fact that directly calling @rhombus(Posn) would have
 formed a dot provider. The function might have an annotation on its
 argument that indicates a dot-provider constructor, but that's a
 feature of the formal argument, and not of an actual value.
@@ -108,11 +108,11 @@ over a notion of expression, static-information uses cn be described
 locally over a notion of expressions and binding.
 
 Below is how some rules for basic built-in forms might be written. Read
-@rhombus[Γ] as ``the local environment mapping names to static
-information,'' and read @rhombus[τ] as ``static information.'' Read
-@rhombus[→] as a compile-time expansion.
+@rhombus(Γ) as ``the local environment mapping names to static
+information,'' and read @rhombus(τ) as ``static information.'' Read
+@rhombus(→) as a compile-time expansion.
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
     Γ ⊢ id : Γ(id)
 
        Γ ⊢ e : τ
@@ -148,114 +148,114 @@ notation.
 
 Here's a summary of the static-information behavior of classes:
 
-@itemlist[
+@itemlist(
 
-  @item{A class name bound by @rhombus[class] is a dot provider. It
-   provides field-accessor functions, as in @rhombus[Posn.x].},
+  @item{A class name bound by @rhombus(class) is a dot provider. It
+   provides field-accessor functions, as in @rhombus(Posn.x).},
 
   @item{As an annotation, a class name makes any binding or
    expression using the annotation a dot provider. A class name
-   followed by @rhombus[.of] has the same effect; in addition, it associates
+   followed by @rhombus(.of) has the same effect; in addition, it associates
    any information implied by the argument annotations as static
    information for fields accessed from the binding or exression
    through a dot. For example, assuming a `class Rect(top_left,
-   side)@rhombus[ declaration, ]r :: Rect.of(Posn, Integer)` causes
-   @rhombus[r.top_left] to have @rhombus[Posn] information, with means that
-   @rhombus[r.top_left.x] works.},
+   side)@rhombus( declaration, )r :: Rect.of(Posn, Integer)` causes
+   @rhombus(r.top_left) to have @rhombus(Posn) information, with means that
+   @rhombus(r.top_left.x) works.},
 
   @item{When a class field has an annotation, then that annotation's
-   static information is associated with a field accessed through @rhombus[.].
-   In the @rhombus[Line] example, the @rhombus[p2] field of @rhombus[Line] has a @rhombus[Posn]
-   annotation, so a @rhombus[l1 :: Line] binding means that @rhombus[l1.p2] is a dot
-   provider to access @rhombus[x] and @rhombus[y].},
+   static information is associated with a field accessed through @rhombus(.).
+   In the @rhombus(Line) example, the @rhombus(p2) field of @rhombus(Line) has a @rhombus(Posn)
+   annotation, so a @rhombus(l1 :: Line) binding means that @rhombus(l1.p2) is a dot
+   provider to access @rhombus(x) and @rhombus(y).},
 
   @item{When a class field has an annotation, then that annotation's
    static information is associated as result information for a field
-   accessor accessed through @rhombus[.]. For example, @rhombus[Line.p1] gets the
-   @rhombus[Posn] annotation's static information as its call-result
-   information, so @rhombus[Line.p1(e)] has that information, which means that
-   @rhombus[Line.p1(e)] is a dot provider.},
+   accessor accessed through @rhombus(.). For example, @rhombus(Line.p1) gets the
+   @rhombus(Posn) annotation's static information as its call-result
+   information, so @rhombus(Line.p1(e)) has that information, which means that
+   @rhombus(Line.p1(e)) is a dot provider.},
 
   @item{When a class field has an annotation, and when the class
    name is used as a pattern form in a binding, then the annotation's
    static information is associated with the argument pattern. For
-   example, @rhombus[Line(p1, p2)] as a binding pattern associates @rhombus[Posn]
-   information to @rhombus[p1] and to @rhombus[p2], which means that they're dot
+   example, @rhombus(Line(p1, p2)) as a binding pattern associates @rhombus(Posn)
+   information to @rhombus(p1) and to @rhombus(p2), which means that they're dot
    providers.},
 
   @item{When a class name is used as a binding pattern, any ``downward''
    static information that flows the binding is checked for static
    information keyed by the class's accessors, and that information is
    propagated as ``downward'' information to the corresponding binding
-   subpattern. For example, if @rhombus[Rect(tl, s)] as a binding receives
+   subpattern. For example, if @rhombus(Rect(tl, s)) as a binding receives
    ``downward'' information that associates (the internal key for)
-   @rhombus[Rect.top_left] to @rhombus[Posn]-annotation information, then
-   the binding form @rhombus[tl] receives @rhombus[Posn]-annotation
+   @rhombus(Rect.top_left) to @rhombus(Posn)-annotation information, then
+   the binding form @rhombus(tl) receives @rhombus(Posn)-annotation
    information.},
 
-]
+)
 
 More rules about static information in general:
 
-@itemlist[
+@itemlist(
   
   @item{A expression that is parentheses wrapped around an inner expression
    has the same static information as the inner expression.},
 
   @item{When a function call's function position has result static
    information, the function call as a whole is given that static
-   information. For example, since @rhombus[Line.p1] has result information
-   that describes a dot provider, @rhombus[Line.p1(e)] is a dot provider.},
+   information. For example, since @rhombus(Line.p1) has result information
+   that describes a dot provider, @rhombus(Line.p1(e)) is a dot provider.},
 
-  @item{When a @rhombus[fun] defintition form includes a result annotation, then the
+  @item{When a @rhombus(fun) defintition form includes a result annotation, then the
    annotation's information is associated to the defined function name
    as call-result information. For example, if a function defintion
-   starts @rhombus[fun flip(x) :: Posn], then @rhombus[Posn] static information is
-   associated to @rhombus[flip] as result information, so @rhombus[flip(x)] is a dot
-   provider. The same applies to a @rhombus[def] form that behaves like a
-   @rhombus[fun] definition form.},
+   starts @rhombus(fun flip(x) :: Posn), then @rhombus(Posn) static information is
+   associated to @rhombus(flip) as result information, so @rhombus(flip(x)) is a dot
+   provider. The same applies to a @rhombus(def) form that behaves like a
+   @rhombus(fun) definition form.},
 
-  @item{When the right-hand side of a @rhombus[val], @rhombus[def], or @rhombus[let] has a single
+  @item{When the right-hand side of a @rhombus(val), @rhombus(def), or @rhombus(let) has a single
    group, and when that goes does not start with a definition-form
    name, then static information from that right-hand side expression
-   is propagated to the binding side. For example, @rhombus[val p: Posn(1, 2)]
-   associated that static information of @rhombus[Posn(1, 2)] with @rhombus[p], which
-   among other things means that @rhombus[p.x] will be allowed.}
+   is propagated to the binding side. For example, @rhombus(val p: Posn(1, 2))
+   associated that static information of @rhombus(Posn(1, 2)) with @rhombus(p), which
+   among other things means that @rhombus(p.x) will be allowed.}
 
-]
+)
 
-The @rhombus[List], @rhombus[Array], and @rhombus[Map] expression and
+The @rhombus(List), @rhombus(Array), and @rhombus(Map) expression and
 binding forms are analogous to class-name forms. For example,
-@rhombus[Array] as a constructor in an expression form associates
-reference-result information to the overall @rhombus[Array] expression,
+@rhombus(Array) as a constructor in an expression form associates
+reference-result information to the overall @rhombus(Array) expression,
 as does @litchar{[}...@litchar{]} for constructing a list. In a list
-binding pattern, when @rhombus[...] is used after a binding subpattern,
+binding pattern, when @rhombus(...) is used after a binding subpattern,
 the ``upward'' static information of the subpattern for each identifier
 wrapped as reference-result information for the identifier outside the
-list pattern, since each; for example @rhombus[[p :: Posn, ...]] as a
-binding pattern causes @rhombus[p] to have static information that says
-its reference result as @rhombus[Posn]-annotation information. The
-@rhombus[List.of], @rhombus[Array.of], and @rhombus[Map.of] annotation
+list pattern, since each; for example @rhombus([p :: Posn, ...]) as a
+binding pattern causes @rhombus(p) to have static information that says
+its reference result as @rhombus(Posn)-annotation information. The
+@rhombus(List.of), @rhombus(Array.of), and @rhombus(Map.of) annotation
 forms in bindings propagate ``downward`` reference-result information to
 nested annotations. ``Downward'' static information is used by
-@rhombus[List] or @litchar{[}...@litchar{]} pattern constructions only
+@rhombus(List) or @litchar{[}...@litchar{]} pattern constructions only
 in the case that there's a single element binding pattern followed by
-@rhombus[...], while @rhombus[Array] and @rhombus[Map] as pattern
+@rhombus(...), while @rhombus(Array) and @rhombus(Map) as pattern
 constructors cannot use ``downward'' information.
 
-The @rhombus[::] binding form and the @rhombus[matching] annotation form
+The @rhombus(::) binding form and the @rhombus(matching) annotation form
 allow static information to flow both ``downward'' and ``upward''
 through both annotations and binding patterns.
 
 @section{Binding Patterns and Static Information}
 
-See @secref["bind-macro-protocol"] for information on how binding macros
+See @secref("bind-macro-protocol") for information on how binding macros
 receive and produce static information. A Turnstile-like set of forms
 should be built on top of that low-level API.
 
 @section{Annotations and Static Information}
 
-See [the low-level annotation API](annotation-macros.md) for information on
+See (the low-level annotation API)(annotation-macros.md) for information on
 how annotation macros receive and produce static information. A
 Turnstile-like sets of forms should be built on top of that low-level
 API, too.

--- a/rhombus/scribblings/syntax-class.scrbl
+++ b/rhombus/scribblings/syntax-class.scrbl
@@ -3,13 +3,13 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "syntax-classes"]{Syntax Classes}
+@title(~tag: "syntax-classes"){Syntax Classes}
 
-As shown in @secref["syntax"], a variable can be bound in a syntax
-pattern via @rhombus[$], parentheses, @rhombus[::], and a
+As shown in @secref("syntax"), a variable can be bound in a syntax
+pattern via @rhombus($), parentheses, @rhombus(::), and a
 @deftech{syntax class} name to specify the kind of syntax the pattern
-variable can match. The syntax classes @rhombus[Term, ~stxclass],
-@rhombus[Group, ~stxclass], and @rhombus[Multi, ~stxclass] are built in,
+variable can match. The syntax classes @rhombus(Term, ~stxclass),
+@rhombus(Group, ~stxclass), and @rhombus(Multi, ~stxclass) are built in,
 among others.
 
 @(rhombusblock:
@@ -17,8 +17,8 @@ among others.
 )
 
 Rhombus also supports user-defined syntax classes via
-@rhombus[syntax.class]. Use the @rhombus[syntax.class] form with a block
-that contains @rhombus[pattern] with pattern alternatives:
+@rhombus(syntax.class). Use the @rhombus(syntax.class) form with a block
+that contains @rhombus(pattern) with pattern alternatives:
 
 @(rhombusblock:
     syntax.class Arithmetic:
@@ -28,8 +28,8 @@ that contains @rhombus[pattern] with pattern alternatives:
 )
 
 Equivalently, use a shorthand syntax that omits the use of
-@rhombus[pattern] an inlines alternatives into the immediate
-@rhombus[syntax.class] form:
+@rhombus(pattern) an inlines alternatives into the immediate
+@rhombus(syntax.class) form:
 
 @(rhombusblock:
     syntax.class Arithmetic
@@ -38,10 +38,10 @@ Equivalently, use a shorthand syntax that omits the use of
 )
 
 Defining a syntax class in this way makes it available for use in syntax
-patterns, such as in @rhombus[match]. The syntax class must be defined
+patterns, such as in @rhombus(match). The syntax class must be defined
 at the same phase as the referencing pattern. To define a syntax class
 for use in a macro definition, place it inside a
-@rhombus[begin_for_meta] block.
+@rhombus(begin_for_meta) block.
 
 @(rhombusblock:
     begin_for_meta:
@@ -54,7 +54,7 @@ Once defined, a syntax class can be used to annotate a pattern
 variable that matches any of pattern alternatives specified in the
 syntax class. Generally, a syntax class can make a sequence of terms,
 so a pattern variable annotated with a syntax class is bound to a
-@tech{repetition} for use with @rhombus[...].
+@tech{repetition} for use with @rhombus(...).
 
 @(rhombusblock:
     expr.macro 'add_one_to_expr $(expr :: Arithmetic)':
@@ -65,7 +65,7 @@ so a pattern variable annotated with a syntax class is bound to a
     add_one_to_expr 2 > 3 // error, "expected Arithmetic"
 )
 
-The @rhombus[$]-escaped variables in a syntax class's patterns bind to
+The @rhombus($)-escaped variables in a syntax class's patterns bind to
 matched syntax objects as attributes of the class. They can be accessed
 from a pattern variable using dot notation.
 

--- a/rhombus/scribblings/syntax.scrbl
+++ b/rhombus/scribblings/syntax.scrbl
@@ -3,9 +3,9 @@
     "util.rhm" open
     "common.rhm" open)
 
-@title[~tag: "syntax"]{Syntax Objects}
+@title(~tag: "syntax"){Syntax Objects}
 
-The @rhombus[''] form produces a syntax object. The syntax object holds
+The @rhombus('') form produces a syntax object. The syntax object holds
 an unparsed shrubbery, not a parsed Rhombus expression.
 
 @(rhombusblock:
@@ -17,31 +17,31 @@ an unparsed shrubbery, not a parsed Rhombus expression.
     // '1' + 2  // would be a run-time error, since '1 is not a number
   )
 
-The @rhombus[''] form is more precisely a quasiquoting operator. The
-@rhombus[$] unquotes the immediate following terms. That is, the term
-after @rhombus[$] is a Rhombus expression whose value replaces the
-@rhombus[$] and its argument within the quoted form.
+The @rhombus('') form is more precisely a quasiquoting operator. The
+@rhombus($) unquotes the immediate following terms. That is, the term
+after @rhombus($) is a Rhombus expression whose value replaces the
+@rhombus($) and its argument within the quoted form.
 
 @(rhombusblock:
     '1 + $(2 + 3)'  // prints a shrubbery: 1 + 5
   )
 
-A @rhombus[$] only unquotes when it is followed by a term, otherwise the @rhombus[$]
+A @rhombus($) only unquotes when it is followed by a term, otherwise the @rhombus($)
 itself remains quoted.
 
 @(rhombusblock:
     '1 + $('$') 2'  // prints a shrubbery: 1 + $ 2
   )
 
-@aside{Nested @rhombus[''] does not increase the quoting level like
+@aside{Nested @rhombus('') does not increase the quoting level like
  Racket quasiquote.}
 
-Like @rhombus[$], @rhombus[...] is treated specially within a @rhombus['']-quoted term (except,
-like @rhombus[$], when it’s the only thing in the term). When @rhombus[...] immediately
-follows a term that includes at least one @rhombus[$], the
-form after that @rhombus[$] must refer to a repetition. Then,
-instead of the parenthesized group in place of @rhombus[$], the term before
-@rhombus[...] is replicated as many times as the repetition has items, and each of
+Like @rhombus($), @rhombus(...) is treated specially within a @rhombus('')-quoted term (except,
+like @rhombus($), when it’s the only thing in the term). When @rhombus(...) immediately
+follows a term that includes at least one @rhombus($), the
+form after that @rhombus($) must refer to a repetition. Then,
+instead of the parenthesized group in place of @rhombus($), the term before
+@rhombus(...) is replicated as many times as the repetition has items, and each of
 those items is used in one replication.
 
 @(rhombusblock:
@@ -50,10 +50,10 @@ those items is used in one replication.
     '(hi $seq) ...' // prints a shrubbery: (hi 1) (hi 2) (hi 3)
   )
 
-There’s a subtlety here: could @rhombus[seq] have zero elements? If so,
-replicating the @rhombus[hi] form zero times within a group would leave
+There’s a subtlety here: could @rhombus(seq) have zero elements? If so,
+replicating the @rhombus(hi) form zero times within a group would leave
 an empty group, but a shrubbery never has an empty group. To manage this
-gap, a @rhombus[$] replication to a group with zero terms generates a
+gap, a @rhombus($) replication to a group with zero terms generates a
 multi-group syntax object with zero groups. Attempting to generate a group
 with no terms within a larger sequence with multiple groups is an error.
 
@@ -64,9 +64,9 @@ with no terms within a larger sequence with multiple groups is an error.
     // 'x; (hi $seq) ...; y'  // would be a run-time error
   )
 
-When @rhombus[...] is the only term in a group, and when that group follows
-another, then @rhombus[...] replicates the preceding group. For example,
-putting @rhombus[...] after a @litchar{,} in parentheses means that it follows a the
+When @rhombus(...) is the only term in a group, and when that group follows
+another, then @rhombus(...) replicates the preceding group. For example,
+putting @rhombus(...) after a @litchar{,} in parentheses means that it follows a the
 group before the @litchar{,}, which effectively replicates that group with its
 separating comma:
 
@@ -76,7 +76,7 @@ separating comma:
     '(hi $seq, ...)' // prints a shrubbery: (hi 1, hi 2, hi 3)
   )
 
-Along the same lines, @rhombus[...] just after a @litchar{|} can replicate a preceding
+Along the same lines, @rhombus(...) just after a @litchar{|} can replicate a preceding
 @litchar{|} block:
 
 @(rhombusblock:
@@ -85,12 +85,12 @@ Along the same lines, @rhombus[...] just after a @litchar{|} can replicate a pre
     'cond | $seq | ...' // prints a shrubbery: cond |« 1  » |« 2  » |« 3 »
   )
 
-In other words, @rhombus[...] in various places within a quoted shrubbery
+In other words, @rhombus(...) in various places within a quoted shrubbery
 works the way you’d expect it to work.
 
-When @rhombus[''] is used in a binding position, it constructs a pattern that
+When @rhombus('') is used in a binding position, it constructs a pattern that
 matches syntax objects, and it binds variables that are escaped in the
-pattern with @rhombus[$].
+pattern with @rhombus($).
 
 @(rhombusblock:
     val '$x + $y': '1 + (2 + 3)'
@@ -99,19 +99,19 @@ pattern with @rhombus[$].
     y  // prints a shrubbery: (2 + 3)
   )
 
-A @rhombus[$]-escaped variable in a @rhombus[''] pattern matches one term if
-the group with the @rhombus[$] escape has other terms. Keep in mind
-that @rhombus[''] creates syntax objects containing shrubberies that are not
+A @rhombus($)-escaped variable in a @rhombus('') pattern matches one term if
+the group with the @rhombus($) escape has other terms. Keep in mind
+that @rhombus('') creates syntax objects containing shrubberies that are not
 yet parsed, so a variable will not be matched to a multi-term sequence
 that would be parsed as an expression. For example, a pattern variable
-@rhombus[y] by itself cannot be matched to a sequence @rhombus[2 + 3]:
+@rhombus(y) by itself cannot be matched to a sequence @rhombus(2 + 3):
 
 @(rhombusblock:«
     // val '$x + $y': '1 + 2 + 3'  // would be a run-time error
   »)
 
-If a @rhombus[$] escape is alone within its group, however, the
-@rhombus[$]-escaped variable stands for a match to an entire group.
+If a @rhombus($) escape is alone within its group, however, the
+@rhombus($)-escaped variable stands for a match to an entire group.
 
 @(rhombusblock:
     val '$x': '1 + 2 + 3'
@@ -138,7 +138,7 @@ group is interchangeable with a single-term syntax object:
   )
 
 To match a single term in a group context, annotate the pattern variable
-with the @rhombus[Term, ~stxclass] syntax class using the @rhombus[::] operator.
+with the @rhombus(Term, ~stxclass) syntax class using the @rhombus(::) operator.
 
 @(rhombusblock:
     val '$(x :: Term)': '1'
@@ -147,9 +147,9 @@ with the @rhombus[Term, ~stxclass] syntax class using the @rhombus[::] operator.
     // val '$(x :: Term)': '1 + 2' // would be an run-time error
   )
 
-If a @rhombus[$] escape is not only alone within its group, but the
+If a @rhombus($) escape is not only alone within its group, but the
 group is the only one in a sequence of groups, then the
-@rhombus[$]-escaped variable stands for a match to an entire sequence of
+@rhombus($)-escaped variable stands for a match to an entire sequence of
 groups. In a template, when a group-sequence context has a single group
 with only an escape in the group, then it can be filled with a
 multi-group syntax object. There is no contraint that the original and
@@ -165,11 +165,11 @@ context can be put into a brackets context, for example.
 In the same way that a single-term syntax object can be used as a group
 syntax object, a single-group syntax object can be used as a multi-group
 syntax object, and a single-term syntax object can be used as a
-multi-term syntax object. Use the @rhombus[Group,~stxclass] syntax class
+multi-term syntax object. Use the @rhombus(Group,~stxclass) syntax class
 to match a single group instead of a multi-group sequence.
 
-Meanwhile, @rhombus[..., ~bind] works the way you would expect in a
-pattern, matching any @rhombus[..., ~bind]-replicated pattern variables
+Meanwhile, @rhombus(..., ~bind) works the way you would expect in a
+pattern, matching any @rhombus(..., ~bind)-replicated pattern variables
 to form a repetition of matches:
 
 @(rhombusblock:
@@ -180,8 +180,8 @@ to form a repetition of matches:
     '$y ...'  // prints a shrubbery: 2 + 3
   )
 
-@aside{A tail pattern @rhombus[$$(@rhombus[$])$$(@rhombus[id, ~var]) $$(@rhombus[..., ~bind])] combined with a tail
- template @rhombus[$$(@rhombus[$])$$(@rhombus[id, ~var]) ...] is similar to using @litchar{.} in
+@aside{A tail pattern @rhombus($$(@rhombus($))$$(@rhombus(id, ~var)) $$(@rhombus(..., ~bind))) combined with a tail
+ template @rhombus($$(@rhombus($))$$(@rhombus(id, ~var)) ...) is similar to using @litchar{.} in
  S-expression patterns and templates, where it allows sharing between the
  input and output syntax objects. That sharing and an associated expansion-cost difference
  is all the more important in the Rhombus expansion protocol, which

--- a/scribble/private/docmodule.rhm
+++ b/scribble/private/docmodule.rhm
@@ -29,7 +29,7 @@ for_meta:
 decl.macro 'docmodule ($mod ...)':
   '$(parsed(['defmodule',
              keyword(#{#:require-form}),
-             unparsed('fun (mod): @rhombus[import: $$(mod)]'),
+             unparsed('fun (mod): @rhombus(import: $$(mod))'),
              translate_mod('$mod ...')]))'
 
 expr.macro 'rhombusmodname ($mod ...) $tail ...':

--- a/shrubbery/lex.rkt
+++ b/shrubbery/lex.rkt
@@ -595,12 +595,12 @@
     (values start-pos end-pos eof?))
   (case in-mode
     ;; 'initial mode is right after `@` without immediate `{`, and we
-    ;; may transition from 'initial mode to 'brackets mode at `[`
-    [(initial brackets)
+    ;; may transition from 'initial mode to 'args mode at `(`
+    [(initial args)
      ;; recur to parse in shrubbery mode:
      (define-values (t type paren start end backup sub-status pending-backup)
        (recur (in-at-shrubbery-status status)))
-     ;; to keep the term and possibly exit 'initial or 'brackets mode:
+     ;; to keep the term and possibly exit 'initial or 'args mode:
      (define (ok status)
        (define-values (next-status pending-backup)
          (cond
@@ -615,9 +615,9 @@
               [else
                (values
                 (cond
-                  [(and (not (eq? in-mode 'brackets))
-                        (eqv? #\[ (peek-char in)))
-                   (in-at 'brackets (in-at-comment? status) #t #f sub-status '())]
+                  [(and (not (eq? in-mode 'args))
+                        (eqv? #\( (peek-char in)))
+                   (in-at 'args (in-at-comment? status) #t #f sub-status '())]
                   [(in-escaped? sub-status)
                    (in-escaped-at-status sub-status)]
                   [else sub-status])

--- a/shrubbery/scribblings/at-notation.scrbl
+++ b/shrubbery/scribblings/at-notation.scrbl
@@ -1,16 +1,16 @@
 #lang scribble/rhombus/manual
 
-@title[~tag: "at-notation"]{At-Notation Using @litchar["@"]}
+@title(~tag: "at-notation"){At-Notation Using @litchar("@")}
 
-An @litchar["@"] form of the shape
+An @litchar("@") form of the shape
 
-@verbatim[~indent: 2]|{
- @«|@italic{command} ...»[|@italic{arg}, ...]{ |@italic{body} }...
+@verbatim(~indent: 2)|{
+ @«|@italic{command} ...»(|@italic{arg}, ...){ |@italic{body} }...
 }|
 
 is parsed into the same representation as
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
     @italic{command} ...(@italic{arg}, ..., [@italic{parsed_body}, ...], ...)
 }
 
@@ -18,37 +18,39 @@ That is, the command part is left at the front and spliced into its
 enclosing group, while the argument and body parts are wrapped with
 parentheses to make them like arguments. Each body text is parsed into
 a list of string literals and escapes, and multiple body texts can
-be provided in multiple @litchar["{"]...@litchar["}"]s.
+be provided in multiple @litchar("{")...@litchar("}")s.
 
 The command part usually does not have @litchar{«»}, and it is instead
-usually written as an identifier, operator, or parenthesized term. The
-argument and body parts, when present, always use @litchar{[]} and @litchar{{}},
-respectively. Any of the three kinds parts can be omitted, but when
+usually written as an identifier, operator, parenthesized, or bracketed term. The
+argument and body parts, when present, always use @litchar{()} and @litchar{{}},
+respectively. Any of the three parts can be omitted, but
+a command must be present to include arguments, and at least one part must
+be present. When
 multiple parts are present, they must have no space between them or
-the leading @litchar["@"]. When the argument and body parts are both
+the leading @litchar("@"). When the argument and body parts are both
 omitted, the command part is simply spliced into its context.
 
-The conversion to a call-like form, keeping each body in a separate
-list, and allowing multiple body arguments are the three main ways
-that shrubbery @litchar["@"] notation differs from @litchar{#lang at-exp} notation. The
+The conversion to a call-like form, using @litchar{()} for arguments, keeping each body in a separate
+list, and allowing multiple body arguments are the main ways
+that shrubbery @litchar("@") notation differs from @litchar{#lang at-exp} notation. The
 other differences are the use of @litchar{«}...@litchar{»} instead of @litchar{|}...@litchar{|} for
-delimiting a command, and the use of @litchar["@//"] instead of @litchar["@;"] for
+delimiting a command, and the use of @litchar("@//") instead of @litchar("@;") for
 comments. The details are otherwise meant to be the same, and the rest
 of this section is mostly a recap.
 
-A body part is treated as literal text, except where @litchar["@"] is
-used in a body to escape. An unescaped @litchar["}"] closes a body,
-except that an unescaped @litchar["{"] must be balanced by an unescaped
-@litchar["}"], with both treated as part of the body text. Instead of
-@litchar["{"], a body-starting opener can be @litchar{|} plus
-@litchar["{"] with any number of ASCII punctuation and symbol characters
-(other than @litchar["{"]) in between; the corresponding closer is then
+A body part is treated as literal text, except where @litchar("@") is
+used in a body to escape. An unescaped @litchar("}") closes a body,
+except that an unescaped @litchar("{") must be balanced by an unescaped
+@litchar("}"), with both treated as part of the body text. Instead of
+@litchar("{"), a body-starting opener can be @litchar{|} plus
+@litchar("{") with any number of ASCII punctuation and symbol characters
+(other than @litchar("{")) in between; the corresponding closer is then
 the same sequence in reverse, except that some characters are flipped:
-@litchar["{"] to @litchar["}"], @litchar{(} to @litchar{)}, @litchar{)}
+@litchar("{") to @litchar("}"), @litchar{(} to @litchar{)}, @litchar{)}
 to @litchar{(}, @litchar{[} to @litchar{]}, @litchar{]} to @litchar{[},
 @litchar{<} to @litchar{>}, and @litchar{>} to @litchar{<}. With an
-@litchar{|}...@litchar["{"] opener, an escape is formed by using the
-opener followed by @litchar["@"], while opener–closer pairs balance
+@litchar{|}...@litchar("{") opener, an escape is formed by using the
+opener followed by @litchar("@"), while opener–closer pairs balance
 within the body text. When multiple body parts are provided, each can
 use a different opener and closer. The parsed form of the body breaks up
 the body text into lines and @litchar{"\n"} as separate string literals
@@ -56,21 +58,21 @@ in the parsed list form, with each escape also being its own element in
 the list form. Parsed body text also has leading and trailing whitespace
 adjusted the same as with @litchar{#lang at-exp}.
 
-After the @litchar["@"] of an escape in body text, the escape has the
-same form as an at-notaton form that starts with @litchar["@"] as a
-shubbery. That is, @litchar["@"] forms are essentially the same whether
+After the @litchar("@") of an escape in body text, the escape has the
+same form as an at-notaton form that starts with @litchar("@") as a
+shubbery. That is, @litchar("@") forms are essentially the same whether
 starting in shrubbery mode or body-text mode.
 
 In body text, there are two additional comment forms that are not
-supported in shrubbery mode. A @litchar["@//{"] starts a block comment
-that ends with @litchar["}"], and the comment form is not part of the
-body text. The @litchar["@//"] comment form must be prefixed with an
+supported in shrubbery mode. A @litchar("@//{") starts a block comment
+that ends with @litchar("}"), and the comment form is not part of the
+body text. The @litchar("@//") comment form must be prefixed with an
 opener when its enclosing body is started with an opener that isn't just
-@litchar["{"], and the @litchar["{"] after @litchar["@//"] can more
-generally be an @litchar{|}...@litchar["{"] opener with the
+@litchar("{"), and the @litchar("{") after @litchar("@//") can more
+generally be an @litchar{|}...@litchar("{") opener with the
 corresponding closer. Opener–closer pairs must be balanced in the
-commented block, the same as in body text. A @litchar["@//"] comment
+commented block, the same as in body text. A @litchar("@//") comment
 form (prefixed with an opener as needed to form an escape) that is not
-followed by @litchar["{"] or an @litchar{|}...@litchar["{"] opener
+followed by @litchar("{") or an @litchar{|}...@litchar("{") opener
 comments out the rest of the line, including a comment-terminating
 newline.

--- a/shrubbery/scribblings/example.scrbl
+++ b/shrubbery/scribblings/example.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/rhombus/manual
 
-@title[~tag: "example"]{Examples}
+@title(~tag: "example"){Examples}
 
 Here are some example shrubberies. Each line either uses old indentation
 to continue a nesting level that was started on a previous line, starts
@@ -50,13 +50,13 @@ Identifiers are C-style with alphanumerics and underscores. Operators
 are sequences of symbolic characters in the sense of
 @litchar{char-symbolic?}, roughly. No spaces are needed between
 operators and non-operators, so @litchar{1+2} and @litchar{1 + 2} mean
-the same thing. Comments are C-style. See @secref["lexeme-parsing"]
+the same thing. Comments are C-style. See @secref("lexeme-parsing")
 for more information.
 
 The following tokens are used for grouping, in addition to line breaks
 and indentation:
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
 ( ) [ ] { } '  ; ,   : |   « »  \
 }
 

--- a/shrubbery/scribblings/grammar.rhm
+++ b/shrubbery/scribblings/grammar.rhm
@@ -13,5 +13,5 @@ export:
   bseq balt boptional nonterm bseq kleenestar kleeneplus boptional
   bis bor
 
-def bis: @elem{@hspace[1]::=@hspace[1]}
-def bor: @elem{@hspace[1] | @hspace[1]}
+def bis: @elem{@hspace(1)::=@hspace(1)}
+def bor: @elem{@hspace(1) | @hspace(1)}

--- a/shrubbery/scribblings/group-and-block.scrbl
+++ b/shrubbery/scribblings/group-and-block.scrbl
@@ -5,7 +5,7 @@
 @(def closer: @emph{closer})
 @(def opener_closer: @elem{@opener--@italic{closer}})
 
-@title[~tag: "group-and-block"]{Groups and Blocks}
+@title(~tag: "group-and-block"){Groups and Blocks}
 
 The heart of shrubbery notation is its set of rules for organizing
 @deftech{terms} into @deftech{groups}, @deftech{blocks}, and
@@ -13,7 +13,7 @@ The heart of shrubbery notation is its set of rules for organizing
 structure of a shrubbery-notation document, where literal fragments like
 @litchar{(} serve merely as tags:
 
-@nested[~style: symbol(inset),
+@nested(~style: symbol(inset),
         bnf.BNF([@nonterm{document},
                  kleenestar(@nonterm{group})],
                 [@nonterm{group},
@@ -22,8 +22,8 @@ structure of a shrubbery-notation document, where literal fragments like
                  @nonterm{atom},
                  balt(bseq(@litchar{(}, kleenestar(@nonterm{group}), @litchar{)}),
                       bseq(@litchar{[}, kleenestar(@nonterm{group}), @litchar{]}),
-                      bseq(@litchar["{"], kleenestar(@nonterm{group}), @litchar["}"]),
-                      bseq(@litchar["'"], kleenestar(@nonterm{group}), @litchar["'"]))],
+                      bseq(@litchar("{"), kleenestar(@nonterm{group}), @litchar("}")),
+                      bseq(@litchar("'"), kleenestar(@nonterm{group}), @litchar("'")))],
                 [@nonterm{tail-term},
                  @nonterm{term},
                  @nonterm{block},
@@ -31,11 +31,11 @@ structure of a shrubbery-notation document, where literal fragments like
                 [@nonterm{block},
                  bseq(@litchar{:}, kleenestar(@nonterm{group}))],
                 [@nonterm{alt-block},
-                 bseq(@litchar["|"], kleenestar(@nonterm{block}))])]
+                 bseq(@litchar("|"), kleenestar(@nonterm{block}))]))
 
 A document is a sequence of groups, each of which is a non-empty
 sequence of terms. Terms include @deftech{atoms}, which are either
-individual @seclink["lexeme-parsing"]{lexeme tokens}, @opener_closer
+individual @seclink("lexeme-parsing"){lexeme tokens}, @opener_closer
 pairs that contain groups, or blocks as created with @litchar{:} or
 @litchar{|}---but a block as a term is constrained to appear only at the
 end of a group.
@@ -70,7 +70,7 @@ when this document says “the previous line” or “the next line.”
 @section{Grouping by Opener--Closer Pairs}
 
 An @opener_closer pair @litchar{(} and @litchar{)}, @litchar{[} and
-@litchar{]}, @litchar["{"] and @litchar["}"], or @litchar{'} and
+@litchar{]}, @litchar("{") and @litchar("}"), or @litchar{'} and
 @litchar{'} (those two are the same character) forms a @tech{term} that
 can span lines and encloses nested groups. Within most @opener_closer
 pairs, @litchar{,} separates groups, but @litchar{;} separates group
@@ -95,7 +95,7 @@ retains whether a subgroup is formed by @litchar{()}, @litchar{[]},
 The following three forms are not allowed, because they are missing a
 @litchar{,} between two groups:
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
 // Not allowed
 (1
  2)
@@ -108,7 +108,7 @@ The following three forms are not allowed, because they are missing a
 A @litchar{,} is disallowed if it would create an empty group, except
 that a trailing @litchar{,} is allowed.
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
 // Not allowed
 (, 1)
 (1,, 2)
@@ -131,7 +131,7 @@ on its own line.
 
 Using @litchar{'} as both an @opener and @closer prevents simple nesting
 of those forms. There is no problem if a @litchar{(}, @litchar{[}, or
-@litchar["{"], appears between one @litchar{'} as an opener and another
+@litchar("{"), appears between one @litchar{'} as an opener and another
 @litchar{'} as an opener; otherwise, two consecutive @litchar{'}s
 intended as openers would instead be parsed as an opener and a closer.
 To disambiguate, @litchar{«} can be used immediately after immediately
@@ -150,7 +150,7 @@ A sequence of groups has a particular indentation that is determined by
 the first group in the sequence. Subsequent groups in a sequence must
 start with the same indentation as the first group.
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
 group 1
 group 2
 // error, because the group is indented incorrectly:
@@ -202,9 +202,9 @@ any indentation; it doesn't have to be indented to the right of the
 
 A block that is started with @litchar{:} normally cannot be empty
 (unless explicit-grouping @litchar{«} and @litchar{»} are used as
-described in @secref["guillemot"]), so the following is ill-formed:
+described in @secref("guillemot")), so the following is ill-formed:
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
 bad_empty:  // empty block disallowed
 }
 
@@ -219,7 +219,7 @@ single element @litchar{untagged}, the second top-level group has just a
 block with zero groups, and the third has a group with one parenthesized
 sequence of groups where the middle one has an empty block:
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
     : untagged
 
     :
@@ -227,7 +227,7 @@ sequence of groups where the middle one has an empty block:
     (1, :, 2)
 }
 
-@section[~tag: "continuing-op"]{Continuing with Indentation and an Operator}
+@section(~tag: "continuing-op"){Continuing with Indentation and an Operator}
 
 When a newly indented line starts with an operator and when the
 preceding line does @emph{not} end with @litchar{:}, then the indented line
@@ -249,7 +249,7 @@ A block is always at the end of its immediately containing group. One
 consequence is that an operator-starting line cannot continue a group
 that already has a block:
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
 hello: world
   + 3 // bad indentation
 }
@@ -267,7 +267,7 @@ with a block that has a @litchar{+ 3} group:
       + 3
   )
 
-@section[~tag: "alt-block"]{Blocking with @litchar{|}}
+@section(~tag: "alt-block"){Blocking with @litchar{|}}
 
 A @litchar{|} is implicitly shifted half a column right (so, implicitly
 nested), and it is implicitly followed by a @litchar{:} that
@@ -332,7 +332,7 @@ of groups. Standard indentation uses no additional space of
 indentation before @litchar{|} relative to its enclosing block's group.
 
 
-@section[~tag: "semicolon"]{Separating Groups with @litchar{;} and @litchar{,}}
+@section(~tag: "semicolon"){Separating Groups with @litchar{;} and @litchar{,}}
 
 A @litchar{;} separates two groups on the same line. A @litchar{;} is
 allowed in any context—except between groups immediately within,
@@ -379,7 +379,7 @@ group is a block that contains a single group:
      universe)
   )
 
-@section[~tag: "guillemot"]{Line- and Column-Insensitivity with @litchar{«} and @litchar{»}}
+@section(~tag: "guillemot"){Line- and Column-Insensitivity with @litchar{«} and @litchar{»}}
 
 A block can be delimited explicitly with @litchar{«} and @litchar{»} to
 disable the use of line and column information for parsing between
@@ -534,13 +534,13 @@ To stay consistent with blocks expressed through line breaks and
 indentation, a block with @litchar{«} and @litchar{»} must still appear at the end of
 its enclosing group.
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
 // not allowed, because a block must end a group
 inside:« fruit » more
 }
 
 
-@section[~tag: "continuing-backslash"]{Continuing a Line with @litchar{\}}
+@section(~tag: "continuing-backslash"){Continuing a Line with @litchar{\}}
 
 As a last resort, @litchar{\} can be used at the end of a line (optionally
 followed by whitespace and coments on the line) to continue the next
@@ -580,7 +580,7 @@ it continues.
            list)
 )
 
-@section[~tag: "group-comment"]{Group Comments with @litchar{#//}}
+@section(~tag: "group-comment"){Group Comments with @litchar{#//}}
 
 A @litchar{#//} comments out a group or @litchar{|} alternative. To comment out a
 group, @litchar{#//} must appear either on its own line before a group or at
@@ -591,7 +591,7 @@ on its own line before the alternative or just before a @litchar{|} that does
 The interaction between @litchar{#//} and indentation depends on how it is
 used:
 
-@itemlist[
+@itemlist(
 
  @item{When @litchar{#//} appears completely on its own line (possibly with
    whitespace and non-group comments), then its indentation does not
@@ -614,7 +614,7 @@ used:
    @litchar{#//} is not allowed to start a line for commenting out a @litchar{|}
    alternative on the same line.}
 
-]
+)
 
 A @litchar{#//} is not allowed without a group or alternative afterward to
 comment out. Multiple @litchar{#//}s do not nest (i.e., two @litchar{#//}s in a row is
@@ -673,4 +673,4 @@ The following three groups all parse the same:
   )
 
 
-@include_section["at-notation.scrbl"]
+@include_section("at-notation.scrbl")

--- a/shrubbery/scribblings/lexeme-parsing.scrbl
+++ b/shrubbery/scribblings/lexeme-parsing.scrbl
@@ -1,11 +1,11 @@
 #lang scribble/rhombus/manual
 @(import: "grammar.rhm" open)
 
-@title[~tag: "lexeme-parsing"]{Lexeme Parsing}
+@title(~tag: "lexeme-parsing"){Lexeme Parsing}
 
 The tokens used for grouping and indentation are distinct lexemes:
 
-@verbatim[~indent: 2]|{
+@verbatim(~indent: 2)|{
 ( ) [ ] { } '   ; ,   : |   « »  \
 }|
 
@@ -15,7 +15,7 @@ star in the left column indicates the productions that correspond to
 
 Numbers are supported directly in in simple forms---decimal integers,
 decimal floating point, and hexadecimal integers---in all cases allowing
-@litchar{_}s between digits. A @litchar["#{"]...@litchar["}"] escape
+@litchar{_}s between digits. A @litchar("#{")...@litchar("}") escape
 provides access to the full Racket S-expression number grammar. Special
 floating-point values use a @litchar{#} notation: @litchar{#inf},
 @litchar{#neginf}, and @litchar{#nan}.
@@ -59,29 +59,29 @@ multi-character operator cannot appear @emph{after} a number. The
 @litchar{+} and @litchar{-} characters as a number prefix versus an
 operator are also subject to a special rule: they are parsed as
 operators when immediately preceded by an alphanumeric character,
-@litchar{_}, @litchar{.}, @litchar{)}, @litchar{]}, or @litchar["}"]
+@litchar{_}, @litchar{.}, @litchar{)}, @litchar{]}, or @litchar("}")
 with no whitespace in between. For example, @litchar{1+2} is
 @litchar{1} plus @litchar{2}, but @litchar{1 +2} is @litchar{1}
 followed by the number @litchar{+2}.
 
-When a @litchar["#{"]...@litchar["}"] escape describes an identifier
+When a @litchar("#{")...@litchar("}") escape describes an identifier
 S-expression, it is an identifier in the same sense as a
 shrubbery-notation identifier. the same holds for numbers, booleans,
-strings, byte strings, and keywords. A @litchar["#{"]...@litchar["}"]
+strings, byte strings, and keywords. A @litchar("#{")...@litchar("}")
 escape must _not_ describe a pair, because pairs are used to represent a
 parsed shrubbery, and allowing pairs would create ambiguous or
 ill-formed representations.
 
-A @litchar["@"] starts an at-expression form similar to the notaton
+A @litchar("@") starts an at-expression form similar to the notaton
 supported by @litchar{#lang at-exp} (which oriented toward S-expressions
-and readtable-based). @Secref["at-notation"] explains in more detail, but
-the table below sketches the shape of @litchar["@"] forms.
+and readtable-based). @Secref("at-notation") explains in more detail, but
+the table below sketches the shape of @litchar("@") forms.
 
-@(def is_lex: @elem{★@hspace[1]})
+@(def is_lex: @elem{★@hspace(1)})
 @(def no_lex: "")
-@(def empty_line: ["", @hspace[1], "", "", ""])
+@(def empty_line: ["", @hspace(1), "", "", ""])
 
-@tabular[
+@tabular(
   [
     [is_lex, @nonterm{identifier}, bis, bseq(@nonterm{alpha}, kleenestar(@nonterm{alphanum})), ""],
     empty_line,
@@ -107,10 +107,10 @@ the table below sketches the shape of @litchar["@"] forms.
                                               @litchar{+}, @litchar{-}, @litchar{.}, @litchar{/}}, ""],
     empty_line,
     [no_lex, @nonterm{special}, bis, @elem{@italic{one of} @litchar{(}, @litchar{)}, @litchar{[},
-                                           @litchar{]}, @litchar["{"], @litchar["}"], @litchar{'},
+                                           @litchar{]}, @litchar("{"), @litchar("}"), @litchar{'},
                                            @litchar{«}, @litchar{»}}, ""],
     ["", "", bor, @elem{@italic{one of} @litchar{"}, @litchar{;}, @litchar{,}, @litchar{#},
-                        @litchar{\}, @litchar{_}, @litchar["@"]}, ""],
+                        @litchar{\}, @litchar{_}, @litchar("@")}, ""],
     ["", "", bor, @elem{@italic{single-character Unicode emoji sequence}}, ""],
     empty_line,
     [is_lex, @nonterm{number}, bis, @nonterm{integer}, ""],
@@ -175,7 +175,7 @@ the table below sketches the shape of @litchar["@"] forms.
     empty_line,
     [no_lex, @nonterm{bytestrelem}, bis, @italic{like Racket, but no literal newline}, ""],
     empty_line,
-    [is_lex, @nonterm{sexpression}, bis, bseq(@litchar["#{"], @nonterm{racket}, @litchar["}"]), ""],
+    [is_lex, @nonterm{sexpression}, bis, bseq(@litchar("#{"), @nonterm{racket}, @litchar("}")), ""],
     empty_line,
     [no_lex, @nonterm{racket}, bis, @italic{any non-pair Racket S-expression}, ""],
     empty_line,
@@ -184,10 +184,11 @@ the table below sketches the shape of @litchar["@"] forms.
     empty_line,
     [no_lex, @nonterm{nonnlchar}, bis, @italic{any character other than newline}, ""],
     empty_line,
-    [is_lex, @nonterm{atexpression}, bis, bseq(@litchar["@"],
-                                               boptional(@nonterm{command}),
+    [is_lex, @nonterm{atexpression}, bis, bseq(@litchar("@"),
+                                               @nonterm{command},
                                                boptional(@nonterm{arguments}),
                                                boptional(@nonterm{body})), "no space between parts"],
+    ["", "", bor, bseq(@litchar("@"), @nonterm{body}), "no space between parts"],
     empty_line,
     [no_lex, @nonterm{command}, bis, @nonterm{identifier}, ""],
     ["", "", bor, @nonterm{keyword}, ""],
@@ -198,20 +199,21 @@ the table below sketches the shape of @litchar["@"] forms.
     ["", "", bor, @nonterm{bytestring}, ""],
     ["", "", bor, @nonterm{racket}, ""],
     ["", "", bor, bseq(@litchar{(}, @kleenestar(@nonterm{group}), @litchar{)}), ""],
+    ["", "", bor, bseq(@litchar{[}, @kleenestar(@nonterm{group}), @litchar{]}), ""],
     ["", "", bor, bseq(@litchar{«}, @nonterm{group}, @litchar{»}), ""],
     empty_line,
-    [no_lex, @nonterm{arguments}, bis, bseq(@litchar{[}, @kleenestar(@nonterm{group}), @litchar{]}),
+    [no_lex, @nonterm{arguments}, bis, bseq(@litchar{(}, @kleenestar(@nonterm{group}), @litchar{)}),
      @italic{usual @litchar{,}-separated}],
     empty_line,
-    [no_lex, @nonterm{body}, bis, bseq(@litchar["{"], @nonterm{text}, @litchar["}"]),
+    [no_lex, @nonterm{body}, bis, bseq(@litchar("{"), @nonterm{text}, @litchar("}")),
      @elem{@italic{escapes in} @nonterm{text}}],
     ["", "", bor, bseq(@nonterm{atopen}, @nonterm{text}, @nonterm{atclose}),
      @elem{@nonterm{atclose} @italic{match} @nonterm{atopen}}],
     empty_line,
-    [no_lex, @nonterm{atopen}, bis, bseq(@litchar{|}, kleenestar(@nonterm{asciisym}), @litchar["{"]), ""],
+    [no_lex, @nonterm{atopen}, bis, bseq(@litchar{|}, kleenestar(@nonterm{asciisym}), @litchar("{")), ""],
     empty_line,
-    [no_lex, @nonterm{atclose}, bis, bseq(@litchar["}"], kleenestar(@nonterm{asciisym}), @litchar{|}),
+    [no_lex, @nonterm{atclose}, bis, bseq(@litchar("}"), kleenestar(@nonterm{asciisym}), @litchar{|}),
      @italic{flips paren-line}],
     
   ]
-]
+)

--- a/shrubbery/scribblings/meta.scrbl
+++ b/shrubbery/scribblings/meta.scrbl
@@ -26,19 +26,19 @@ breaks and indentation to impart grouping information, as in Python.
 Shrubbery notation explores a point in the design space where the
 notation is
 
-@itemlist[
+@itemlist(
 
  @item{line- and indentation-sensitive, and},
  
  @item{intended to constrain grouping but not reflect every detail of
   grouping.}
 
-]
+)
 
 Deferring complete grouping to another parser relieves a burden on
 reader-level notation. At the same time, line- and indentation-sensitive
 rules constrain parsing to ensure that line breaks and indentation in
 the source are not misleading.
 
-@include_section["rationale.scrbl"]
-@include_section["prior-art.scrbl"]
+@include_section("rationale.scrbl")
+@include_section("prior-art.scrbl")

--- a/shrubbery/scribblings/parsed-representation.scrbl
+++ b/shrubbery/scribblings/parsed-representation.scrbl
@@ -7,7 +7,7 @@
 
 The parse of a shrubbery can be represented by an S-expression:
 
-@itemlist[
+@itemlist(
 
  @item{Each group is represented as a list that starts @litchar{'group}, and
    the rest of the list are the elements of the group.},
@@ -39,7 +39,7 @@ The parse of a shrubbery can be represented by an S-expression:
  @item{A block created to follow @litchar{|} appears immediately in an @litchar{'alts}
    list.}
 
-]
+)
 
 Note that a block can only appear immediately in a @litchar{'group} or @litchar{'alts}
 list, and only at the end within a @litchar{'group} list. Note also that there is no possibility of confusion between
@@ -49,33 +49,33 @@ always appear as non-initial items in a @litchar{'group} list.
 
 Overall, the grammar of S-expression representations is as follows:
 
-@nested[~style: symbol(inset), shrubbery_s_expression_grammar]
+@nested(~style: symbol(inset), shrubbery_s_expression_grammar)
 
 Here's the same grammar, but expressed using Rhombus constructors:
 
-@nested[~style: symbol(inset),
+@nested(~style: symbol(inset),
         bnf.BNF([@nonterm{parsed},
-                 @rhombus[[symbol(top), $$(@nonterm{group}), ...]]],
+                 @rhombus([symbol(top), $$(@nonterm{group}), ...])],
                 [@nonterm{group},
-                 @rhombus[[symbol(group), $$(@nonterm{term}), ..., $$(@nonterm{tail-term})]]],
+                 @rhombus([symbol(group), $$(@nonterm{term}), ..., $$(@nonterm{tail-term})])],
                 [@nonterm{term},
                  @nonterm{atom},
-                 @rhombus[[symbol(op), $$(@nonterm{symbol})]],
-                 @rhombus[[symbol(parens), $$(@nonterm{group}), ...]],
-                 @rhombus[[symbol(brackets), $$(@nonterm{group}), ...]],
-                 @rhombus[[symbol(braces), $$(@nonterm{group}), ...]],
-                 @rhombus[[symbol(quotes), $$(@nonterm{group}), ...]]],
+                 @rhombus([symbol(op), $$(@nonterm{symbol})]),
+                 @rhombus([symbol(parens), $$(@nonterm{group}), ...]),
+                 @rhombus([symbol(brackets), $$(@nonterm{group}), ...]),
+                 @rhombus([symbol(braces), $$(@nonterm{group}), ...]),
+                 @rhombus([symbol(quotes), $$(@nonterm{group}), ...])],
                 [@nonterm{tail-term},
                  @nonterm{term},
                  @nonterm{block},
-                 @rhombus[[symbol(alts), $$(@nonterm{block}), ...]]],
+                 @rhombus([symbol(alts), $$(@nonterm{block}), ...])],
                 [@nonterm{block},
-                 @rhombus[[symbol(block), $$(@nonterm{group}), ...]]])]
+                 @rhombus([symbol(block), $$(@nonterm{group}), ...])]))
 
 Here are some example shrubberies with their S-expression parsed
 representations:
 
-@verbatim[~indent: 2]{
+@verbatim(~indent: 2){
 def pi: 3.14
 
 (group de pi (block (group 3.14)))

--- a/shrubbery/scribblings/prior-art.scrbl
+++ b/shrubbery/scribblings/prior-art.scrbl
@@ -7,7 +7,7 @@ informed by Python.
 
 Sampling notation's rules relating indentation, lines, @litchar{;}, and
 @litchar{:} are originally based on the
-@hyperlink["https://github.com/tonyg/racket-something"]{#lang something}
+@hyperlink("https://github.com/tonyg/racket-something"){#lang something}
 reader, which also targets an underlying expander that
 further groups tokens. Shrubbery notation evolved away from using
 @litchar{{}} for blocks, however, because @litchar{:} was nearly always
@@ -17,7 +17,7 @@ be used. Freeing @litchar{{}} from use for blocks, meanwhile, allows its
 use for set and map notations.
 
 Shrubbery notation is also based on
-@hyperlink["https://github.com/jeapostrophe/racket2-rfcs/blob/lexpr/lexpr/0004-lexpr.md"]{Lexprs},
+@hyperlink("https://github.com/jeapostrophe/racket2-rfcs/blob/lexpr/lexpr/0004-lexpr.md"){Lexprs},
 particularly its use of @litchar{|}. Lexprs uses mandatory @litchar{:} and @litchar{|} tokens
 as a prefix for indentation, and it absorbs an additional line after
 an indented section to allow further chaining of the group. Although
@@ -27,7 +27,7 @@ in the case of @litchar{if}, in favor of @litchar{|} notation like other
 conditionals).
 
 Shrubbery notation is in some sense a follow-up to
-@hyperlink["https://github.com/mflatt/racket2-rfcs/blob/sapling/sapling/0005-sapling.md"]{sapling notation}.
+@hyperlink("https://github.com/mflatt/racket2-rfcs/blob/sapling/sapling/0005-sapling.md"){sapling notation}.
 The primary difference is that shrubbery notation is
 indentation-sensitive, while sapling notation is
 indentation-insensitive. Indentation sensitivity and block conventions

--- a/shrubbery/scribblings/rationale.scrbl
+++ b/shrubbery/scribblings/rationale.scrbl
@@ -4,7 +4,7 @@
 
 The lexeme-level syntax is chosen to be familiar to programmers
 generally. The sequence @litchar{1+2} is one plus two, not a strangely
-spelled identifier. Tokens like @litchar{(}, @litchar{,}, @litchar["{"]
+spelled identifier. Tokens like @litchar{(}, @litchar{,}, @litchar("{")
 and @litchar{;} are used in familiar ways. Shrubbery notation provides
 enough grouping structure that code navigation and transformation should
 be useful and straightforward in an editor.
@@ -84,13 +84,13 @@ operators, but the rule for continuing a group between @litchar{(} and
 @litchar{)} or @litchar{[} and @litchar{]} currently depends on
 distinguishing operators from non-operators.
 
-For @litchar["@"], the choice of treating @litchar|{@f[arg]{text}}| as
+For @litchar("@"), the choice of treating @litchar|{@f(arg){text}}| as
 @litchar{f(arg, ["text"])} instead of @litchar{f(arg, "text")} reflects
-experience with S-expression @litchar["@"] notation. Although it seems
+experience with S-expression @litchar("@") notation. Although it seems
 convenient that, say @litchar|{@bold{x}}| is treated as @litchar{(bold "x")},
 the consequence is that a function like @litchar{bold} might be
 implemented at first to take a single argument; later, a use like
 @litchar|{@bold{Hello @name}}| breaks, because two arguments are
 provided. Making explicit the list that's inherent in body parsing
 should help reduce such mistakes (or bad design choices) for functions
-that are meant to be used with @litchar["@"] notation.
+that are meant to be used with @litchar("@") notation.

--- a/shrubbery/scribblings/shrubbery.scrbl
+++ b/shrubbery/scribblings/shrubbery.scrbl
@@ -8,17 +8,17 @@
 
 Shrubbery notation is a set of text-level convention that build toward a
 full programming language, such as
-@seclink[~doc: [symbol(lib), "rhombus/scribblings/rhombus.scrbl"], "top"]{Rhombus}.
+@seclink(~doc: [symbol(lib), "rhombus/scribblings/rhombus.scrbl"], "top"){Rhombus}.
 The notation is line- and indentation-sensitive, and it is intended to partially group
 input, but leave further parsing to another layer, especially
-@seclink[~doc: [symbol(lib), "enforest/scribblings/enforest.scrbl"], "top"]{enforestation}.
+@seclink(~doc: [symbol(lib), "enforest/scribblings/enforest.scrbl"], "top"){enforestation}.
 The parsed form of a shrubbery imposes grouping to ensure that further
 parsing is consistent with the shrubbery's lines and indentation.
 
-@table_of_contents[]
+@table_of_contents()
 
-@include_section["example.scrbl"]
-@include_section["group-and-block.scrbl"]
-@include_section["lexeme-parsing.scrbl"]
-@include_section["parsed-representation.scrbl"]
-@include_section["meta.scrbl"]
+@include_section("example.scrbl")
+@include_section("group-and-block.scrbl")
+@include_section("lexeme-parsing.scrbl")
+@include_section("parsed-representation.scrbl")
+@include_section("meta.scrbl")

--- a/shrubbery/tests/input.rkt
+++ b/shrubbery/tests/input.rkt
@@ -1618,7 +1618,7 @@ INPUT
 (define input3
 #<<INPUT
 @(a, b)
-@(a, b)[0]
+@(a, b)(0)
 
 @[7]
 @{9}
@@ -1627,18 +1627,18 @@ then @[7]{8}
 then @{8}
 
 @apple{one}{two}
-@banana[0]{three}{four}{five}
+@banana(0){three}{four}{five}
 @coconut{six} {seven}
 
 @none{}
-@«5»[3]{yohoo @9[a, b, c]{
+@«5»(3){yohoo @9(a, b, c){
                this is plain text
                inside braces}
         0
         }
 
-@«bracketed»["apple"]
-@«{bracketed}»["apple"]
+@«bracketed»("apple")
+@«{bracketed}»("apple")
 
 @«1 2 3»: 5
 @«1 2 3»{data}: 5
@@ -1656,10 +1656,10 @@ then @{8}
   5 @// line comment
   6}
 
-@itemlist[@item{x
+@itemlist(@item{x
                 y},
           @item{z
-                w}]
+                w})
 
 @(in #{s-exp} mode)
 @{also in @(#{s-exp}) mode}
@@ -1672,10 +1672,10 @@ INPUT
   '(top
     (group (parens (group a) (group b)))
     (group (parens (group a) (group b)) (parens (group 0)))
-    (group (parens (group 7)))
+    (group (brackets (group 7)))
     (group (parens (group (brackets (group "9")))))
-    (group (parens (group 7) (group (brackets (group "8, 10 ") (group "more")))))
-    (group then (parens (group 7) (group (brackets (group "8")))))
+    (group (brackets (group 7)) (parens (group (brackets (group "8, 10 ") (group "more")))))
+    (group then (brackets (group 7)) (parens (group (brackets (group "8")))))
     (group then (parens (group (brackets (group "8")))))
     (group apple (parens (group (brackets (group "one")))
                          (group (brackets (group "two")))))


### PR DESCRIPTION
In Racket's S-expression `@` extension, `[]` is used for arguments, as in `@racket[(+ 1 2)]` or `@title[#:tag "ex"]{Example}`. 

In shrubbery notation, maybe it's better to use `()`, so that there's not such a big difference between `@` forms and the kind of function-call syntax that shrubbery notation is otherwise designed to enable. So, `@rhombus[1+2]` or `@title(~tag: "ex"){Example}`. The changes to `demo.rhm` in #229 motivated this experiment, especially the way `unwrap_syntax(a_ann)` changed to `@unwrap_syntax[a_ann]`.

To get a feel for how the change would play out, see parts of the Rhombus documentation implementation, such as https://github.com/mflatt/rhombus-prototype/blob/atparen/rhombus/scribblings/definition.scrbl.