### PR TITLE
For each parens

### DIFF
--- a/rhombus/private/for.rkt
+++ b/rhombus/private/for.rkt
@@ -110,8 +110,9 @@
                                                          #`((#,group-tag any ...))
                                                          #'rhs-blk)
                           . bodys))]
-            [(group prim-for-clause #:each (block (group any ...+ rhs-blk)
-                                                  ...))
+            [(group prim-for-clause #:each ({~or block parens}
+                                            (group any ...+ rhs-blk)
+                                            ...))
              ;; parse binding as binding group
              #`(#:splice (for-clause-step
                           orig
@@ -262,6 +263,10 @@
        #:datum-literals (group block)
        [(form-id d::each-decl)
         #`[(#,group-tag prim-for-clause #:each d.bind ... d.blk)]]
+       [(form-id (tag::parens (group d::each-decl) ...))
+        #`[(#,group-tag prim-for-clause #:each (tag
+                                                (group d.bind ... d.blk)
+                                                ...))]]
        [(form-id (tag::block (group d::each-decl) ...))
         #`[(#,group-tag prim-for-clause #:each (tag
                                                 (group d.bind ... d.blk)

--- a/rhombus/scribblings/ref-for.scrbl
+++ b/rhombus/scribblings/ref-for.scrbl
@@ -28,6 +28,7 @@
         $body
         ...
       ...
+    #,(@rhombus(each, ~for_clause)) ($bind: $body; ..., ...)
     #,(@rhombus(keep_when, ~for_clause)) $expr_or_block
     #,(@rhombus(skip_when, ~for_clause)) $expr_or_block
     #,(@rhombus(break_when, ~for_clause)) $expr_or_block
@@ -175,6 +176,10 @@
                         $body
                         ...
                       ...'
+  for_clause.macro 'each ($bind:
+                            $body
+                            ...,
+                          ...)'
   for_clause.macro 'each $bind:
                       $body
                       ...'

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -16,6 +16,10 @@ check:
   ~is [0, 1]
 
 check:
+  for List: each (i: 0..2); i
+  ~is [0, 1]
+
+check:
   for Map:
     each i: 0..2
     values(i, "" +& i)
@@ -48,6 +52,10 @@ check:
       i: 0..2
       j: 0..2
     [i, -j-1]
+  ~is [[0, -1], [1, -2]]
+
+check:
+  for List: each (i: 0..2, j: 0..2); [i, -j-1]
   ~is [[0, -1], [1, -2]]
 
 check:
@@ -171,3 +179,11 @@ check:
     each i: 3..7
     i
   ~raises "index is out of range"
+
+check:
+  for List:
+    each (x: let ns: for List: each (n: 1..4); n
+             ns ++ List.rest(List.reverse(ns)),
+          y: 1..6)
+    x * y
+  ~is [1, 4, 9, 8, 5]


### PR DESCRIPTION
Allows `each` clauses in `for` macros to use parentheses like
```
each (x: l)
```
Which allows some `for` forms to be written on one line more easily:
```
for List: each (x: l); f(x)
```
Without needing to use special characters like `«»`.

This also allows multiple sequences:
```
each (x: xs, y: ys)
```
Equivalent to
```
each:
  x: xs
  y: ys
```