### PR TITLE
allow `=` instead of `:` in `def`, `let`, and `field`

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -58,17 +58,17 @@ md2(Posn(1, 4))
 
 // more definitions
 
-def π: 3.14
+def π = 3.14
 π
 
-def (((ππ))): π * π
+def (((ππ))) = π * π
 ππ
 
 def (ma, mb, mc):
   values("1", "2", "3")
 mb
-  
-def List.cons(ca, cb): List.cons(1, [2])
+
+def List.cons(ca, cb) = List.cons(1, [2])
 ca
 
 fun
@@ -82,10 +82,10 @@ fun
 size(Posn(8, 6))
 size(1, 2)
 
-def Posn(px, py) -: Posn: Posn(1, 2)
+def Posn(px, py) -: Posn = Posn(1, 2)
 List(px, py)
 
-def identity: fun (x): x
+def identity = fun (x): x
 identity(1 + (fun (x): x) (99) )
 
 size
@@ -210,8 +210,8 @@ bind.macro '$a <> $b':
                    ($a, $b))')
 
 bind.infoer 'build_reverse_cons_infoer($in_id, ($a_in, $b_in))':
-  def a: bind_meta.get_info(a_in, '()')
-  def b: bind_meta.get_info(b_in, '()')
+  def a = bind_meta.get_info(a_in, '()')
+  def b = bind_meta.get_info(b_in, '()')
   match bind_meta.unpack_info(a)
   | '($a_ann, $a_id, $a_info, ($a_bind_info, ...), $a_matcher, $a_binder, $a_data)':
       match bind_meta.unpack_info(b)
@@ -262,7 +262,7 @@ bind.binder 'build_reverse_cons_bind($in_id, ($a, $b, $a_part_id, $b_part_id))':
 // an expression operator that's consistent with the pattern
 expr.rule '$a <> $b': ~parsed_right; 'Pair.cons($b, $a)'
 
-def rx <> (ry :: Integer) : "2" <> 1
+def rx <> (ry :: Integer) = "2" <> 1
 rx
 
 // definition form, which returns either a block of definitions
@@ -271,7 +271,7 @@ rx
 defn.macro 'define_eight $e ...':
   match '$e ...'
   | '$name':
-      'def $name: 8'
+      'def $name = 8'
        
 define_eight ate
 ate
@@ -304,7 +304,7 @@ let accum: accum+1
 let accum: accum+1
 accum
 
-def ok_later: "ok"
+def ok_later = "ok"
 check_later()
 
 // Nested class types with contracts
@@ -313,7 +313,7 @@ class IPosn(x :: Integer, y :: Integer)
 
 class ILine(p1 :: IPosn, p2 :: IPosn)
 
-def l1: ILine(IPosn(1, 2), IPosn(3, 4))
+def l1 = ILine(IPosn(1, 2), IPosn(3, 4))
 
 l1.p2.x
 
@@ -325,7 +325,7 @@ ILine.p1(l1).x
 fun (p): (p :: IPosn).x
 
 begin:
-  def ILine(p1, p2): l1
+  def ILine(p1, p2) = l1
   p1.x + p2.y
 
 // function result contracts
@@ -348,7 +348,7 @@ add_two(7) .= 9.0
 add_two(6, 7) == "6 and 7"
 
 begin:
-  def f: fun (x) :: Integer: x
+  def f = fun (x) :: Integer: x
   f(10)
 
 fun on_diag(n :: Integer) :: Posn:
@@ -356,7 +356,7 @@ fun on_diag(n :: Integer) :: Posn:
 
 on_diag(1).x
 
-def known_posn: on_diag(2)
+def known_posn = on_diag(2)
 known_posn.x
 
 // contracts and dot providers
@@ -389,7 +389,7 @@ let vec :: Vector: Posn(3, 4)
 vec.angle
 vec.magnitude
 
-def AlsoPosn(also_x, also_y): Posn(10, 20)
+def AlsoPosn(also_x, also_y) = Posn(10, 20)
 also_x +& "," +& also_y
 
 expr.macro 'or_zero $p $tail ...':
@@ -414,18 +414,18 @@ begin:
 
 // indexables
 
-def nums: [1, 2, 3]
-def yes_nums :: List: nums
-def yep_nums :: List.of(Integer): nums
+def nums = [1, 2, 3]
+def yes_nums :: List = nums
+def yep_nums :: List.of(Integer) = nums
 
 nums[1]
 
 begin:
   use_dynamic
-  def also_nums: if #true | nums | #false
+  def also_nums = if #true | nums | #false
   also_nums[1]
 
-def nums_a: Array(1, 2, 3)
+def nums_a = Array(1, 2, 3)
 def yes_nums_a :: Array: nums_a
 def yep_nums_a :: Array.of(Integer): nums_a
 
@@ -433,36 +433,36 @@ nums_a[1]
 nums_a[2] := 30
 nums_a[2]
 
-def map: Map{symbol'x': "hello", symbol(y): "goodbye"}
-def yes_map :: Map : map
-def yup_map :: Map.of(Symbol, String) : map
+def map = Map{symbol'x': "hello", symbol(y): "goodbye"}
+def yes_map :: Map = map
+def yup_map :: Map.of(Symbol, String) = map
 
 map
 map[symbol'y']
 
-def also_map: Map([1, "one"], [2, "two"])
+def also_map = Map([1, "one"], [2, "two"])
 also_map[2]
 
-def also_also_map: {1: "one", 2: "two"}
+def also_also_map = {1: "one", 2: "two"}
 also_also_map[2]
 
-def key_map: {symbol'a': "ay", symbol'b': "bee"}
+def key_map = {symbol'a': "ay", symbol'b': "bee"}
 key_map[symbol'a']
 
-def mixed_map: {symbol'a': 1, "b": 2}
+def mixed_map = {symbol'a': 1, "b": 2}
 mixed_map[symbol'a'] + mixed_map["b"]
 
-def mut_map: MutableMap([1, "mone"])
+def mut_map = MutableMap([1, "mone"])
 mut_map[1]
 mut_map[2] := "mtwo"
 mut_map[2]
 
-def a_set: {1, 3, 5, 7, 9}
+def a_set = {1, 3, 5, 7, 9}
 if a_set[1] && !a_set[2]
 | "ok"
 | 1/0
 
-def [x, y, ...]: nums
+def [x, y, ...] = nums
 [y, ...]
 
 [100, 1000, & nums]
@@ -476,28 +476,28 @@ def [x, y, ...]: nums
 
 (fun(y, z): z)(y, ...)
 
-def Array(ax, ay, az): nums_a
+def Array(ax, ay, az) = nums_a
 az
 
-def local_map: Map{symbol'alice': Posn(4, 5),
-                   symbol'bob': Posn(7, 9)}
+def local_map = Map{symbol'alice': Posn(4, 5),
+                    symbol'bob': Posn(7, 9)}
 
 fun locale(who, neighborhood :: Map.of(Symbol, Posn)):
-  def p: neighborhood[who]
+  def p = neighborhood[who]
   p.x +& ", " +& p.y
 
 locale(symbol'alice', local_map)
 
-def {symbol'bob': bob_loc}: local_map
+def {symbol'bob': bob_loc} = local_map
 bob_loc
 
-def Map{symbol'alice': alice_loc2, symbol'bob': bob_loc2}: local_map
+def Map{symbol'alice': alice_loc2, symbol'bob': bob_loc2} = local_map
 [alice_loc2, bob_loc2]
 
-def Map([symbol'alice', also_alice_loc2], [symbol'bob', also_bob_loc2]): local_map
+def Map([symbol'alice', also_alice_loc2], [symbol'bob', also_bob_loc2]) = local_map
 [also_alice_loc2, also_bob_loc2]
 
-def [p :: Posn, ...] : [Posn(1, 2), Posn(3, 4)]
+def [p :: Posn, ...] = [Posn(1, 2), Posn(3, 4)]
 [p, ...][0].x
 
 fun
@@ -519,10 +519,10 @@ got_milk(["apple", "milk", "banana"])
 got_milk(["apple", "coffee", "banana"])
 
 begin:
- def [n, ...]: [3, 4]
+ def [n, ...] = [3, 4]
  List(1, 2, n, ...)
 
-def nested_p :: Posn.of(Integer, Posn.of(Integer, Integer)): Posn(1, Posn(3, 4))
+def nested_p :: Posn.of(Integer, Posn.of(Integer, Integer)) = Posn(1, Posn(3, 4))
 nested_p.y.x
 
 // rest arguments
@@ -586,8 +586,8 @@ defn.sequence_macro 'reverse_defns; $defn1 ...; $defn2 ...; $tail; ...':
   values('$defn2 ...; $defn1 ...', '$tail; ...')
 
 reverse_defns
-def seq_x: seq_y+1
-def seq_y: 10
+def seq_x = seq_y+1
+def seq_y = 10
 
 seq_x
 
@@ -645,17 +645,17 @@ annot.macro 'MyInt':
                                    '(($(statinfo_meta.dot_provider_key), myint_dot_provider))'),
          '')
 
-def (one -: MyInt): 1
+def (one -: MyInt) = 1
 
 one.add(4).is_zero
 
 ((one.add(4)) -: MyInt).is_zero
 
-def two: 2 :: MyInt
+def two = 2 :: MyInt
 two.is_zero
 
 expr.rule 'I($n)': '$n -: MyInt'
-def three: (I(3))
+def three = (I(3))
 three.is_zero
 
 operator ((x -: MyInt) my_plus (y -: MyInt)) -: MyInt:
@@ -705,7 +705,7 @@ for values(x = 0, y = 2):
 fun grid2(m, n):
   for List:
     each i: 0..m
-    def k: i + 1
+    def k = i + 1
     each j: 0..n
     [k, j]
 
@@ -734,7 +734,7 @@ syntax.class Arithmetic
 | '$x + $y'
 | '$x - $y'
 
-def '$(exp :: Arithmetic)': '1 + 2'
+def '$(exp :: Arithmetic)' = '1 + 2'
 exp.x
 
 meta:
@@ -778,7 +778,7 @@ syntax.class NTerms
     ~attr average:
       '$(sum / 2)'
 
-def '$(two_terms :: NTerms)': '~two 24 42'
+def '$(two_terms :: NTerms)' = '~two 24 42'
 two_terms.a
 two_terms.c
 two_terms.average

--- a/rhombus/private/class-clause-parse.rkt
+++ b/rhombus/private/class-clause-parse.rkt
@@ -16,6 +16,7 @@
          "parens.rkt"
          "name-root-ref.rkt"
          "parse.rkt"
+         "var-decl.rkt"
          (only-in "function.rkt" fun)
          (only-in "implicit.rkt" #%body))
 
@@ -53,7 +54,6 @@
                      (lambda (stx) stx)))
   (values internal-id
           (expose internal-id)))
