### PR TITLE
Add recur argument to Equatable methods

### DIFF
--- a/rhombus/private/equatable.rkt
+++ b/rhombus/private/equatable.rkt
@@ -9,9 +9,7 @@
          "class-dot.rkt"
          (only-in "class-desc.rkt" define-class-desc-syntax))
 
-(provide (for-spaces (rhombus/namespace
-                      rhombus/class
-                      rhombus/annot)
+(provide (for-spaces (rhombus/class)
                      Equatable))
 
 (define-values (prop:Equatable Equatable? Equatable-ref)
@@ -59,35 +57,6 @@
                   (hasheq 'equal_recur 0 'hash_recur 1)
                   #hasheq()
                   #t))
-
-(define-name-root Equatable
-  #:fields
-  ([equal_recur equal-recur-method]
-   [hash_recur hash-recur-method]))
-
-(define-annotation-syntax Equatable
-  (identifier-annotation #'Equatable-public? #'((#%dot-provider equatable-instance))))
-
-(define-dot-provider-syntax equatable-instance
-  (dot-provider-more-static (make-handle-class-instance-dot #'Equatable #hasheq() #hasheq())))
-
-(define (get-equatable who v)
-  (define vt (Equatable-public-ref v #false))
-  (unless vt
-    (raise-argument-error* who rhombus-realm "Equatable" v))
-  vt)
-
-(define equal-recur-method
-  (let ([equal_recur
-         (lambda (this other recur)
-           ((vector-ref (get-equatable 'equal_recur this) 0) this other recur))])
-    equal_recur))
-  
-(define hash-recur-method
-  (let ([hash_recur
-         (lambda (this recur)
-           ((vector-ref (get-equatable 'hash_recur this) 1) this recur))])
-    hash_recur))
 
 (define (equal-recur-internal-method this other recur)
   ((vector-ref (Equatable-ref this) 0) this other recur))

--- a/rhombus/private/equatable.rkt
+++ b/rhombus/private/equatable.rkt
@@ -38,10 +38,10 @@
                   #'()
                   #'prop:Equatable
                   #'Equatable-ref
-                  (vector-immutable (box-immutable 'equal_recur)
-                                    (box-immutable 'hash_recur))
+                  (vector-immutable (box-immutable 'equals)
+                                    (box-immutable 'hash_code))
                   #'#(#:abstract #:abstract)
-                  (hasheq 'equal_recur 0 'hash_recur 1)
+                  (hasheq 'equals 0 'hash_code 1)
                   #hasheq()
                   #t))
 
@@ -51,10 +51,10 @@
                   #'()
                   #'prop:Equatable-public
                   #'Equatable-public-ref
-                  (vector-immutable (box-immutable 'equal_recur)
-                                    (box-immutable 'hash_recur))
+                  (vector-immutable (box-immutable 'equals)
+                                    (box-immutable 'hash_code))
                   #'#(#:abstract #:abstract)
-                  (hasheq 'equal_recur 0 'hash_recur 1)
+                  (hasheq 'equals 0 'hash_code 1)
                   #hasheq()
                   #t))
 

--- a/rhombus/private/equatable.rkt
+++ b/rhombus/private/equatable.rkt
@@ -25,10 +25,10 @@
 
 
 (define (bounce-to-equal-mode-proc this other recur mode)
-  (equals-internal-method this other))
+  (equal-recur-internal-method this other recur))
 
 (define (bounce-to-hash-mode-proc this recur mode)
-  (hashCode-internal-method this))
+  (hash-recur-internal-method this recur))
 
 (define bounced-equal+hash-implementation
   (list bounce-to-equal-mode-proc bounce-to-hash-mode-proc))
@@ -40,9 +40,10 @@
                   #'()
                   #'prop:Equatable
                   #'Equatable-ref
-                  (vector-immutable (box-immutable 'equals) (box-immutable 'hashCode))
+                  (vector-immutable (box-immutable 'equal_recur)
+                                    (box-immutable 'hash_recur))
                   #'#(#:abstract #:abstract)
-                  (hasheq 'equals 0 'hashCode 1)
+                  (hasheq 'equal_recur 0 'hash_recur 1)
                   #hasheq()
                   #t))
 
@@ -52,16 +53,17 @@
                   #'()
                   #'prop:Equatable-public
                   #'Equatable-public-ref
-                  (vector-immutable (box-immutable 'equals) (box-immutable 'hashCode))
+                  (vector-immutable (box-immutable 'equal_recur)
+                                    (box-immutable 'hash_recur))
                   #'#(#:abstract #:abstract)
-                  (hasheq 'equals 0 'hashCode 1)
+                  (hasheq 'equal_recur 0 'hash_recur 1)
                   #hasheq()
                   #t))
 
 (define-name-root Equatable
   #:fields
-  ([equals equals-method]
-   [hashCode hashCode-method]))
+  ([equal_recur equal-recur-method]
+   [hash_recur hash-recur-method]))
 
 (define-annotation-syntax Equatable
   (identifier-annotation #'Equatable-public? #'((#%dot-provider equatable-instance))))
@@ -75,18 +77,20 @@
     (raise-argument-error* who rhombus-realm "Equatable" v))
   vt)
 
-(define equals-method
-  (let ([equals (lambda (this other)
-                  ((vector-ref (get-equatable 'equals this) 0) this other))])
-    equals))
+(define equal-recur-method
+  (let ([equal_recur
+         (lambda (this other recur)
+           ((vector-ref (get-equatable 'equal_recur this) 0) this other recur))])
+    equal_recur))
   
-(define hashCode-method
-  (let ([hashCode (lambda (this)
-                 ((vector-ref (get-equatable 'hashCode this) 1) this))])
-    hashCode))
+(define hash-recur-method
+  (let ([hash_recur
+         (lambda (this recur)
+           ((vector-ref (get-equatable 'hash_recur this) 1) this recur))])
+    hash_recur))
 
-(define (equals-internal-method v op)
-  ((vector-ref (Equatable-ref v) 0) v op))
+(define (equal-recur-internal-method this other recur)
+  ((vector-ref (Equatable-ref this) 0) this other recur))
 
-(define (hashCode-internal-method v op)
-  ((vector-ref (Equatable-ref v) 1) v op))
+(define (hash-recur-internal-method this recur)
+  ((vector-ref (Equatable-ref this) 1) this recur))

--- a/rhombus/tests/equatable.rhm
+++ b/rhombus/tests/equatable.rhm
@@ -4,28 +4,28 @@ use_static
 
 class AnythingGoes():
   private implements Equatable
-  private override equal_recur(other, recur): #true
-  private override hash_recur(recur): 0
+  private override equals(other, recur): #true
+  private override hash_code(recur): 0
 
 class NoGo():
   private implements Equatable
-  private override equal_recur(other, recur): #false
-  private override hash_recur(recur): 0
+  private override equals(other, recur): #false
+  private override hash_code(recur): 0
 
 class Fail():
   private implements Equatable
-  private override equal_recur(other, recur): error("failure")
-  private override hash_recur(recur): error("failure")
+  private override equals(other, recur): error("failure")
+  private override hash_code(recur): error("failure")
 
 check AnythingGoes() == AnythingGoes() ~is #true
 check:
   use_dynamic
-  AnythingGoes().equal_recur(AnythingGoes(), fun (& _): #true)
-  ~raises "equal_recur: no such field or method"
+  AnythingGoes().equals(AnythingGoes(), fun (& _): #true)
+  ~raises "equals: no such field or method"
 check:
   use_dynamic
-  AnythingGoes().hash_recur(fun (_): 0)
-  ~raises "hash_recur: no such field or method"
+  AnythingGoes().hash_code(fun (_): 0)
+  ~raises "hash_code: no such field or method"
 
 check AnythingGoes() == NoGo() ~is #false
 check NoGo() == AnythingGoes()  ~is #false

--- a/rhombus/tests/equatable.rhm
+++ b/rhombus/tests/equatable.rhm
@@ -1,0 +1,40 @@
+#lang rhombus
+
+use_static
+
+class AnythingGoes():
+  implements Equatable
+  override equal_recur(other, recur): #true
+  override hash_recur(recur): 0
+
+class NoGo():
+  implements Equatable
+  override equal_recur(other, recur): #false
+  override hash_recur(recur): 0
+
+class Fail():
+  implements Equatable
+  override equal_recur(other, recur): error("failure")
+  override hash_recur(recur): error("failure")
+
+check AnythingGoes() == AnythingGoes() ~is #true
+// TODO: hide methods `equal_recur` and `hash_recur`,
+//       then test that they can't be called directly
+
+check AnythingGoes() == NoGo() ~is #false
+check NoGo() == AnythingGoes()  ~is #false
+
+check NoGo() == NoGo() ~is #false
+begin:
+  let ng: NoGo()
+  check ng == ng ~is #true
+
+check AnythingGoes() == Fail() ~is #false
+check Fail() == AnythingGoes() ~is #false
+check NoGo() == Fail() ~is #false
+check Fail() == NoGo() ~is #false
+check Fail() == Fail() ~raises "failure"
+begin:
+  let f: Fail()
+  check f == f ~is #true
+

--- a/rhombus/tests/equatable.rhm
+++ b/rhombus/tests/equatable.rhm
@@ -3,23 +3,29 @@
 use_static
 
 class AnythingGoes():
-  implements Equatable
-  override equal_recur(other, recur): #true
-  override hash_recur(recur): 0
+  private implements Equatable
+  private override equal_recur(other, recur): #true
+  private override hash_recur(recur): 0
 
 class NoGo():
-  implements Equatable
-  override equal_recur(other, recur): #false
-  override hash_recur(recur): 0
+  private implements Equatable
+  private override equal_recur(other, recur): #false
+  private override hash_recur(recur): 0
 
 class Fail():
-  implements Equatable
-  override equal_recur(other, recur): error("failure")
-  override hash_recur(recur): error("failure")
+  private implements Equatable
+  private override equal_recur(other, recur): error("failure")
+  private override hash_recur(recur): error("failure")
 
 check AnythingGoes() == AnythingGoes() ~is #true
-// TODO: hide methods `equal_recur` and `hash_recur`,
-//       then test that they can't be called directly
+check:
+  use_dynamic
+  AnythingGoes().equal_recur(AnythingGoes(), fun (& _): #true)
+  ~raises "equal_recur: no such field or method"
+check:
+  use_dynamic
+  AnythingGoes().hash_recur(fun (_): 0)
+  ~raises "hash_recur: no such field or method"
 
 check AnythingGoes() == NoGo() ~is #false
 check NoGo() == AnythingGoes()  ~is #false


### PR DESCRIPTION
Adds a `recur` argument to the `Equatable` methods, and also changes the method names to reflect that. The `Equatable` interface is intended to be privately implemented, so this also removes the `Equatable` namespace and its "public" method access points, as well as the `Equatable` annotation since a class that privately implements `Equatable` won't match the annotation anyway.

Using the `recur` argument allows `Equatable` to specify correct `chaperone-of?` behavior, as well as other benefits like cycle-detection and other things enabled by `equal?/recur` and `equal-always?/recur`, such as looser equality for inexact numbers for `check-within` testing purposes.

See also
 - https://github.com/racket/rhombus-prototype/pull/265#issuecomment-1373079389
 - `cheat/c` from https://github.com/racket/rhombus-prototype/pull/265#issuecomment-1374000621
 - Racket discord, rhombus channel, 2023-01-04: https://discord.com/channels/571040468092321801/871953739982995547/1060369305314807929
 - Racket discord, rhombus equality channel, equal-within thread, 2023-02-03: https://discord.com/channels/571040468092321801/1071150855123914782/1071156782761783416