### PR TITLE
docs: misplaced comma in Function.of_arity

### DIFF
--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -20,7 +20,7 @@ normally bound to implement function calls.
 
 @doc(
   annot.macro 'Function'
-  annot.macro 'Function.of_arity($expr_or_keyword,, $expr_or_keyword, ...)'
+  annot.macro 'Function.of_arity($expr_or_keyword, $expr_or_keyword, ...)'
   grammar expr_or_keyword:
     $expr
     $keyword


### PR DESCRIPTION
Changes `,,` to `,` in the documentation of `Function.of_arity`