-  
 
 (define-for-syntax (extract-rhs b)
   (syntax-parse b
@@ -328,14 +328,13 @@
   (define-splicing-syntax-class (:field mode)
     #:description "field identifier with optional annotation"
     #:attributes (form)
-    (pattern (~seq form-id bind ...
-                   (~and blk (_::block . _)))
-             #:with (id:identifier (~optional c::unparsed-inline-annotation)) #'(bind ...)
+    (pattern (~seq form-id d::var-decl)
+             #:with (id:identifier (~optional c::unparsed-inline-annotation)) #'(d.bind ...)
              #:attr ann-seq (if (attribute c)
                                 #'c.seq
                                 #'#f)
              #:attr form (wrap-class-clause #`(field id
-                                                     tmp-id ann-seq blk form-id
+                                                     tmp-id ann-seq d.blk form-id
                                                      #,mode)))))
 
 (define-syntax field

--- a/rhombus/private/class-field.rkt
+++ b/rhombus/private/class-field.rkt
@@ -11,12 +11,16 @@
   (for/list ([added (in-list added-fields)])
     (with-syntax ([id (added-field-id added)]
                   [tmp-id (added-field-arg-id added)]
-                  [blk (added-field-arg-blk added)]
+                  [rhs (let ([blk (added-field-arg-blk added)])
+                         (syntax-parse blk
+                           #:datum-literals (block)
+                           [(block . _) #`(rhombus-body-at . #,blk)]
+                           [_ #`(rhombus-expression #,blk)]))]
                   [predicate (added-field-predicate added)]
                   [annotation-str (added-field-annotation-str added)]
                   [form-id (added-field-form-id added)])
       #`(define tmp-id (lambda ()
-                         (let ([id (rhombus-body-at . blk)])
+                         (let ([id rhs])
                            #,(if (syntax-e #'predicate)
                                  #`(if (predicate id)
                                        id

--- a/rhombus/private/equal.rkt
+++ b/rhombus/private/equal.rkt
@@ -5,6 +5,10 @@
 
 (provide (rename-out [rhombus= =]))
 
+(module+ for-parse
+  (provide (for-syntax :equal
+                       :not-equal)))
+
 (define-syntax rhombus=
   (make-expression+binding-infix-operator
    #'rhombus=
@@ -27,3 +31,13 @@
         (raise-syntax-error #f
                             "not a binding operator"
                             #'o)]))))
+
+(begin-for-syntax
+  (define-syntax-class :equal
+    #:datum-literals (op)
+    #:literals (rhombus=)
+    (pattern (op rhombus=)))
+  (define-syntax-class :not-equal
+    #:datum-literals (op)
+    #:literals (rhombus=)
+    (pattern (~not (op rhombus=)))))

--- a/rhombus/private/parse.rkt
+++ b/rhombus/private/parse.rkt
@@ -257,6 +257,9 @@
        [else
         (syntax-parse #'g
           [g-e::expression #'g-e.parsed])])]
+    [((~datum group) . _)
+     (syntax-parse e
+       [g-e::expression #'g-e.parsed])]
     [((~datum block) g ...) #`(rhombus-body g ...)]))
 
 ;; Forces enforestation through `rhombus-expression`; note that

--- a/rhombus/private/var-decl.rkt
+++ b/rhombus/private/var-decl.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse
+                     "tag.rkt")
+         (submod "equal.rkt" for-parse)
+         "parens.rkt")
+
+(provide (for-syntax :var-decl))
+
+(begin-for-syntax
+  (define-splicing-syntax-class :var-decl
+    #:datum-literals (group block)
+    #:attributes ([bind 1] blk)
+    (pattern (~seq bind::not-equal ...+ _::equal rhs ...+)
+             #:attr blk #`(#,group-tag rhs ...))
+    (pattern (~seq bind ...+ (~and rhs (_::block . _)))
+             #:attr blk #'rhs)))
+

--- a/rhombus/scribblings/annotation-vs-bind.scrbl
+++ b/rhombus/scribblings/annotation-vs-bind.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def ann_eval: make_rhombus_eval())
+@(def ann_eval = make_rhombus_eval())
 
 @examples(
   ~eval: ann_eval,

--- a/rhombus/scribblings/annotation.scrbl
+++ b/rhombus/scribblings/annotation.scrbl
@@ -3,14 +3,14 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def ann_eval: make_rhombus_eval())
+@(def ann_eval = make_rhombus_eval())
 
 @examples(
   ~eval: ann_eval,
   ~hidden: #true,
   class Posn(x, y),
   fun flip(p -: Posn): Posn(p.y, p.x),
-  def origin: Posn(0, 0)
+  def origin = Posn(0, 0)
 )
 
 @title(~tag: "annotation"){Annotations and the Dot Operator}

--- a/rhombus/scribblings/bind-macro.scrbl
+++ b/rhombus/scribblings/bind-macro.scrbl
@@ -19,7 +19,7 @@ as a prefix operator to constrain a pattern to number inputs:
         ~parsed_right
         '$n :: Number'
     ~repl:
-      def $$$salary: 100.0
+      def $$$salary = 100.0
 
       salary
   )

--- a/rhombus/scribblings/definition.scrbl
+++ b/rhombus/scribblings/definition.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def posn_eval: make_rhombus_eval())
+@(def posn_eval = make_rhombus_eval())
 
 @title(~tag: "classes_and_patterns"){Classes and Patterns}
 
@@ -23,7 +23,7 @@ extracts the field value from the instance.
 @(demo:
     ~eval: posn_eval
     ~defn:
-      def origin: Posn(0, 0)
+      def origin = Posn(0, 0)
     ~repl:
       origin
       origin.x
@@ -103,7 +103,7 @@ in any binding position, including the one for @rhombus(def):
 @(demo:
     ~eval: posn_eval
     ~defn:
-      def (flipped -: Posn):  flip(Posn(1, 2))
+      def (flipped -: Posn) = flip(Posn(1, 2))
     ~repl:
       flipped.x
   )
@@ -195,14 +195,14 @@ visible before the @rhombus(let) form.
 @(rhombusblock:
     #lang rhombus
 
-    def get_after(): after
+    fun get_after(): after
 
-    def accum: 0
-    let accum: accum+1
-    let accum: accum+1
+    def accum = 0
+    let accum = accum+1
+    let accum = accum+1
     accum  // prints 2
 
-    def after: 3
+    def after = 3
     get_after()  // prints 3
   )
 

--- a/rhombus/scribblings/defn-macro.scrbl
+++ b/rhombus/scribblings/defn-macro.scrbl
@@ -20,7 +20,7 @@ Here’s the classic @rhombus(def_five) macro:
         rhombus/meta open
 
       defn.macro 'def_five $id':
-        'def $id: 5'
+        'def $id = 5'
     ~repl:
       def_five v
       v

--- a/rhombus/scribblings/expr-macro.scrbl
+++ b/rhombus/scribblings/expr-macro.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def macro_eval: make_rhombus_eval())
+@(def macro_eval = make_rhombus_eval())
 
 @title(~tag: "expr-macro"){Expression Macros}
 

--- a/rhombus/scribblings/for.scrbl
+++ b/rhombus/scribblings/for.scrbl
@@ -42,7 +42,7 @@ languages, is that definitions or expressions can be written among
 @(demo:
     for:
       each friend: ["Alice", "Bob", "Carol"]
-      def dear_friend: "dear " +& friend
+      def dear_friend = "dear " +& friend
       each say: ["Hello", "Goodbye"]
       displayln(say +& ", " +& dear_friend +& "!")
 )

--- a/rhombus/scribblings/function.scrbl
+++ b/rhombus/scribblings/function.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def posn_eval: make_rhombus_eval())
+@(def posn_eval = make_rhombus_eval())
 
 @examples(
   ~eval: posn_eval,
@@ -31,9 +31,9 @@ an anonymous function value.
 
 @(demo:
     ~defn:
-      def curried_add: fun (x):
-                         fun (y):
-                           x+y
+      def curried_add = fun (x):
+                          fun (y):
+                            x+y
     ~repl:
       curried_add(10)(20)
   )

--- a/rhombus/scribblings/list.scrbl
+++ b/rhombus/scribblings/list.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def list_eval: make_rhombus_eval())
+@(def list_eval = make_rhombus_eval())
 
 @examples(
   ~eval: list_eval,
@@ -115,7 +115,7 @@ be used multiple times.
 @(demo:
     ~eval: list_eval
     ~defn:
-      def [groceries, ...]: ["apple", "banana", "milk"]
+      def [groceries, ...] = ["apple", "banana", "milk"]
     ~repl:
       [groceries, ..., "cupcake"]
       [groceries, ..., groceries, ...]
@@ -128,7 +128,7 @@ or reference a plain list value whose elements are the rest of the list.
 @(demo:
     ~eval: list_eval
     ~defn:
-      def [x, & others]: [groceries, ...]
+      def [x, & others] = [groceries, ...]
     ~repl:
       others
       ["broccoli", & others ++ ["cupcake"], x]

--- a/rhombus/scribblings/map.scrbl
+++ b/rhombus/scribblings/map.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def map_eval: make_rhombus_eval())
+@(def map_eval = make_rhombus_eval())
 
 @examples(
   ~eval: map_eval,
@@ -22,7 +22,7 @@ for assignment.
 
 @(demo:
     ~defn:
-      def buckets: Array(1, 2, 3, 4)
+      def buckets = Array(1, 2, 3, 4)
     ~repl:
       buckets[0]
       buckets[1] := 5
@@ -44,8 +44,8 @@ which case it accepts keys paired with values in two-item lists:
 @(demo:
     ~eval: map_eval
     ~defn:
-      def neighborhood: Map(["alice", Posn(4, 5)],
-                            ["bob", Posn(7, 9)])
+      def neighborhood = Map(["alice", Posn(4, 5)],
+                             ["bob", Posn(7, 9)])
     ~repl:
       neighborhood["alice"]
       ~error: neighborhood["clara"]
@@ -59,8 +59,8 @@ itself, the expression will have to be in parentheses.)
 @(demo:
     ~eval: map_eval
     ~defn:
-      def neighborhood: {"alice": Posn(4, 5),
-                         "bob": Posn(7, 9)}
+      def neighborhood = {"alice": Posn(4, 5),
+                          "bob": Posn(7, 9)}
     ~repl:
       neighborhood["alice"]
   )
@@ -115,7 +115,7 @@ for keys and one for values:
     ~eval: map_eval
     ~defn:
       fun locale(who, neighborhood -: Map.of(String, Posn)):
-        def p: neighborhood[who]
+        def p = neighborhood[who]
         p.x +& ", " +& p.y
     ~repl:
       locale("alice", neighborhood)
@@ -135,8 +135,8 @@ using @litchar{[}...@litchar{]} with @rhombus(:=) just like an array.
 @(demo:
     ~eval: map_eval
     ~defn:
-      def locations: MutableMap{"alice": Posn(4, 5),
-                                "bob": Posn(7, 9)}
+      def locations = MutableMap{"alice": Posn(4, 5),
+                                 "bob": Posn(7, 9)}
     ~repl:
       locations["alice"] := Posn(40, 50)
       locations["alice"]
@@ -151,7 +151,7 @@ binds with lists. In a map @litchar("{")...@litchar("}") expression,
 @(demo:
     ~eval: map_eval
     ~defn:
-      def {"bob": bob_home, & others}: neighborhood
+      def {"bob": bob_home, & others} = neighborhood
     ~repl:
       others
       {& others, "clara": Posn(8, 2)}

--- a/rhombus/scribblings/module.scrbl
+++ b/rhombus/scribblings/module.scrbl
@@ -23,7 +23,7 @@ module, then its value gets printed out.
 
 The ways to define names in a module include @rhombus(def) and
 @rhombus(fun). The @rhombus(def) form defines an immutable variable, and
-it expects an identifier to define followed by a block. The
+it expects an identifier to define followed by either @rhombus(=) or a block. The
 @rhombus(fun) form defines a function when it see an identifier,
 parentheses around argument names, and then a block. Function calls have
 the usual shape: a function name (or, more generally, an expression that
@@ -33,7 +33,7 @@ parentheses.
 @(rhombusblock:
     #lang rhombus
 
-    def fahrenheit_freezing: 32
+    def fahrenheit_freezing = 32
                              
     fun fahrenheit_to_celsius(f):
       (f - 32) * 5/9
@@ -56,6 +56,18 @@ parentheses.
  Use can use the @litchar{,enter} command to load a module and evaluate
  additional expressions in the context of that module's body.}
 
+The definition of @rhombus(fahrenheit_freezing) could also have been
+written with @litchar{:} instead of @rhombus(=), like this:
+
+@(rhombusblock:
+    def fahrenheit_freezing: 32
+  )
+
+By convention, however, @rhombus(=) is used for single expressions, while
+@litchar{:} is useful for multi-line definitions and blocks. A @rhombus(=) is
+interchangable for @litchar{:} only in certain forms, like
+@rhombus(def).
+
 A Rhombus module can export definitions to other modules using
 @rhombus(export), and it can import other modules using
 @rhombus(import). The @litchar{#lang rhombus} line is a kind of
@@ -71,7 +83,7 @@ definitions.
       fahrenheit_freezing
       fahrenheit_to_celsius
 
-    def fahrenheit_freezing: 32
+    def fahrenheit_freezing = 32
 
     fun fahrenheit_to_celsius(f):
       (f - 32) * 5/9)
@@ -135,7 +147,7 @@ are shown with a leading @litchar{> } prompt and the expected result.
 
 @(demo:
     ~defn:
-      def fahrenheit_freezing: 32
+      def fahrenheit_freezing = 32
       fun fahrenheit_to_celsius(f):
         (f - 32) * 5/9
     ~repl:

--- a/rhombus/scribblings/more-arguments.scrbl
+++ b/rhombus/scribblings/more-arguments.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def args_eval: make_rhombus_eval())
+@(def args_eval = make_rhombus_eval())
 
 @examples(
   ~eval: args_eval,
@@ -34,10 +34,10 @@ arguments:
     ~repl:
       add(1, 2, 3, 4)
     ~repl:
-      def [n, ...]: [20, 30, 40]
+      def [n, ...] = [20, 30, 40]
       add(10, n, ..., 50)
     ~repl:
-      def ns: [20, 30, 40]
+      def ns = [20, 30, 40]
       add(10, & ns, 50)
   )
 

--- a/rhombus/scribblings/multiple-value.scrbl
+++ b/rhombus/scribblings/multiple-value.scrbl
@@ -20,7 +20,7 @@ value is matched against the corresponding group.
 
 @(demo:
     ~defn:
-      def (n, s): values(1, "apple")
+      def (n, s) = values(1, "apple")
     ~repl:
       n
       s
@@ -33,7 +33,7 @@ look more the same:
 
 @(demo:
     ~defn:
-      def values(n, s): values(1, "apple")
+      def values(n, s) = values(1, "apple")
     ~repl:
       n
       s

--- a/rhombus/scribblings/mutable-var.scrbl
+++ b/rhombus/scribblings/mutable-var.scrbl
@@ -11,7 +11,7 @@ assigns to a mutable variable.
 
 @(demo:
     ~defn:
-      def mutable todays_weather: "sunny"
+      def mutable todays_weather = "sunny"
     ~repl:
       todays_weather
       todays_weather := "rainy"
@@ -32,7 +32,7 @@ The @rhombus(:=) operator can also change object fields accessed via
     ~defn:
       class Box(mutable content)
     ~repl:
-      def present: Box("socks")
+      def present = Box("socks")
       present.content
       present.content := "toy"
       present.content

--- a/rhombus/scribblings/namespace.scrbl
+++ b/rhombus/scribblings/namespace.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def ns_eval: make_rhombus_eval())
+@(def ns_eval = make_rhombus_eval())
 
 @title(~tag: "namespaces-overview"){Namespaces}
 
@@ -31,8 +31,8 @@ name with @rhombus(.).
         export:
           tau
           Complex
-        def pi: 3.14
-        def tau: 2 * pi
+        def pi = 3.14
+        def tau = 2 * pi
         class Complex(real, imag)
     ~repl:
       math.tau
@@ -44,7 +44,7 @@ A name defined with @rhombus(namespace) can be used with @rhombus(import),
 but the name must be prefixed with @rhombus(., ~impmod) to distinguish it from a
 module path. Also, @rhombus(import) can be used in nested blocks
 generally, such as a block created with @rhombus(begin) or
-@rhombus(val):
+@rhombus(def):
 
 @(demo:
     ~eval: ns_eval
@@ -71,7 +71,7 @@ existing namespace or by nesting @rhombus(namespace) forms.
           math
           english
         namespace english:
-          def greeting: "Hello"
+          def greeting = "Hello"
           export: greeting
     ~repl:
       subject.english.greeting
@@ -100,7 +100,7 @@ scope of the extending definition.
 @(demo:
     ~eval: ns_eval
     begin:
-      def math.e: 2.71
+      def math.e = 2.71
       math.e
     ~error: math.e
   )

--- a/rhombus/scribblings/operator.scrbl
+++ b/rhombus/scribblings/operator.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def op_eval: make_rhombus_eval())
+@(def op_eval = make_rhombus_eval())
 
 @examples(
   ~eval: op_eval,

--- a/rhombus/scribblings/ref-class.scrbl
+++ b/rhombus/scribblings/ref-class.scrbl
@@ -38,6 +38,7 @@
 
   grammar maybe_default:
     = $default_expr
+    : : $default_body; ...
     ε,
 
   grammar class_clause_or_body_or_export:
@@ -47,7 +48,9 @@
 
 
   grammar class_clause:
+    $$(@rhombus(field, ~class_clause)) $identifier $maybe_annotation = $expr
     $$(@rhombus(field, ~class_clause)) $identifier $maybe_annotation: $body; ...
+    $$(@rhombus(private, ~class_clause)) $$(@rhombus(field, ~class_clause)) $identifier $maybe_annotation = $expr
     $$(@rhombus(private, ~class_clause)) $$(@rhombus(field, ~class_clause)) $identifier $maybe_annotation: $body; ...
     $$(@rhombus(method, ~class_clause)) $method_impl
     $$(@rhombus(override, ~class_clause)) $method_impl
@@ -119,14 +122,14 @@
  however, then it is not included as an argument for the default
  constructor, binding form, or annotation form.
 
- When a default-value expression is provided for a field after
- @rhombus(=), then the default constructor evaluates the
- @rhombus(default_expr) to obtain a value for the argument when it is not
- supplied. If a by-position field has a default-value expression, then
+ When a default-value expression or block is provided for a field after
+ @rhombus(=) or @litchar{:}, then the default constructor evaluates the
+ @rhombus(default_expr) or @rhombus(default_body)s to obtain a value for the argument when it is not
+ supplied. If a by-position field has a default-value expression or block, then
  all later by-position fields must have a default. If the class extends a
  superclass that has a non- @rhombus(private, ~class_clause) by-position
  argument with a default, then all by-position arguments of the subclass
- must have a default. A @rhombus(default_expr) can refer to earlier field
+ must have a default. A @rhombus(default_expr) or @rhombus(default_body) can refer to earlier field
  names in the same @rhombus(class) to produce a default value. If a
  @rhombus(priviate) @rhombus(field_spec) lacks a @rhombus(=) and
  default-value expression, then a custom constructor must be declared
@@ -148,9 +151,9 @@
  When a @rhombus(class_clause) is a @rhombus(field, ~class_clause) form,
  then an additional field is added to the class, but the additional field
  is not represented by an arguments to the constructor, annotation form,
- or binding-pattern form. Instead, the
- @rhombus(body) block in @rhombus(field, ~class_clause) gives the added
- field its initial value; that block is evaluated each time an instance
+ or binding-pattern form. Instead, the @rhombus(expr) or
+ @rhombus(body) block the  @rhombus(field, ~class_clause) gives the added
+ field its initial value; that expression or block is evaluated each time an instance
  of the class is created, but it cannot refer to @rhombus(this),
  fields of the class, or methods of the class. All fields
  added through a @rhombus(field, ~class_clause) clause are mutable, and they
@@ -423,11 +426,12 @@
 }
 
 @doc(  
+  class_clause.macro 'field $identifier $maybe_annotation = $expr',
   class_clause.macro 'field $identifier $maybe_annotation: $body; ...',
 ){
 
  A @tech{class clause} recognized by @rhombus(class) to add fields to
- the class. The @rhombus(body) is evaluated each time the class is instantiated,
+ the class. The @rhombus(expr) or @rhombus(body) block is evaluated each time the class is instantiated,
  but it cannot refer to @rhombus(this) or fields or methods of an object.
  See @rhombus(class) for more information.
 

--- a/rhombus/scribblings/ref-def.scrbl
+++ b/rhombus/scribblings/ref-def.scrbl
@@ -4,12 +4,13 @@
 @title{Definitions}
 
 @doc(
+  defn.macro 'def $binding = $expr',
   defn.macro 'def $binding:
                 $body
                 ...'
 ){
 
- Binds the identifiers of @rhombus(binding) to the value of the
+ Binds the identifiers of @rhombus(binding) to the value of @rhombus(expr) or the
  @rhombus(body) sequence. The @rhombus(body) itself can include
  definitions, and its normally it ends with an expression to provide the
  result value.
@@ -19,27 +20,27 @@
  annotations.
 
 @examples(
-  def pi: 3.14,
+  def pi = 3.14,
   pi
 )
 
 @examples(
   ~label: #false,
   def pi:
-    def tau: 6.28
+    def tau = 6.28
     tau/2,
   pi
 )
 
 @examples(
   ~label: #false,
-  def [x, y, z]: [1+2, 3+4, 5+6],
+  def [x, y, z] = [1+2, 3+4, 5+6],
   y
 )
 
 @examples(
   ~label: #false,
-  def ns :: List: [1+2, 3+4, 5+6],
+  def ns :: List = [1+2, 3+4, 5+6],
   ns
 )
 
@@ -47,6 +48,7 @@
 
 
 @doc(
+  defn.macro 'let $binding = $expr',
   defn.macro 'let $binding:
                 $body
                 ...'
@@ -58,9 +60,9 @@
 
 @examples(
   begin:
-    let v: 1
+    let v = 1
     fun get_v(): v
-    let v: v+1
+    let v = v+1
     [get_v(), v]
 )
 

--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -66,7 +66,7 @@ normally bound to implement function calls.
                 $body
                 ...',
   defn.macro 'fun
-              | $identifier_path($binding, ..., $rest, ...) $maybe_res_ann:
+              | $identifier_path($kw_binding, ..., $rest, ...) $maybe_res_ann:
                   $body
                   ...
               | ...',
@@ -76,7 +76,7 @@ normally bound to implement function calls.
                 ...',
 
   expr.macro 'fun
-              | ($binding, ..., $rest, ...) $maybe_res_ann:
+              | ($kw_binding, ..., $rest, ...) $maybe_res_ann:
                   $body
                   ...
               | ...',
@@ -88,8 +88,15 @@ normally bound to implement function calls.
   grammar kwopt_binding:
     $binding
     $keyword: $binding
-    $binding $$(@tt{=}) $default_expr
-    $keyword: $binding $$(@tt{=}) $default_expr,
+    $binding = $default_expr
+    $binding: $default_body; ...
+    $keyword: $binding = $default_expr
+    $keyword: $binding: $default_body; ...
+    $keyword = $default_expr,
+  
+  grammar kw_binding:
+    $binding
+    $keyword: $binding,
   
   grammar maybe_res_ann:
     :: $annotation
@@ -139,14 +146,17 @@ normally bound to implement function calls.
   curried_add(1)(2)
 )
 
- When @litchar{|} is not used, then arguments can have default values.
+ When @litchar{|} is not used, then arguments can have default values
+ as specified after a @rhombus(=) or in a block after the argument name.
  Bindings for earlier arguments are visible in each
- @rhombus(default_expr), but not bindings for later arguments;
+ @rhombus(default_expr) or @rhombus(default_body), but not bindings for later arguments;
  accordingly, matching actions are interleaved with binding effects (such
  as rejecting a non-matching argument) left-to-right, except that the
  result of a @rhombus(default_expr) is subject to the same constraints
  imposed by annotations and patterns for its argument as an explicitly
- supplied argument would be.
+ supplied argument would be. An argument form @rhombus($keyword = $default_expr)
+ is equivalent to the form @rhombus($keyword: $identifier = $default_expr)
+ for the @rhombus($identifier) with the same string form as @rhombus($keyword).
 
 @examples(
   fun f(x, y = x+1):
@@ -240,7 +250,7 @@ Only one @rhombus(~& map_binding) can appear in a @rhombus(rest) sequence.
                        ...',
 
   entry_point.macro 'fun
-                     | ($binding, ..., $rest, ...) $maybe_res_ann:
+                     | ($kw_binding, ..., $rest, ...) $maybe_res_ann:
                          $body
                          ...
                      | ...'

--- a/rhombus/scribblings/set.scrbl
+++ b/rhombus/scribblings/set.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def set_eval: make_rhombus_eval())
+@(def set_eval = make_rhombus_eval())
 
 @title(~tag: "set"){Sets}
 
@@ -19,13 +19,13 @@ set. The @rhombus(++) operator effectively unions sets.
 @(demo:
     ~eval: set_eval
     ~defn:
-      def friends: {"alice", "bob", "carol"}
+      def friends = {"alice", "bob", "carol"}
     ~repl:
       if friends["alice"] && friends["carol"]
       | "I know both"
       | "Who are they?"
     ~defn:
-      def new_friends: friends ++ {"david"}
+      def new_friends = friends ++ {"david"}
     ~repl:
       new_friends["david"]
       friends["david"]

--- a/rhombus/scribblings/syntax-class.scrbl
+++ b/rhombus/scribblings/syntax-class.scrbl
@@ -3,7 +3,7 @@
     "util.rhm" open
     "common.rhm" open)
 
-@(def sc_eval: make_rhombus_eval())
+@(def sc_eval = make_rhombus_eval())
 
 @examples(
   ~eval: sc_eval,
@@ -24,7 +24,7 @@ among others.
 
 @(demo:
     ~defn:
-      def '$(x :: Term)': '1'
+      def '$(x :: Term)' = '1'
 )
 
 Rhombus also supports user-defined syntax classes via
@@ -106,7 +106,7 @@ alternative of a syntax class.
       | '$x + $y + $z'
       | '$x - $y'
     ~repl:
-      def '$(expr :: Arithmetic)': '1 + 2 + 3'
+      def '$(expr :: Arithmetic)' = '1 + 2 + 3'
       expr.y
       ~error: expr.z
 )

--- a/rhombus/scribblings/syntax.scrbl
+++ b/rhombus/scribblings/syntax.scrbl
@@ -46,7 +46,7 @@ those items is used in one replication.
 
 @(demo:
     ~defn:
-      def [seq, ...]: ['1', '2', '3']
+      def [seq, ...] = ['1', '2', '3']
     ~repl:
       '(hi $seq) ...'
   )
@@ -60,7 +60,7 @@ with no terms within a larger sequence with multiple groups is an error.
 
 @(demo:
     ~repl:
-      def [seq, ...]: []
+      def [seq, ...] = []
       '(hi $seq) ...'
       ~error: 'x; (hi $seq) ...; y'
   )
@@ -73,7 +73,7 @@ separating comma:
 
 @(demo:
     ~repl:
-      def [seq, ...]: ['1', '2', '3']
+      def [seq, ...] = ['1', '2', '3']
       '(hi $seq, ...)'
   )
 
@@ -82,7 +82,7 @@ Along the same lines, @rhombus(...) just after a @litchar{|} can replicate a pre
 
 @(demo:
     ~repl:
-      def [seq, ...]: ['1', '2', '3']
+      def [seq, ...] = ['1', '2', '3']
       'cond | $seq | ...'
   )
 
@@ -95,7 +95,7 @@ pattern with @rhombus($).
 
 @(demo:
     ~repl:
-      def '$x + $y': '1 + (2 + 3)'
+      def '$x + $y' = '1 + (2 + 3)'
       x
       y
   )
@@ -108,7 +108,7 @@ that would be parsed as an expression. For example, a pattern variable
 @rhombus(y) by itself cannot be matched to a sequence @rhombus(2 + 3):
 
 @(demo:
-    ~error: def '$x + $y': '1 + 2 + 3'
+    ~error: def '$x + $y' = '1 + 2 + 3'
   )
 
 If a @rhombus($) escape is alone within its group, however, the
@@ -116,7 +116,7 @@ If a @rhombus($) escape is alone within its group, however, the
 
 @(demo:
     ~repl:
-      def '$x': '1 + 2 + 3'
+      def '$x' = '1 + 2 + 3'
       x
   )
 
@@ -126,7 +126,7 @@ multi-term group in any other template context is an error.
 
 @(demo:
     ~repl:
-      def '$x': '1 + 2 + 3'
+      def '$x' = '1 + 2 + 3'
       '[$x]'
       ~error: '[0 + $x]'
   )
@@ -136,7 +136,7 @@ group is interchangeable with a single-term syntax object:
 
 @(demo:
     ~repl:
-      def '$y': '1'
+      def '$y' = '1'
       '[$y]'
       '[0 + $y]'
   )
@@ -146,10 +146,10 @@ with the @rhombus(Term, ~stxclass) syntax class using the @rhombus(::) operator.
 
 @(demo:
     ~repl:
-      def '$(x :: Term)': '1'
+      def '$(x :: Term)' = '1'
       x
     ~repl:
-      ~error: def '$(x :: Term)': '1 + 2'
+      ~error: def '$(x :: Term)' = '1 + 2'
   )
 
 If a @rhombus($) escape is not only alone within its group, but the
@@ -162,8 +162,8 @@ destination contexts have the same shape, so a match from a block-like
 context can be put into a brackets context, for example.
 
 @(demo:
-    def '$x': '1 + 2 + 3
-               4 * 5 * 6'
+    def '$x' = '1 + 2 + 3
+                4 * 5 * 6'
     '[$x]'
   )
 
@@ -179,7 +179,7 @@ to form a repetition of matches:
 
 @(demo:
     ~defn:
-      def '$x + $y ... + 0': '1 + 2 + 3 + 0'
+      def '$x + $y ... + 0' = '1 + 2 + 3 + 0'
     ~repl:
       x
       [y, ...]

--- a/rhombus/tests/alt-fun.rhm
+++ b/rhombus/tests/alt-fun.rhm
@@ -183,7 +183,7 @@ check: pythag(~a: 3, ~b: 4, ~c: 6); #false
 begin:
   check: object_name(pythag); symbol(pythag)
   check: procedure_arity(pythag); 0
-  def values(req_kws, all_kws): procedure_keywords(pythag)
+  def values(req_kws, all_kws) = procedure_keywords(pythag)
   check: req_kws; []
   check: all_kws; [keyword(~a), keyword(~b), keyword(~c)]
 

--- a/rhombus/tests/array.rhm
+++ b/rhombus/tests/array.rhm
@@ -22,23 +22,23 @@ begin:
     Array(1, 2, 3).length()
     3
   check:
-    def arr: Array(1, 2, 3)
+    def arr = Array(1, 2, 3)
     arr.length()
     3
   check:
-    def arr :: Array: dynamic(Array(1, 2, 3))
+    def arr :: Array = dynamic(Array(1, 2, 3))
     arr.length()
     3
   check:
-    def arr -: Array: dynamic(Array(1, 2, 3))
+    def arr -: Array = dynamic(Array(1, 2, 3))
     arr.length()
     3
   check:
-    def arr :: Array.of(Integer): dynamic(Array(1, 2, 3))
+    def arr :: Array.of(Integer) = dynamic(Array(1, 2, 3))
     arr.length()
     3
   check:
-    def [v, ...]: dynamic([1, 2, 3])
+    def [v, ...] = dynamic([1, 2, 3])
     Array(v, ...).length()
     3
 

--- a/rhombus/tests/boolean-pattern.rhm
+++ b/rhombus/tests/boolean-pattern.rhm
@@ -12,7 +12,7 @@ check:
   // static info flows from lhs to rhs
   use_static
   class Posn(x, y)
-  def Posn(x, y) && z : dynamic(Posn(1, 2))
+  def Posn(x, y) && z = dynamic(Posn(1, 2))
   z.x
   1
 
@@ -21,7 +21,7 @@ check:
   // static info doens't go right to left
   use_static
   class Posn(x, y)
-  def z && Posn(x, y) : dynamic(Posn(1, 2))
+  def z && Posn(x, y) = dynamic(Posn(1, 2))
   z.x
   "static operator not supported"
 

--- a/rhombus/tests/check.rhm
+++ b/rhombus/tests/check.rhm
@@ -48,8 +48,8 @@ expr.macro
            '')
 
 fun check_same(where, thunk, expected_thunk, ~mode: mode):
-  def values(got, exn_msg): call_capturing_exn(thunk)
-  def expected: call_capturing_values(expected_thunk)
+  def values(got, exn_msg) =call_capturing_exn(thunk)
+  def expected = call_capturing_values(expected_thunk)
   def ok:
     match mode
     | keyword(~print) || keyword(~eval_print):

--- a/rhombus/tests/class-method.rhm
+++ b/rhombus/tests/class-method.rhm
@@ -166,7 +166,7 @@ check:
     method m0(): [y, x]
     method m1(z): [y, x, z]
     method m2(z): m1(-z)
-  def p: Posn(1, 2)
+  def p = Posn(1, 2)
   [p.m0(),
    p.m1(3),
    p.m2(3)]
@@ -185,8 +185,8 @@ check:
     override m1(w): [y, x, z, w]
     method m3(a, b, c): [a, m0(), m1(5), m2(6)]
     method m4(x): x
-  def p: Posn(1, 2)
-  def p3: Posn3D(1, 2, 3)
+  def p = Posn(1, 2)
+  def p3 = Posn3D(1, 2, 3)
   [p.m0(), p.m1(3), p.m2(3),
    p3.m0(),
    p3.m1(4),
@@ -206,7 +206,7 @@ check:
   begin:
     class Posn(x, y):
       method m0(): [y, x]
-    def p: Posn(1, 2)
+    def p = Posn(1, 2)
     p.m0
   "method must be called for static mode"
 
@@ -223,7 +223,7 @@ check:
   use_dynamic
   class Posn(x, y):
     method m0(): [y, x]
-  def p: Posn(1, 2)
+  def p = Posn(1, 2)
   [dynamic(p).x,
    dynamic(p).m0 +& "",
    dynamic(p).m0()]
@@ -233,9 +233,9 @@ check:
 
 check:
   class Posn(x, y):
-    private field q: 1
+    private field q = 1
     method m0(): [q, this.q]
-  def p: Posn(1, 2)
+  def p = Posn(1, 2)
   [p.m0()]
   [[1, 1]]
 
@@ -243,7 +243,7 @@ check:
   ~eval_exn
   use_static
   class Posn(x, y):
-    private field q: 1
+    private field q = 1
   (Posn(1, 2)).q
   "no such public field or method"
 
@@ -272,7 +272,7 @@ check:
     extends Posn
     private field q: "other"
     method get(): q
-  def p: Posn3D(0, 2, 3)
+  def p = Posn3D(0, 2, 3)
   [p.lookup(p), p.get()]
   [1, "other"]
 
@@ -322,7 +322,7 @@ check:
     nonfinal
     override a(): [super.a()]
     override c(): [super.b()]
-  def p: Posn3D(1, 2, 3)
+  def p = Posn3D(1, 2, 3)
   [p.a(), p.b(), p.c(),
    Posn.a(p), Posn.b(p), Posn.c(p)]
   [[1], 2, [2],
@@ -348,7 +348,7 @@ check:
     extends Posn
     override a(): [super.a()]
     override c(): [super.b()]
-  def p: Posn3D(1, 2, 3)
+  def p = Posn3D(1, 2, 3)
   [Posn.a(p), Posn.b(p), Posn.c(p),
    Posn3D.a(p), Posn3D.b(p), Posn3D.c(p)]
   [[1], 2, [2],

--- a/rhombus/tests/class-namespace.rhm
+++ b/rhombus/tests/class-namespace.rhm
@@ -6,8 +6,8 @@ use_static
 check:
   class Posn(x, y):
     export: origin
-  def origin: Posn(0, 0)
-  def p: Posn.origin
+  def origin = Posn(0, 0)
+  def p = Posn.origin
   [p.x, p.y]
   [0, 0]
 
@@ -21,7 +21,7 @@ check:
 check:
   ~eval_exn
   class Posn(x, y):
-    def x: 10
+    def x = 10
     export: x
   "conflicts with field name"
 
@@ -29,7 +29,7 @@ check:
   ~eval_exn
   class Posn(x, y):
     method dist(): x+y
-    def dist: 10
+    def dist = 10
     export: dist
   "conflicts with method name"
 
@@ -37,6 +37,6 @@ check:
   ~eval_exn
   interface Pointable:
     method zero(): 0
-    def zero: 0
+    def zero = 0
     export: zero
   "conflicts with method name"

--- a/rhombus/tests/class-print.rhm
+++ b/rhombus/tests/class-print.rhm
@@ -6,7 +6,7 @@ use_static
 check:
   class Posn(x, ~y, private w = 10):
     nonfinal
-    field quiet: 11
+    field quiet = 11
   
   class Posn3D(~z: z, w):
     nonfinal

--- a/rhombus/tests/class-private-field.rhm
+++ b/rhombus/tests/class-private-field.rhm
@@ -28,8 +28,8 @@ check:
   class Posn(x, y, private color = "blue"):
     method get_color():
       color
-  def p: Posn(1, 2)
-  def Posn(px, py): p
+  def p = Posn(1, 2)
+  def Posn(px, py) = p
   [p.x, p.y, p.get_color(),
    px, py,
    p is_a Posn.of(Integer, Integer)]
@@ -45,10 +45,10 @@ check:
     private method secret():
       [color]
     internal _Posn
-  def p: Posn(1, 2)
-  def _p: _Posn(-1, -2, "red")
-  def Posn(px, py): p
-  def _Posn(_px, _py, _pcolor): p
+  def p = Posn(1, 2)
+  def _p = _Posn(-1, -2, "red")
+  def Posn(px, py) = p
+  def _Posn(_px, _py, _pcolor) = p
   [p.x, p.y, p.get_color(),
    _p.x, _p.y, _p.get_color(),
    px, py,
@@ -77,9 +77,9 @@ check:
     extends Posn
     method get_weight():
       weight
-  def p3: Posn3D(1, 2, 3)
-  def Posn(px, py): p3
-  def Posn3D(px3, py3, pz3): p3
+  def p3 = Posn3D(1, 2, 3)
+  def Posn(px, py) = p3
+  def Posn3D(px3, py3, pz3) = p3
   [p3.x, p3.y, p3.get_color(), p3.z, p3.get_weight(),
    px, py,
    px3, py3, pz3,
@@ -100,9 +100,9 @@ check:
   class Posn3D(z):
     nonfinal
     extends Posn
-  def p3: Posn3D(1, 2, 3)
-  def Posn(px, py): p3
-  def Posn3D(px3, py3, pz3): p3
+  def p3 = Posn3D(1, 2, 3)
+  def Posn(px, py) = p3
+  def Posn3D(px3, py3, pz3) = p3
   [p3.x, p3.y, p3.get_color(), p3.z,
    px, py,
    px3, py3, pz3,
@@ -127,9 +127,9 @@ check:
       super(x, y)("heavy", z)
     method get_weight():
       weight
-  def p3: Posn3D(1, 2, 3)
-  def Posn(px, py): p3
-  def Posn3D(px3, py3, pz3): p3
+  def p3 = Posn3D(1, 2, 3)
+  def Posn(px, py) = p3
+  def Posn3D(px3, py3, pz3) = p3
   [p3.x, p3.y, p3.get_color(), p3.z, p3.get_weight(),
    px, py,
    px3, py3, pz3,
@@ -166,9 +166,9 @@ check:
     annotation
     | 'Posn3D $dot of{$x, $y, $z}': 'Posn.of{$x, $y} && _Posn3D.of(Any, $z)'
     | 'Posn3D' : '_Posn3D'      
-  def p3: Posn3D(1, 2, 3)
-  def Posn{px, py}: p3
-  def Posn3D{px3, py3, pz3}: p3
+  def p3 = Posn3D(1, 2, 3)
+  def Posn{px, py} = p3
+  def Posn3D{px3, py3, pz3} = p3
   [p3.x, p3.y, p3.get_color(), p3.z, p3.get_weight(),
    px, py,
    px3, py3, pz3,
@@ -183,8 +183,8 @@ check:
     constructor (x, y):
       super(x, y, 10)
     internal _Posn
-  def p: Posn(1, 2)
-  def Posn(x, y): p
+  def p = Posn(1, 2)
+  def Posn(x, y) = p
   [_Posn.stamp(p),
    (p -: _Posn).stamp]
   [10, 10]

--- a/rhombus/tests/class.rhm
+++ b/rhombus/tests/class.rhm
@@ -5,7 +5,7 @@ use_static
   
 check:
   class Posn(x, y)
-  def p: Posn(1, 2)
+  def p = Posn(1, 2)
   [p is_a Posn, p.x, p.y]
   [#true, 1, 2]
 
@@ -24,7 +24,7 @@ check:
 check:
   ~eval_exn
   class Posn(x, y):
-    field x: 0
+    field x = 0
   "duplicate field name"
 
 check:
@@ -37,8 +37,8 @@ check:
 
 check:
   class Posn(~x, y)
-  def p: Posn(~x: 1, 2)
-  def p2: Posn(2, ~x: 1)
+  def p = Posn(~x: 1, 2)
+  def p2 = Posn(2, ~x: 1)
   [p.x, p.y, p2.x, p2.y]
   [1, 2, 1, 2]
 
@@ -47,8 +47,8 @@ check:
     nonfinal
   class Posn3D(z):
     extends Posn
-  def p: Posn3D(~x: 1, 2, 3)
-  def p2: Posn3D(2, 3, ~x: 1)
+  def p = Posn3D(~x: 1, 2, 3)
+  def p2 = Posn3D(2, 3, ~x: 1)
   [p.x, p.y, p.z, p2.x, p2.y, p2.z]
   [1, 2, 3, 1, 2, 3]
 
@@ -57,8 +57,8 @@ check:
     nonfinal
   class Posn3D(~z):
     extends Posn
-  def p: Posn3D(1, 2, ~z: 3)
-  def p2: Posn3D(~z: 3, 1, 2)
+  def p = Posn3D(1, 2, ~z: 3)
+  def p2 = Posn3D(~z: 3, 1, 2)
   [p.x, p.y, p.z, p2.x, p2.y, p2.z]
   [1, 2, 3, 1, 2, 3]
 
@@ -67,8 +67,8 @@ check:
     nonfinal
   class Posn3D(~z: zz):
     extends Posn
-  def p: Posn3D(~x: 1, 2, ~z: 3)
-  def p2: Posn3D(~z: 3, 2, ~x: 1)
+  def p = Posn3D(~x: 1, 2, ~z: 3)
+  def p2 = Posn3D(~z: 3, 2, ~x: 1)
   [p.x, p.y, p.zz, p2.x, p2.y, p2.zz]
   [1, 2, 3, 1, 2, 3]
 
@@ -77,7 +77,7 @@ check:
     nonfinal
   class Posn3D(z):
     extends Posn
-  def p: Posn3D(1, 2, 3)
+  def p = Posn3D(1, 2, 3)
   [p is_a Posn, p is_a Posn3D, p.x, p.y, p.z,
    Posn(1, 2) is_a Posn3D]
   [#true, #true, 1, 2, 3,
@@ -87,7 +87,7 @@ check:
   class Posn(x, y):
     constructor (z):
       super(z+1, z-1)
-  def p: Posn(1)
+  def p = Posn(1)
   [p.x, p.y]
   [2, 0]
 
@@ -98,7 +98,7 @@ check:
     extends Posn
     constructor (z):
       super(z+1, z+2)(z+3)
-  def p: Posn3D(1)
+  def p = Posn3D(1)
   [p.x, p.y, p.z]
   [2, 3, 4]
 
@@ -112,7 +112,7 @@ check:
     extends Posn3D
     constructor (z):
       super(z+1, z+2, z+3)(z+4)
-  def p: Posn4D(1)
+  def p = Posn4D(1)
   [p.x, p.y, p.z, p.w]
   [2, 3, 4, 5]
 
@@ -127,7 +127,7 @@ check:
     constructor:
       fun (z):
         super(z+1, z+2)(z+3)
-  def p: Posn3D(1)
+  def p = Posn3D(1)
   [p.x, p.y, p.z]
   [3, 2, 4]
 
@@ -149,7 +149,7 @@ check:
     constructor:
       fun (z):
         super(z+1)(z+5)
-  def p: Posn4D(1)
+  def p = Posn4D(1)
   [p.x, p.y, p.z, p.w]
   [4, 3, 5, 6]
 
@@ -170,8 +170,8 @@ check:
           super(z+1)(z+3)
       | (x, y, z):
           super(~x: x, ~y: y)(z)
-  def p: Posn3D(1)
-  def p2: Posn3D(10, 20, 30)
+  def p = Posn3D(1)
+  def p2 = Posn3D(10, 20, 30)
   [p.x, p.y, p.z,
    p2.x, p2.y, p2.z]
   [2, 0, 4,
@@ -183,7 +183,7 @@ check:
     nonfinal
   class Posn3D(z):
     extends Posn
-  def p: dynamic(Posn3D(1, 2, 3))
+  def p = dynamic(Posn3D(1, 2, 3))
   [p.x, p.y, p.z]
   [1, 2, 3]
 
@@ -207,9 +207,9 @@ check:
       | '().of($x, $y)':
           '_Posn.of($y, $x)'
       | '()': '_Posn'    
-  def p: Posn(0, 2)
-  def Posn(yy, xx): p
-  def Posn(a): p    
+  def p = Posn(0, 2)
+  def Posn(yy, xx) = p
+  def Posn(a) = p    
   [p.y, p.x, yy, xx, a,
    p is_a Posn,
    Posn(1, "2") is_a Posn.of(Integer, String)]
@@ -220,11 +220,11 @@ check:
 check:
   class Posn(x, y):
     nonfinal
-    field w: 0
+    field w = 0
   class Posn3D(z):
     extends Posn
-  def p1: Posn(10, 20)
-  def p: Posn3D(1, 2, 3)
+  def p1 = Posn(10, 20)
+  def p = Posn3D(1, 2, 3)
   [[p1.x, p1.y, p1.w],
    [p.x, p.y, p.w, p.z]]
   [[10, 20, 0],
@@ -233,11 +233,11 @@ check:
 check:
   class Posn(~x, y):
     nonfinal
-    field w: 0
+    field w = 0
   class Posn3D(z):
     extends Posn
-  def p1: Posn(20, ~x: -10)
-  def p: Posn3D(2, ~x: 1, 3)
+  def p1 = Posn(20, ~x: -10)
+  def p = Posn3D(2, ~x: 1, 3)
   [[p1.x, p1.y, p1.w],
    [p.x, p.y, p.w, p.z]]
   [[-10, 20, 0],
@@ -246,15 +246,15 @@ check:
 check:
   class Posn(~x, y):
     nonfinal
-    field w: 0
+    field w = 0
     internal _Posn
   class Posn3D(z):
     extends Posn
     internal _Posn3D
-  def p1: Posn(20, ~x: -10)
-  def p: Posn3D(2, ~x: 1, 3)
-  def ip1: _Posn(20, ~x: -10)
-  def ip: _Posn3D(2, ~x: 1)(3)
+  def p1 = Posn(20, ~x: -10)
+  def p = Posn3D(2, ~x: 1, 3)
+  def ip1 = _Posn(20, ~x: -10)
+  def ip = _Posn3D(2, ~x: 1)(3)
   fun get(p1 :: Posn, p :: Posn3D):
     [[p1.x, p1.y, p1.w],
      [p.x, p.y, p.w, p.z]]
@@ -270,8 +270,8 @@ check:
     constructor:
       fun(x, y, z):
         super(~x: 1, y)(z)
-  def p2: Posn(~x: 1, 2)
-  def p3: Posn3D(1, 2, 3)
+  def p2 = Posn(~x: 1, 2)
+  def p3 = Posn3D(1, 2, 3)
   [[p2.x, p2.y], [p3.x, p3.y, p3.z]]
   [[1, 2], [1, 2, 3]]
 
@@ -289,9 +289,9 @@ check:
     constructor:
       fun(x, y, z, w):
         super(x, y, z)(~w: w)
-  def p2: Posn(~x: 1, 2)
-  def p3: Posn3D(1, 2, 3)
-  def p4: Posn4D(1, 2, 3, 4)
+  def p2 = Posn(~x: 1, 2)
+  def p3 = Posn3D(1, 2, 3)
+  def p4 = Posn4D(1, 2, 3, 4)
   [[p2.x, p2.y],
    [p3.x, p3.y, p3.z],
    [p4.x, p4.y, p4.z, p4.w]]
@@ -317,10 +317,10 @@ check:
     constructor:
       fun(x, y, z, w):
         super(x, ~y: y, z)(w)
-  def p2: Posn(~ex: 1, ~wy: 2)
-  def p3: Posn3D(1, ~y: 2, 3)
-  def _p3: _Posn3D(~ex: 1, ~wy: 2)(3)
-  def p4: Posn4D(1, 2, 3, 4)
+  def p2 = Posn(~ex: 1, ~wy: 2)
+  def p3 = Posn3D(1, ~y: 2, 3)
+  def _p3 = _Posn3D(~ex: 1, ~wy: 2)(3)
+  def p4 = Posn4D(1, 2, 3, 4)
   [[p2.x, p2.y],
    [p3.x, p3.y, p3.z],
    [_p3.x, _p3.y, _p3.z],
@@ -332,31 +332,31 @@ check:
 
 check:
   class Posn(x, y = 0)
-  def p: Posn(1)
+  def p = Posn(1)
   [p.x, p.y]
   [1, 0]
 
 check:
   class Posn(x, y = x):
     nonfinal
-  def p: Posn(1)
+  def p = Posn(1)
   [p.x, p.y]
   [1, 1]
 
 check:
   class Posn(~x, y = x):
     nonfinal
-  def p: Posn(~x: 1)
-  def p2: Posn(~x: -1, 2)
+  def p = Posn(~x: 1)
+  def p2 = Posn(~x: -1, 2)
   [p.x, p.y, p2.x, p2.y]
   [1, 1, -1, 2]
 
 check:
   class Posn3D(~x = 10, y, ~z: z = x+y)
-  def p: Posn3D(2)
-  def p2: Posn3D(2, ~z: 3)
-  def p3: Posn3D(2, ~x: 3)
-  def p4: Posn3D(~z: 0, 2, ~x: 3)
+  def p = Posn3D(2)
+  def p2 = Posn3D(2, ~z: 3)
+  def p3 = Posn3D(2, ~x: 3)
+  def p4 = Posn3D(~z: 0, 2, ~x: 3)
   [[p.x, p.y, p.z],
    [p2.x, p2.y, p2.z],
    [p3.x, p3.y, p3.z],
@@ -408,13 +408,13 @@ check:
   class Posn(mutable x :: Integer, y :: Integer):
     method m():
       x := 8
-  def p: Posn(2, 0)
+  def p = Posn(2, 0)
   [p.x, p.x := 5, p.x, p.y, p.m(), p.x]
   [2, #void, 5, 0, #void, 8]
 
 check:
   class Posn(x :: Integer, mutable y :: Integer)
-  def p: Posn(2, 0)
+  def p = Posn(2, 0)
   [p.y, p.y := 5, p.y, p.x]
   [0, #void, 5, 2]
 
@@ -434,10 +434,10 @@ check:
   class Posn4D(w):
     extends Posn3D
     nonfinal
-  def p: Posn4D(1, ~y: 2, 3, 6)
-  def Posn(a2, ~y: b2): p
-  def Posn3D(a3, ~y: b3, c3): p
-  def Posn4D(a4, ~y: b4, c4, d4): p
+  def p = Posn4D(1, ~y: 2, 3, 6)
+  def Posn(a2, ~y: b2) = p
+  def Posn3D(a3, ~y: b3, c3) = p
+  def Posn4D(a4, ~y: b4, c4, d4) = p
   [[a2, b2],
    [a3, b3, c3],
    [a4, b4, c4, d4]]
@@ -454,9 +454,9 @@ check:
     internal _Posn3D
     binding:
       rule '()($x, $y ..., $z)': 'Posn($x, ~y: $y ...) && _Posn3D($z)'
-  def p: Posn3D(1, ~y: 2, 3)
-  def Posn(a2, ~y: b2): p
-  def Posn3D(a3, b3, c3): p
+  def p = Posn3D(1, ~y: 2, 3)
+  def Posn(a2, ~y: b2) = p
+  def Posn3D(a3, b3, c3) = p
   [[a2, b2],
    [a3, b3, c3]]
   [[1, 2],
@@ -481,10 +481,10 @@ check:
     internal _Posn4D
     binding:
       rule '()($x, ~y: $y, $z, $w)': 'Posn3D[$x, $y, $z] && _Posn4D($w)'
-  def p: Posn4D(1, ~y: 2, 3, 6)
-  def Posn(X a2, Y b2): p
-  def Posn3D[a3, b3, c3]: p
-  def Posn4D(a4, ~y: b4, c4, d4): p
+  def p = Posn4D(1, ~y: 2, 3, 6)
+  def Posn(X a2, Y b2) = p
+  def Posn3D[a3, b3, c3] = p
+  def Posn4D(a4, ~y: b4, c4, d4) = p
   [[a2, b2],
    [a3, b3, c3],
    [a4, b4, c4, d4]]
@@ -502,7 +502,7 @@ check:
   class Posn4D(w):
     extends Posn3D
     nonfinal
-  def p: Posn4D(1, ~y: "2", symbol'three', keyword'~four')
+  def p = Posn4D(1, ~y: "2", symbol'three', keyword'~four')
   p :: Posn
   p :: Posn.of(Integer, ~y: String)
   p :: Posn3D
@@ -522,7 +522,7 @@ check:
     annotation:
       rule | '().of($x, $y ..., $z)': 'Posn.of($x, ~y: $y ...) && _Posn3D.of($z)'
            | '()': '_Posn3D'
-  def p: Posn3D(1, ~y: "2", symbol'three')
+  def p = Posn3D(1, ~y: "2", symbol'three')
   p :: Posn
   p :: Posn.of(Integer, ~y: String)
   p :: Posn3D
@@ -552,7 +552,7 @@ check:
     annotation:
       rule | '() $dot of($x, ~y: $y, $z, $w)': 'Posn3D.of[$x, $y, $z] && _Posn4D.of($w)'
            | '()': '_Posn4D'
-  def p: Posn4D(1, ~y: "2", symbol'three', keyword'~four')
+  def p = Posn4D(1, ~y: "2", symbol'three', keyword'~four')
   p :: Posn
   p :: Posn.of(X Integer, Y String)
   p :: Posn3D
@@ -565,28 +565,28 @@ check:
 check:
   fun lookup_specs(make, model): [12, 25]
   class Car(make, model, private mpg):
-    private field gas: 0
+    private field gas = 0
     constructor(make, model):
-      def [tank_size, mpg]: lookup_specs(make, model)
+      def [tank_size, mpg] = lookup_specs(make, model)
       def car: super(make, model, mpg)
       car.gas := tank_size
       car
     method go(dist):
       gas := gas - dist/mpg
       gas
-  def c: Car("Mazda", "Miata")
+  def c = Car("Mazda", "Miata")
   c.go(100)
   8
 
 check:
   class Posn(x, y):
-    field w :: Integer: 0
+    field w :: Integer = 0
     field name -: String: "ok"
   Posn(1, 2).name +& Posn(3, 4).w
   "ok0"
 
 check:
-  def mutable n: 0
+  def mutable n = 0
   class Posn(x, y):
     field color: "red" +& begin: n := n + 1; n
   [Posn(1, 2).color, Posn(1, 2).color]

--- a/rhombus/tests/equality-map-set.rhm
+++ b/rhombus/tests/equality-map-set.rhm
@@ -50,7 +50,7 @@ check:
 
 check:
   begin:
-    def v: mcons(1, 2)
+    def v = mcons(1, 2)
     v == v
   #true
 
@@ -68,9 +68,9 @@ check:
   "hash-ref: no value found for key"
 
 begin:
-  def a: mcons(1, 2)
-  def b: mcons(1, 2)
-  def m: {a: "a", b: "b"}
+  def a = mcons(1, 2)
+  def b = mcons(1, 2)
+  def m = {a: "a", b: "b"}
   check:
     m[a]
     "a"
@@ -88,15 +88,15 @@ check:
 
 check:
   begin:
-    def v: mcons(1, 2)
+    def v = mcons(1, 2)
     {v}[v]
   #true
 
 begin:
-  def a: mcons(1, 2)
-  def b: mcons(1, 2)
-  def c: mcons(1, 2)
-  def s: {a, b}
+  def a = mcons(1, 2)
+  def b = mcons(1, 2)
+  def c = mcons(1, 2)
+  def s = {a, b}
   check:
     s[a]
     #true
@@ -115,8 +115,8 @@ check: {"a": 1, "b": 2}; {"b": 2, "a": 1}
 check: {"a": 1, "b": 2}; Map{"b": 2, "a": 1}
 check: {"a": 1, "b": 2}; Map(["b", 2], ["a", 1])
 begin:
-  def a: mcons(1, 2)
-  def b: mcons(1, 2)
+  def a = mcons(1, 2)
+  def b = mcons(1, 2)
   check: {a: 1, b: 2}; {b: 2, a: 1}
   check: {a: 1} == {b: 1}; #false
 check:
@@ -148,23 +148,23 @@ check:
   | _: #false
   "Set.empty"
 
-def local_map: Map{symbol(alice): Posn(4, 5),
-                   symbol(bob): Posn(7, 9)}
+def local_map = Map{symbol(alice): Posn(4, 5),
+                    symbol(bob): Posn(7, 9)}
 
 fun locale(who, neighborhood :: Map.of(Symbol, Posn)):
-  def p: neighborhood[who]
+  def p = neighborhood[who]
   p.x +& ", " +& p.y
 
 check:
   locale(symbol(alice), local_map)
   "4, 5"
 
-def {symbol(bob): bob_loc}: local_map
+def {symbol(bob): bob_loc} = local_map
 check:
   bob_loc
   Posn(7, 9)
 
-def Map{symbol(alice): alice_loc2, symbol(bob): bob_loc2}: local_map
+def Map{symbol(alice): alice_loc2, symbol(bob): bob_loc2} = local_map
 check:
   [alice_loc2, bob_loc2]
   [Posn(4, 5), Posn(7, 9)]
@@ -174,7 +174,7 @@ check: {"a", "b"}; {"b", "a"}
 check: {"a", "b"}; Set{"b", "a"}
 check: {"a", "b"}; Set("b", "a")
 begin:
-  def a: mcons(1, 2)
-  def b: mcons(1, 2)
+  def a = mcons(1, 2)
+  def b = mcons(1, 2)
   check: {a, b}; {b, a}
   check: {a} == {b}; #false

--- a/rhombus/tests/example-extend-a.rhm
+++ b/rhombus/tests/example-extend-a.rhm
@@ -4,4 +4,4 @@ export:
   List
   rename: List as ExList
 
-def List.a: "a"
+def List.a = "a"

--- a/rhombus/tests/example-extend-b.rhm
+++ b/rhombus/tests/example-extend-b.rhm
@@ -3,4 +3,4 @@
 export:
   List
 
-def List.b: "b"
+def List.b = "b"

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -3,7 +3,7 @@ import:
   "check.rhm" open
 
 begin:
-  def mutable accum: []
+  def mutable accum = []
   check:
     for:
       each i: 0..2
@@ -54,7 +54,7 @@ check:
 
 check:
   for List:
-    def len: 2
+    def len = 2
     each:
       i: 0..len
       j: 0..len
@@ -64,7 +64,7 @@ check:
 check:
   for List:
     each i: 0..2
-    def i_plus: i+1
+    def i_plus = i+1
     each j: 0..2
     [i_plus, -j-1]
   [[1, -1], [1, -2], [2, -1], [2, -2]]
@@ -72,7 +72,7 @@ check:
 check:
   for List:
     each i: 0..2
-    def i_len: i+1
+    def i_len = i+1
     each j: 0..i_len
     [i, -j-1]
   [[0, -1], [1, -1], [1, -2]]
@@ -120,8 +120,8 @@ check:
 check:
   for values(sum = 0):
     each i: 0..8
-    def new_sum: sum + i
+    def new_sum = sum + i
     final_when i == 4
-    def result: new_sum + 1
+    def result = new_sum + 1
     result
   15

--- a/rhombus/tests/interface.rhm
+++ b/rhombus/tests/interface.rhm
@@ -22,7 +22,7 @@ check:
     override area(): 33
     override sides(): 100
 
-  def a: ApproxCircle()
+  def a = ApproxCircle()
 
   [a.area(),
    a.sides(),
@@ -69,7 +69,7 @@ check:
     implements Shape
     implements Cowboy
     override draw(): "bullseye"
-  def l: LoneRanger()
+  def l = LoneRanger()
   [l.draw(), (l -: Shape).draw(), (l -: Cowboy).draw()]
   ["bullseye", "bullseye", "bullseye"]
 
@@ -125,7 +125,7 @@ check:
   class Sum(x):
     private implements Adder
     private override total(): x
-  def s: Sum(20)
+  def s = Sum(20)
   [s is_a Adder,
    s is_a _Adder,
    (s -: _Adder).total()]
@@ -190,7 +190,7 @@ check:
     override legs(): 4
     override horns(): 2
     private override seat(): 1
-  def m: MilkShed()
+  def m = MilkShed()
   check:
     ~exn
     (m -: Stool).seat()

--- a/rhombus/tests/list.rhm
+++ b/rhombus/tests/list.rhm
@@ -37,35 +37,35 @@ begin:
     List(1, 2, 3).length()
     3
   check:
-    def lst: [1, 2, 3]
+    def lst = [1, 2, 3]
     lst.length()
     3
   check:
-    def lst :: List: dynamic([1, 2, 3])
+    def lst :: List = dynamic([1, 2, 3])
     lst.length()
     3
   check:
-    def lst -: List: dynamic([1, 2, 3])
+    def lst -: List = dynamic([1, 2, 3])
     lst.length()
     3
   check:
-    def lst :: List.of(Integer): dynamic([1, 2, 3])
+    def lst :: List.of(Integer) = dynamic([1, 2, 3])
     lst.length()
     3
   check:
-    def [v, ...]: dynamic([1, 2, 3])
+    def [v, ...] = dynamic([1, 2, 3])
     [v, ...].length()
     3
   check:
-    def lst :: List.of(List): dynamic([[1, 2, 3]])
+    def lst :: List.of(List) = dynamic([[1, 2, 3]])
     lst.first.length()
     3
   check:
-    def lst :: List.of(Integer): dynamic([1, 2, 3])
+    def lst :: List.of(Integer) = dynamic([1, 2, 3])
     lst.rest.length()
     2
   check:
-    def lst :: NonemptyList.of(List): dynamic([[1, 2, 3]])
+    def lst :: NonemptyList.of(List) = dynamic([[1, 2, 3]])
     lst.first.length()
     3
 

--- a/rhombus/tests/map.rhm
+++ b/rhombus/tests/map.rhm
@@ -35,19 +35,19 @@ begin:
     MutableMap(["a", 1], ["b", 2]).length()
     2
   check:
-    def map: {"a": 1, "b": 2}
+    def map = {"a": 1, "b": 2}
     map.length()
     2
   check:
-    def map :: Map: dynamic({"a": 1, "b": 2})
+    def map :: Map = dynamic({"a": 1, "b": 2})
     map.length()
     2
   check:
-    def map -: Map: dynamic({"a": 1, "b": 2})
+    def map -: Map = dynamic({"a": 1, "b": 2})
     map.length()
     2
   check:
-    def map :: Map.of(String, Integer): dynamic({"a": 1, "b": 2})
+    def map :: Map.of(String, Integer) = dynamic({"a": 1, "b": 2})
     map.length()
     2
 
@@ -83,7 +83,7 @@ begin:
     {&{"b": "oops"}, "c": "oops", "b": 2, "a": 1, &{"c": 3}}
     {"a": 1, "b": 2, "c": 3}
   check:
-    def mutable x: []
+    def mutable x = []
     [{&(begin: x := [1, x]; {"b": 2}), (begin: x:= [2, x]; "a"): 1, &(begin: x:= [3, x]; {"c": 3})},
      x]
     [{"a": 1, "b": 2, "c": 3},

--- a/rhombus/tests/mutable.rhm
+++ b/rhombus/tests/mutable.rhm
@@ -2,30 +2,30 @@
 import: "check.rhm" open
 
 check:
-  def mutable x: 0
+  def mutable x = 0
   [x := 1, x]
   [#void, 1]
 
 check:
-  let x: 0
+  let x = 0
   fun f(): x
-  let x: 2
+  let x = 2
   [x, f()]
   [2, 0]
 
 check:
-  let x: 0
+  let x = 0
   fun f(): x
-  let mutable x: 2
+  let mutable x = 2
   x := 3
   [x, f()]
   [3, 0]
 
 check:
-  let mutable x: 0
+  let mutable x = 0
   fun f(): x
   fun g(n): x := n
-  let mutable x: 2
+  let mutable x = 2
   g(3)
   [x, f()]
   [2, 3]

--- a/rhombus/tests/namespace-extend.rhm
+++ b/rhombus/tests/namespace-extend.rhm
@@ -4,10 +4,10 @@ import:
 
 namespace root:
   namespace trunk:
-    def name: "trunk"
+    def name = "trunk"
     export: name
-  def name: "root"
-  def trunk.side: "left"
+  def name = "root"
+  def trunk.side = "left"
   export: trunk name
 
 check:
@@ -24,7 +24,7 @@ check:
 
 check:
   namespace root.trunk.branch:
-    def name: "branch"
+    def name = "branch"
     export: name
   root.trunk.branch.name
   "branch"
@@ -42,8 +42,8 @@ check:
   root.trunk.f(" hi")
   "trunk hi"
 
-def root.ten: 10
-def root.trunk.seven: 7
+def root.ten = 10
+def root.trunk.seven = 7
 
 check:
   root.ten
@@ -81,12 +81,12 @@ check:
   [[1, 2]]
 
 check:
-  def root.name: "ROOT"
+  def root.name = "ROOT"
   root.name
   "ROOT"
 
 check:
-  def root.trunk.name: "TRUNK"
+  def root.trunk.name = "TRUNK"
   [root.name, root.trunk.name]
   ["root", "TRUNK"]
 
@@ -98,7 +98,7 @@ check:
 namespace route:
   export: trunc
   namespace trunc
-  def trunc.name: "trunc"
+  def trunc.name = "trunc"
 
 check:
   route.trunc.name
@@ -122,10 +122,10 @@ check:
 check:
   namespace math
   namespace ext1:
-    def math.e: 2.71
+    def math.e = 2.71
     export: math
   namespace ext2:
-    def math.d: "d"
+    def math.d = "d"
     export: math
   [ext1.math.e, ext2.math.d]
   [2.71, "d"]

--- a/rhombus/tests/namespace.rhm
+++ b/rhombus/tests/namespace.rhm
@@ -2,7 +2,7 @@
 import: "check.rhm" open
 
 namespace home:
-  def x: "x"
+  def x = "x"
   class Posn(x, y)
   export:
     x

--- a/rhombus/tests/pair.rhm
+++ b/rhombus/tests/pair.rhm
@@ -14,7 +14,7 @@ check:
   [1, 2]
 
 check:
-  def p :: Pair: [1, 2]
+  def p :: Pair = [1, 2]
   p
   [1, 2]
 
@@ -52,25 +52,25 @@ begin:
     Pair.cons(1, 2).rest
     2
   check:
-    def x :: Pair: [1, 2, 3]
+    def x :: Pair = [1, 2, 3]
     x.first
     1
   check:
-    def Pair(x, y): [1, 2, 3]
+    def Pair(x, y) = [1, 2, 3]
     x
     1
   check:
     (["ok", "fine"] :: Pair.of(String, List)).rest
     ["fine"]
   check:
-    def Pair(x :: List, y): [[1, 2, 3]]
+    def Pair(x :: List, y) = [[1, 2, 3]]
     x.length()
     3
   check:
     (["ok", "fine"] :: Pair.of(String, List)).rest.length()
     1
   check:
-    def x :: Pair.of(List, Any): [[1, 2, 3]]
+    def x :: Pair.of(List, Any) = [[1, 2, 3]]
     x.first.length()
     3
 

--- a/rhombus/tests/pattern-template-escape.rhm
+++ b/rhombus/tests/pattern-template-escape.rhm
@@ -90,8 +90,8 @@ check:
   ~print
   //  macro that acts as a template form
   expr.rule '$x =+= $y': '('$('$')$x + $('$')$y')'
-  def a: '3'
-  def b: '4'
+  def a = '3'
+  def b = '4'
   a =+= b
   '3 + 4'
 

--- a/rhombus/tests/rest-args.rhm
+++ b/rhombus/tests/rest-args.rhm
@@ -48,7 +48,7 @@ check:
   [1, 2, 3, 4]
 
 begin:
-  def [a, b, & rst] : [1, 2, 3, 4]
+  def [a, b, & rst] = [1, 2, 3, 4]
   check: a; 1
   check: b; 2
   check: rst; [3, 4]
@@ -78,21 +78,21 @@ check:
   {"a", "b", "c", "d"}
 
 begin:
-  def {"a": a, "b": b, & rst} : {"a": 1, "b": 2, "c": 3, "d": 4}
+  def {"a": a, "b": b, & rst} = {"a": 1, "b": 2, "c": 3, "d": 4}
   check: a; 1
   check: b; 2
   check: rst; {"c": 3, "d": 4}
 
 begin:
-  def Map{"a": a, "b": b, & rst} : {"a": 1, "b": 2, "c": 3, "d": 4}
+  def Map{"a": a, "b": b, & rst} = {"a": 1, "b": 2, "c": 3, "d": 4}
   check: a; 1
   check: b; 2
   check: rst; {"c": 3, "d": 4}
 
 // Match & rest on mutable maps produces an immutable copy
 begin:
-  def m : MutableMap{"a": 1, "b": 2}
-  def r : match m
+  def m = MutableMap{"a": 1, "b": 2}
+  def r = match m
           | {"a": a, & rst}: rst
           | _: #false
   m["b"] := 3
@@ -217,7 +217,7 @@ fun
 fun
 | triangle_area(~base, ~height): (1/2) * base * height
 | triangle_area(~side1, ~side2, ~side3):
-    def s: (1/2) * (side1 + side2 + side3)
+    def s = (1/2) * (side1 + side2 + side3)
     sqrt(s * (s - side1) * (s - side2) * (s - side3))
 
 fun
@@ -236,7 +236,7 @@ check: shape_area(~type: "triangle", ~side1: 17, ~side2: 17, ~side3: 16); 120
 // Repetition Rest with ...
 
 begin:
-  def [x, ...]: [2, 3]
+  def [x, ...] = [2, 3]
   check: expt(x, ...); 8
   check: List(x, ...); [2, 3]
 
@@ -263,7 +263,7 @@ check:
   add(1, 2, 3)
   6
 
-def [n :: Integer, ...]: [10, 20, 30]
+def [n :: Integer, ...] = [10, 20, 30]
 check:
   add(1, n, ...)
   61
@@ -280,7 +280,7 @@ check:
 
 check:
   ~print
-  def [s, ...]: ["a", "b", "c"]
+  def [s, ...] = ["a", "b", "c"]
   '(hi $s) ...'
   '(hi "a") (hi "b") (hi "c")'
   
@@ -291,13 +291,13 @@ check:
 
 class Posn(x, y)
 
-def List(p :: Posn, ...) : [Posn(1, 2), Posn(3, 4)]
+def List(p :: Posn, ...) = [Posn(1, 2), Posn(3, 4)]
 check:
   [p, ...][0].x
   1
 
 fun posns_y1(& rst):
-  def List(p :: Posn, ...) : rst
+  def List(p :: Posn, ...) = rst
   [p, ...][1].y
 
 check:
@@ -326,7 +326,7 @@ check:
   15
 
 check:
-  def [x, ...]: [3, 4]
+  def [x, ...] = [3, 4]
   add(1, 2, x, ..., 5)
   15
 
@@ -335,12 +335,12 @@ check:
   14
 
 check:
-  def [x, ...]: [3, 4]
+  def [x, ...] = [3, 4]
   add(&[-1, 1], 2, x, ..., 5)
   14
 
 check:
-  def mutable s: 0
+  def mutable s = 0
   [add(&(begin: s := [1, s]; [-1, 1]),
        (begin: s := [2, s]; 2),
        &(begin: s := [3, s]; [3, 4]),
@@ -352,19 +352,19 @@ check:
 // `~&` not at end
 
 check:
-  def mutable s: 0
+  def mutable s = 0
   [triangle_area(~base: (begin: s := [1, s]; 1), ~& (begin: s := [2, s]; { keyword'~height': 10 })),
    s]
   [5, [2, [1, 0]]]
 
 check:
-  def mutable s: 0
+  def mutable s = 0
   [triangle_area(~& (begin: s := [2, s]; { keyword'~height': 10 }), ~base: (begin: s := [1, s]; 1)), 
    s]
   [5, [1, [2, 0]]]
 
 check:
-  def mutable s: 0
+  def mutable s = 0
   [anyargs(~& (begin: s := [1, s]; { keyword'~height': 10 }),
            & (begin: s := [2, s]; [9, 10, 11]),
            ~base: (begin: s := [3, s]; 1),
@@ -373,7 +373,7 @@ check:
   [[[9, 10, 11, 8], {keyword'~base': 1, keyword'~height': 10}], [4, [3, [2, [1, 0]]]]]
 
 check:
-  def mutable s: 0
+  def mutable s = 0
   [anyargs(& (begin: s := [1, s]; [9, 10, 11]),
            ~& (begin: s := [2, s]; { keyword'~height': 10 }),
            ~base: (begin: s := [3, s]; 1),
@@ -382,7 +382,7 @@ check:
   [[[9, 10, 11, 8, 88], {keyword'~base': 1, keyword'~height': 10}], [4, [3, [2, [1, 0]]]]]
 
 check:
-  def mutable s: 0
+  def mutable s = 0
   [anyargs(& (begin: s := [1, s]; [9, 10, 11]),
            ~& (begin: s := [2, s]; { keyword'~height': 10 }),
            ~base: (begin: s := [3, s]; 1),

--- a/rhombus/tests/set.rhm
+++ b/rhombus/tests/set.rhm
@@ -27,19 +27,19 @@ begin:
     MutableSet("a", "b").length()
     2
   check:
-    def set: {1, 2}
+    def set = {1, 2}
     set.length()
     2
   check:
-    def set :: Set: dynamic({"a", "b"})
+    def set :: Set = dynamic({"a", "b"})
     set.length()
     2
   check:
-    def set -: Set: dynamic({"a", "b"})
+    def set -: Set = dynamic({"a", "b"})
     set.length()
     2
   check:
-    def set :: Set.of(String): dynamic({"a", "b"})
+    def set :: Set.of(String) = dynamic({"a", "b"})
     set.length()
     2
 
@@ -72,7 +72,7 @@ begin:
     {"b", &{"b"}, "c", "a", &{"c"}}
     {"a", "b", "c"}
   check:
-    def mutable x: []
+    def mutable x = []
     [{&(begin: x := [1, x]; {"b"}), (begin: x:= [2, x]; "a"), &(begin: x:= [3, x]; {"c"})},
      x]
     [{"a", "b", "c"},

--- a/rhombus/tests/syntax-class.rhm
+++ b/rhombus/tests/syntax-class.rhm
@@ -92,7 +92,7 @@ begin:
 begin:
   syntax.class Foo
   | 'a $x':
-      def x: "whatever"
+      def x = "whatever"
   check:
     ~print
     match 'a 1'

--- a/scribble/private/rhombus.rhm
+++ b/scribble/private/rhombus.rhm
@@ -56,19 +56,19 @@ meta:
     | '$_ $_ $_($stxs)': stxs
 
   fun nested(gs, builder, builder_stx, stxs):
-    def [new_g, ...]: map(escape_group, gs)
+    def [new_g, ...] = map(escape_group, gs)
     if andmap(is_literal_group, [new_g, ...])
     | literal_term(builder(map(extract_literal, [new_g, ...]), head_context(stxs)))
     | '$builder_stx([$new_g, ...], Syntax.literal($(head_context(stxs))))'
 
   fun nested_alts(bs, stxs):
-    def [new_b, ...]: map(escape_term, bs)
+    def [new_b, ...] = map(escape_term, bs)
     if andmap(is_literal_term, [new_b, ...])
     | literal_term(alts_syntax(map(extract_literal, [new_b, ...]), head_context(stxs)))
     | 'alts_syntax([$new_b, ...], Syntax.literal($(head_context(stxs))))'
 
   fun escape_group(g):
-    def new_g: escape_tail(g)
+    def new_g = escape_tail(g)
     if is_literal_group(new_g)
     | literal_group(Syntax.relocate(extract_literal(new_g), group_context(g)))
     | 'Syntax.relocate($new_g, Syntax.literal($(group_context(g))))'
@@ -79,9 +79,9 @@ meta:
         'sequence_cons_syntax(elem($expr ...), $(escape_tail('$tail ...')),
                               Syntax.literal($(head_escape_context(stxs))))'
     | '$head $tail ...':
-        def values(a_head, a_tail): adjust_spaces(head, '$tail ...')
-        def new_head: escape_term(a_head)
-        def new_tail: escape_tail(a_tail)
+        def values(a_head, a_tail) = adjust_spaces(head, '$tail ...')
+        def new_head = escape_term(a_head)
+        def new_tail = escape_tail(a_tail)
         if is_literal_term(new_head) && is_literal_group(new_tail)
         | literal_group(sequence_append_syntax(extract_literal(new_head), extract_literal(new_tail)))
         | 'sequence_append_syntax($new_head, $new_tail)'
@@ -102,7 +102,7 @@ meta:
     | '| $(b :: Block) | ...':
         nested_alts([b, ...], stxs)
     | '$(id :: Id_Op)':
-        def mv: Syntax.meta_value(typeset_meta.in_space(id), #false)
+        def mv = Syntax.meta_value(typeset_meta.in_space(id), #false)
         match mv
         | typeset_meta.Transformer(proc):
             'relocate_expansion($(proc(id)),
@@ -113,7 +113,7 @@ meta:
   fun adjust_spaces(head, tail):
     match '$head'
     | '$(id :: Id_Op)':
-        def mv: Syntax.meta_value(typeset_meta.in_space(id), #false)
+        def mv = Syntax.meta_value(typeset_meta.in_space(id), #false)
         match mv
         | typeset_meta.Spacer(proc):
             proc(head, tail, '$$')                
@@ -135,7 +135,7 @@ expr.macro
     values('#{typeset-rhombus}($(escape_group(forms)))',
            '$main_tail ...')
 | 'rhombus ($forms, $(kw_stx :: Keyw)) $main_tail ...':
-    def kw: Syntax.unwrap(kw_stx)
+    def kw = Syntax.unwrap(kw_stx)
     if (kw === keyword(~var)
           || kw === keyword(~bind)
           || kw === keyword(~impmod)
@@ -156,7 +156,7 @@ expr.macro 'rhombusblock $tail ...':
   fun finish(options, fin_tail):
     match fin_tail
     | ': $_':
-        def [opt, ...]: options
+        def [opt, ...] = options
         values('#{typeset-rhombusblock}($opt, ..., $(escape_term(fin_tail)))', '')
     | ~else: Syntax.error("expected a block", '$me $tail ...')
   fun check_options(options):


### PR DESCRIPTION
Using `=` for `def` and similar forms reduces the sea of `:`s, and it connects better to using `=` for default-value expressions for function arguments and class fields. When I compare the two `namespace` blocks below, the `=` form is clearly more readable.

```
class Posn(x, y)

namespace A:

  def origin: Posn(0, 0)
  def p :: Posn: origin
  def Posn(x, y): origin

namespace B:

  def origin = Posn(0, 0)
  def p :: Posn = origin
  def Posn(x, y) = origin
```

Using `:` is still allowed, and it looks nicer for multi-line definitions than having to use `begin`.

```
namespace A:

  def one_thirty:
    def pi = 3.14
    Posn(cos(pi/4), sin(pi/4))

namespace B:

  def one_thirty = begin:
    def pi = 3.14
    Posn(cos(pi/4), sin(pi/4))
```

The difference between `:` and `= begin:` is much smaller than `:` versus `=`. We could support only `=`, but somehow it feels more consistent to me to still allow `:` in `def`, like other forms. I think of `=` as a readable shorthand, similar to way that `fun f(): ....` is a preferred shorthand to `def f = fun(): ....`.

For consistency, `:` is also allowed instead of `=` when providing a default-value expression for an optional functional argument or constructor field. I am not sure this matters.

There is no change to shrubbery notation to support `=`. An alternative is that `=` becomes a block-creating character like `:`. Changing shrubbery notation in that way would make parsing/matching on `=` forms easier, and it would impose a shrubbery-level grouping on uses of `=`. But it would also make shrubbery notation more specific to Rhombus. Since`=` is going to be use in many fewer places than `:`, and since constraining `=` to a single-line continuation might be a good choice anyway, this proposal leaves parsing to the small number of places that will recognize `=`: `def`, `let`, and `field` (in addition to the function-argument and field forms with defaults, which already had to do this kind of parsing).

Disadvantages of this proposal:

 * There's more than one way to write `def` to `let` or `field`, so a programmer has to pick.
 * Syntax matching on `=` forms is clumsy compared to matching `:`.

Advantages of this proposal:

 * There's more than one way to write `def`, etc., so a programmer gets to pick.
 * Using `=` in the relevant positions is more readable than `:`.
 * Typing something like `def x = 5` in a REPL is much nicer than `def x: 5` followed by an extra newline.
 * Allowing `:` preserves a connection to most other forms, and is sometimes tidier.
 