### PR TITLE
Rest argument hash_code_combine & unordered

### DIFF
--- a/rhombus/private/equatable.rkt
+++ b/rhombus/private/equatable.rkt
@@ -56,38 +56,42 @@
 
 (define hash_code_combine
   (case-lambda
+    [() (hash-code-combine)]
+    [(a)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" a))
+     (hash-code-combine a)]
     [(a b)
      (unless (exact-integer? a)
        (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" a))
      (unless (exact-integer? b)
        (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" b))
      (hash-code-combine a b)]
-    [(lst)
-     (unless (and (list? lst)
-                  (andmap exact-integer? lst))
-       (raise-argument-error* 'Equatable.hash_code_combine
-                              rhombus-realm
-                              "List.of(Integer)"
-                              lst))
+    [lst
+     (for ([e (in-list lst)])
+       (unless (exact-integer? e)
+         (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Integer" e)))
      (hash-code-combine* lst)]))
 
-(define-static-info-syntax hash_code_combine (#%function-arity 6))
+(define-static-info-syntax hash_code_combine (#%function-arity -1))
                                                                
 (define hash_code_combine_unordered
   (case-lambda
+    [() (hash-code-combine-unordered)]
+    [(a)
+     (unless (exact-integer? a)
+       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" a))
+     (hash-code-combine-unordered a)]
     [(a b)
      (unless (exact-integer? a)
        (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" a))
      (unless (exact-integer? b)
        (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" b))
      (hash-code-combine-unordered a b)]
-    [(lst)
-     (unless (and (list? lst)
-                  (andmap exact-integer? lst))
-       (raise-argument-error* 'Equatable.hash_code_combine_unordered
-                              rhombus-realm
-                              "List.of(Integer)"
-                              lst))
+    [lst
+     (for ([e (in-list lst)])
+       (unless (exact-integer? e)
+         (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Integer" e)))
      (hash-code-combine-unordered* lst)]))
 
-(define-static-info-syntax hash_code_combine_unoredered (#%function-arity 6))
+(define-static-info-syntax hash_code_combine_unoredered (#%function-arity -1))

--- a/rhombus/scribblings/ref-equal.scrbl
+++ b/rhombus/scribblings/ref-equal.scrbl
@@ -140,17 +140,12 @@
 }
 
 @doc(
-  fun Equatable.hash_code_combine(hc1 :: Integer,
-                                  hc2 :: Integer) :: Integer
-  fun Equatable.hash_code_combine([hc :: Integer, ...]) :: Integer
-  fun Equatable.hash_code_combine_unordered(hc1 :: Integer,
-                                            hc2 :: Integer) :: Integer
-  fun Equatable.hash_code_combine_unordered([hc :: Integer, ...])
-    :: Integer
+  fun Equatable.hash_code_combine(hc :: Integer, ...) :: Integer
+  fun Equatable.hash_code_combine_unordered(hc :: Integer, ...) :: Integer
 ){
 
- Combines two hash codes to produce a new one. Information is generally
- lost in the combination, but this combining function is mixes integers
+ Combines hash codes to produce a new one. Information is generally
+ lost in the combination, but this combining function mixes integers
  in a suitable way to produce good results for hashing.
 
  See @rhombus(Equatable, ~class) for an example.


### PR DESCRIPTION
Changes `hash_code_combine` and `hash_code_combine_unordered` to use a rest argument list instead of a single-argument list. This also lets `hash_code_combine` on one argument mix a single hash code just like `hash-code-combine`.