### PR TITLE
Set equality methods

### DIFF
--- a/rhombus/private/set.rkt
+++ b/rhombus/private/set.rkt
@@ -25,7 +25,14 @@
 (module+ for-info
   (provide (for-syntax set-static-info)))
 
-(struct set (ht))
+(struct set (ht)
+  #:methods gen:equal+hash
+  [(define (equal-proc self other rec)
+     (rec (set-ht self) (set-ht other)))
+   (define (hash-proc self rec)
+     (+ (eq-hash-code struct:set) (rec (set-ht self))))
+   (define (hash2-proc self rec)
+     (+ (eq-hash-code struct:set) (rec (set-ht self))))])
 
 (define (set-member? s v)
   (hash-ref (set-ht s) v #f))

--- a/rhombus/tests/equality-map-set.rhm
+++ b/rhombus/tests/equality-map-set.rhm
@@ -105,6 +105,7 @@ begin:
 
 // empty map, not empty set
 check: {}; Map()
+check: {} == Set(); #false
 check: {"a": 1, "b": 2}; {"b": 2, "a": 1}
 begin:
   val a: mcons(1, 2)

--- a/rhombus/tests/equality-map-set.rhm
+++ b/rhombus/tests/equality-map-set.rhm
@@ -102,3 +102,20 @@ begin:
   check:
     s[c]
     #false
+
+// empty map, not empty set
+check: {}; Map()
+check: {"a": 1, "b": 2}; {"b": 2, "a": 1}
+begin:
+  val a: mcons(1, 2)
+  val b: mcons(1, 2)
+  check: {a: 1, b: 2}; {b: 2, a: 1}
+  check: {a: 1} == {b: 1}; #false
+
+check: Set(); Set()
+check: {"a", "b"}; Set("a", "b")
+begin:
+  val a: mcons(1, 2)
+  val b: mcons(1, 2)
+  check: {a, b}; {b, a}
+  check: {a} == {b}; #false


### PR DESCRIPTION
Implements `gen:equal+hash` for the `set` struct in `rhombus/private/set.rkt`, and adds more tests for equality of sets and maps.