### PR TITLE
Change `to_string` to convert mutable strings to immutable.

### DIFF
--- a/rhombus/private/string.rkt
+++ b/rhombus/private/string.rkt
@@ -56,7 +56,6 @@
 (define/arity (to_string a)
   #:static-infos ((#%call-result #,string-static-infos))
   (cond
-    [(immutable-string? a) a]
     [(string? a) (string->immutable-string a)]
     [(symbol? a) (symbol->immutable-string a)]
     [(keyword? a) (keyword->immutable-string a)]

--- a/rhombus/private/string.rkt
+++ b/rhombus/private/string.rkt
@@ -56,7 +56,8 @@
 (define/arity (to_string a)
   #:static-infos ((#%call-result #,string-static-infos))
   (cond
-    [(string? a) a]
+    [(immutable-string? a) a]
+    [(string? a) (string->immutable-string a)]
     [(symbol? a) (symbol->immutable-string a)]
     [(keyword? a) (keyword->immutable-string a)]
     [(identifier? a) (symbol->immutable-string (syntax-e a))]


### PR DESCRIPTION
Since `String` only corresponds to immutable strings in Rhombus,
`to_string` should always produce them.