### PR TITLE
Add Map.empty a binding as well as an expression

### DIFF
--- a/enforest/scribblings/macro-protocol.scrbl
+++ b/enforest/scribblings/macro-protocol.scrbl
@@ -24,7 +24,7 @@ as an already-parsed term and need not conform to the shrubbery
 grammar's representation. Since the list starting @racket_q_parsed
 itself has no shrubbery representation, it's conveniently opaque to a
 shrubbery layer of patterning matching. For example, in the earlier
-example implementing the @rhombus[->] macro infix operator,
+example implementing the @rhombus(->) macro infix operator,
 
 @(rhombusblock:
     expr.macro '($x -> $y $tail ...)':
@@ -32,23 +32,23 @@ example implementing the @rhombus[->] macro infix operator,
   )
 
 the macro transformer receives an syntax-object representing the
-already-parsed left-hand argument @rhombus[x] as a @racket_q_parsed
+already-parsed left-hand argument @rhombus(x) as a @racket_q_parsed
 list. The macro therefore has no way to pull the expression apart,
 inspect it, or rearrange it. Of course, such facilities could be made
 available to the macro transformer in lower-level form. Meanwhile,
-@rhombus[y] and @rhombus[tail] are likely unparsed terms, that can be
+@rhombus(y) and @rhombus(tail) are likely unparsed terms, that can be
 inspected—although it's possible that some other macro constructs a
-@rhombus[->] expression using already-parsed terms, in which case they
-are similarly opaque to the @rhombus[->] transformer.
+@rhombus(->) expression using already-parsed terms, in which case they
+are similarly opaque to the @rhombus(->) transformer.
 
-For binding-operator macros, @Rhombus includes @rhombus[bind.unpack] to
+For binding-operator macros, @Rhombus includes @rhombus(bind.unpack) to
 expose certain pieces of a binding's implementation, which allows the
 macro to compose or adjust other binding expansions. New binding pieces
-can be put back together into a parsed form using @rhombus[bind.pack].
+can be put back together into a parsed form using @rhombus(bind.pack).
 
 Some contexts may oblige a macro transformer to consume all of the
 remaining terms in a group. For example, a definition or declaration
-context based on prefix identifiers like @rhombus[import],
-@rhombus[val], @rhombus[fun], and @rhombus[struct] might report an error
+context based on prefix identifiers like @rhombus(import),
+@rhombus(val), @rhombus(fun), and @rhombus(struct) might report an error
 if a transformer does not consume all available terms (and that's the
 case in @Rhombus).

--- a/rhombus/private/binding.rkt
+++ b/rhombus/private/binding.rkt
@@ -110,9 +110,13 @@
 
   (define in-binding-space (make-interned-syntax-introducer/add 'rhombus/binding))
 
+  ;; conservative: can return #true when unknown
+  (define (might-be-binding? v)
+    (or (binding-prefix-operator? v) (portal-syntax? v)))
+
   (define-syntax-class :non-binding-identifier
     (pattern id:identifier
-             #:when (not (syntax-local-value* (in-binding-space #'id) binding-prefix-operator?)))))
+             #:when (not (syntax-local-value* (in-binding-space #'id) might-be-binding?)))))
 
 (define-syntax (identifier-info stx)
   (syntax-parse stx

--- a/rhombus/private/literal.rkt
+++ b/rhombus/private/literal.rkt
@@ -21,7 +21,7 @@
 (define-syntax (literal-matcher stx)
   (syntax-parse stx
     [(_ arg-id datum IF success fail)
-     #'(IF (equal? arg-id (quote datum))
+     #'(IF (equal-always? arg-id (quote datum))
            success
            fail)]))
 

--- a/rhombus/private/map.rkt
+++ b/rhombus/private/map.rkt
@@ -5,8 +5,10 @@
                      "srcloc.rkt"
                      "with-syntax.rkt")
          "expression.rkt"
+         "expression+binding.rkt"
          "binding.rkt"
          (submod "annotation.rkt" for-class)
+         "literal.rkt"
          "static-info.rkt"
          "ref-result-key.rkt"
          "map-ref-set-key.rkt"
@@ -48,7 +50,21 @@
                [else (loop (hash-set ht (car args) (cadr args)) (cddr args))])))])
     Map))
 
