### PR TITLE
Avoid statically-unnecessary conditionals in bindings.

### DIFF
--- a/rhombus/private/def+let.rkt
+++ b/rhombus/private/def+let.rkt
@@ -143,6 +143,7 @@
 
 (define-syntax (flattened-if stx)
   (syntax-parse stx
+    [(_ #t success-expr _) #'success-expr]
     [(_ check-expr success-expr fail-expr)
      #'(begin
          (unless check-expr fail-expr)

--- a/rhombus/private/nested-bindings.rkt
+++ b/rhombus/private/nested-bindings.rkt
@@ -40,6 +40,8 @@
 
 (define-syntax (if-block stx)
   (syntax-parse stx
+    [(_ #t thn els) #`(racket-block thn)]
+    [(_ #f thn els) #`(racket-block els)]
     [(_ tst thn els)
      #`(if tst (racket-block thn) (racket-block els))]))
 


### PR DESCRIPTION
These will be optimized away, but it reduces the amount of code
we have to handle in the expander/optimizer and makes expanded
code easier to read.