### PR TITLE
demo: fix at-exp calls [] -> ()

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -602,12 +602,12 @@ weirdly ++ "none"
 '@x'
 '@f{text}'
 '@f{text}{another text}'
-'@f[x, y]{This is plain text.}'
-'@f[x, y]'
+'@f(x, y){This is plain text.}'
+'@f(x, y)'
 '@{text}'
-'@[x, y]{text}'
-'@« library.f »[x, y]{Text with @escape[].}'
-'@(library.f)[x, y]{Text with @« escape ».}'
+'@(x, y){text}'
+'@« library.f »(x, y){Text with @escape().}'
+'@(library.f)(x, y){Text with @« escape ».}'
 '@explain{Multi-line text
            has newlines as separate
            and leading whitespace

--- a/demo.rhm
+++ b/demo.rhm
@@ -605,7 +605,7 @@ weirdly ++ "none"
 '@f(x, y){This is plain text.}'
 '@f(x, y)'
 '@{text}'
-'@(x, y){text}'
+'@[x, y]{text}'
 '@« library.f »(x, y){Text with @escape().}'
 '@(library.f)(x, y){Text with @« escape ».}'
 '@explain{Multi-line text


### PR DESCRIPTION
Since at-exp `[]` was changed to `()` in https://github.com/racket/rhombus-prototype/pull/238 and `[]` was made an error in https://github.com/racket/rhombus-prototype/commit/50d8ccec547867aea142eed0adb80c45ae4ce395, this fixes `demo.rhm`'s instances of `[]` to use `()` instead.

The only other places where searching with the regexp `@[^({]*\[.*\]` turns up any results in files that (possibly) should use the Rhombus version of `@` at notation are in these 4 lines of `shrubbery/tests/color.rkt`:
```
@a{@//^{@a[apple]{banana}}^ 2}
@a{@//^{@a[apple]{banana @//{nested}}}^ 2}
@a{@//^{@a[apple]{banana @//{@[#//nested]}}}^ 2}
@a{@a[apple]{banana @[#//^nested^]} 2}
```
These 5 lines of `shrubbery/tests/input.rkt`:
```
@[7]
@{9}
@[7]{8, 10 @"more"}
then @[7]{8}
then @{8}
```
And of course this failure test:
```
(check-fail "@x[1]{2}" #rx"cannot start `[[]`")
```

All those other tests seem to be passing though, so the only one I "fixed" was `demo.rhm`.