-(define empty-map #hash())
+(define-syntax empty-map
+  (make-expression+binding-prefix-operator
+   #'empty-map
+   '((default . stronger))
+   'macro
+   ;; expression
+   (lambda (stx)
+     (syntax-parse stx
+       [(form-id . tail)
+        (values #'#hashalw() #'tail)]))
+   ;; binding
+   (lambda (stx)
+     (syntax-parse stx
+       [(form-id . tail)
+        (values (binding-form #'literal-infoer #'#hashalw()) #'tail)]))))
 
 (define-name-root Map
   #:fields
@@ -104,7 +120,10 @@
                   (#%map-set! hash-set!)
                   (#%sequence-constructor in-hash))))
 
-(define-binding-syntax Map
+(define-name-root Map
+  #:space rhombus/binding
+  #:fields ([empty empty-map])
+  #:root
   (binding-prefix-operator
    #'Map
    '((default . stronger))

--- a/rhombus/scribblings/ref-map.scrbl
+++ b/rhombus/scribblings/ref-map.scrbl
@@ -129,3 +129,31 @@ operator. These uses of square brackets are implemented by
 )
 
 }
+
+@doc(
+  bind.macro 'Map.empty',
+  expr.macro 'Map.empty'
+){
+
+ An empty map. Differs from @rhombus({}) and @rhombus(Map())
+ because while those as binding forms match any maps
+ including ones with extra keys, @rhombus(Map.empty, ~bind) as a
+ binding only matches empty maps, with no keys.
+
+@examples(
+  Map.empty,
+  match {}
+  | Map.empty: "empty map"
+  | _: #false,
+  match {"x": 1, "y": 2}
+  | Map.empty: "empty map"
+  | _: #false,
+  match {"x": 1, "y": 2}
+  | {}: "curly braces allow extra"
+  | _: #false,
+  match {"x": 1, "y": 2}
+  | Map(): "Map binding allows extra"
+  | _: #false,
+)
+
+}

--- a/rhombus/tests/equality-map-set.rhm
+++ b/rhombus/tests/equality-map-set.rhm
@@ -4,6 +4,10 @@ import:
   racket/base open:
     only: mcons
 
+use_static_dot
+
+class Posn(x, y)
+
 check:
   "apple" == "apple"
   #true
@@ -124,6 +128,27 @@ check:
   | {}: "{}"
   | _: #false
   "{}"
+
+def local_map: Map(symbol(alice), Posn(4, 5),
+                   symbol(bob), Posn(7, 9))
+
+fun locale(who, neighborhood :: Map.of(Symbol, Posn)):
+  val p: neighborhood[who]
+  p.x +& ", " +& p.y
+
+check:
+  locale(symbol(alice), local_map)
+  "4, 5"
+
+def {symbol(bob): bob_loc}: local_map
+check:
+  bob_loc
+  Posn(7, 9)
+
+def Map(symbol(alice), alice_loc2, symbol(bob), bob_loc2): local_map
+check:
+  [alice_loc2, bob_loc2]
+  [Posn(4, 5), Posn(7, 9)]
 
 check: Set(); Set()
 check: {"a", "b"}; Set("a", "b")

--- a/rhombus/tests/equality-map-set.rhm
+++ b/rhombus/tests/equality-map-set.rhm
@@ -106,12 +106,24 @@ begin:
 // empty map, not empty set
 check: {}; Map()
 check: {} == Set(); #false
+check: Map.empty; {}
 check: {"a": 1, "b": 2}; {"b": 2, "a": 1}
 begin:
   val a: mcons(1, 2)
   val b: mcons(1, 2)
   check: {a: 1, b: 2}; {b: 2, a: 1}
   check: {a: 1} == {b: 1}; #false
+check:
+  match {}
+  | Map.empty: "Map.empty"
+  | _: #false
+  "Map.empty"
+check:
+  match {"a": 1}
+  | Map.empty: "Map.empty"
+  | {}: "{}"
+  | _: #false
+  "{}"
 
 check: Set(); Set()
 check: {"a", "b"}; Set("a", "b")


### PR DESCRIPTION
An empty map. Differs from `{}` and `Map()` because while those as binding forms match any maps including ones with extra keys, `Map.empty` as a binding only matches empty maps, with no keys.

Also changes `Map.empty` to a `hashalw`, not an equal-based `hash`.