### PR TITLE
`&` is not supported in combination with `...`

### DIFF
--- a/rhombus/scribblings/more-arguments.scrbl
+++ b/rhombus/scribblings/more-arguments.scrbl
@@ -136,7 +136,7 @@ matching to distinguish calls with the same number of arguments.
 )
 
 A function definition or call can use both @rhombus(&) and @rhombus(~&)
-in either order at the end of an argument sequence. A @rhombus(~&) is
+in either order at the end of an argument sequence. A @rhombus(&) is
 not supported in combination with a @rhombus(...) repetition.
 
 @close_eval(args_eval)

--- a/rhombus/tests/rest-args.rhm
+++ b/rhombus/tests/rest-args.rhm
@@ -317,3 +317,21 @@ fun posns_y(p :: Posn, ...):
 check:
   posns_y(Posn(1, 2), Posn(3, 4), Posn(5, 6))
   4
+
+// ---------------------------
+// Combinations of Positional and Keyword Rest
+
+// Positional rest can be either `&` rest or `...` repetition rest.
+// `~&` keyword rest is compatible with either kind of positional rest,
+// so `~&` and `...` are compatible even though `&` and `...` are not.
+// Positional and keyword rest can be in either order.
+fun anyargs_lm(& l, ~& m): [l, m]
+fun anyargs_ml(~& m, & l): [l, m]
+fun anyargs_rm(r, ..., ~& m): [[r, ...], m]
+fun anyargs_mr(~& m, r, ...): [[r, ...], m]
+
+for:
+  ~each anyargs: [anyargs_lm, anyargs_ml, anyargs_rm, anyargs_mr]
+  check:
+    anyargs("a", "b", ~c: "do", ~d: "re", ~e: "mi")
+    [["a", "b"], {keyword'~c': "do", keyword'~d': "re", keyword'~e': "mi"}]


### PR DESCRIPTION
This adds tests for combinations of both kinds of positional rest with keyword rest arguments, and corrects the documentation to say that `&` is not supported in combination with `...`.