### PR TITLE
block-alts design proposal

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -128,8 +128,8 @@ also_first_one([1, 2, 3, 4])
 
 fun add1(x) :: Int:
   match x
-   | n :: Int : x + 1
-   | ~else: x
+  | n :: Int : x + 1
+  | ~else: x
 
 add1(100)
 // would trigger an error, since "oops" is not an `Int`:

--- a/design/block-alts/block-alts.md
+++ b/design/block-alts/block-alts.md
@@ -397,6 +397,37 @@ syntax_parse stx_expr:
 
 Instead of needing some identifier like `pattern` or `match` separating the options from the cases.
 
+### Option C: `|` pipe indentation equal to group head indentation
+
+For a shrubbery like:
+
+```
+a:
+  b
+| c
+```
+
+To parse as:
+
+```
+(group a
+       (block (group b))
+       (alts (block (group c))))
+```
+
+The indentation of the `|` before `c` must be equal-to the indentation of `a`, less than the indentation of `b`. If it's less than `a`, then it might belong to a parent of `a` instead of `a`'s group. If it's between `a` and `b`, then it's an indentation error. If it's equal to `b`, then it would belong to `b`'s group instead of `a`'s group, and if it's more than `b` it's an indentation error.
+
+This indentation restriction applies to normal alts as well, so:
+
+```
+a
+  | c
+```
+
+is an indentation error too.
+
+The grammar, written/armored forms, and possible modifications to Rhombus forms are the same as written in option A.
+
 Evaluation and Tradeoffs
 --------------
 
@@ -486,6 +517,49 @@ Might "silently" fail, with the parser interpreting the same text as a different
 Instead of giving an error or some other immediate feedback to prompt users to fix their code.
 
 Rightward drift may also become a problem with option B, when programs get larger, more complicated, and more nested, the little bits of extra indentation that option B forces on `|` alts may start to add up.
+
+### Good of C
+
+Making `|` alts indentation between `a` and `b` an error prevents the problem in Bad of A. If
+
+```
+a:
+  b
+ | c
+```
+
+Is an indentation error, then there's no confusion between that and 
+
+```
+a:
+  b
+  | c
+```
+
+Option C also has less "rightward drift" than option B.
+
+### Bad of C
+
+If there are Rhombus programs that use rightward drift for alts:
+
+```
+a
+  | c
+```
+
+instead of
+
+```
+a
+| c
+```
+
+then they will get indentation errors.
+Fortunately, those errors could be made easy to read,
+and any given program should be simple to correct.
+Simple enough that an automatic tool similar to resyntax
+could probably do it.
+But it will still take more than zero effort.
 
 Prior art and References
 ---------

--- a/design/block-alts/block-alts.md
+++ b/design/block-alts/block-alts.md
@@ -1,0 +1,283 @@
+block-alts
+==========================
+
+Summary
+-------
+
+An addition to Shrubbery to allow `|` alts after the end of a `:` block.
+
+Motivation
+----------
+
+ * Syntax class options, including kind and fields, without `pattern` in between
+ * Operator options, including precedence, without `match` in between
+ * Macro options, including precedence and op_stx, without `match` in between
+ * Function cases with a common result annotation, without `match` in between
+ * Using shrubbery syntax for a whitespace-lisp
+
+Design Options
+--------------
+
+### Option A
+
+Describe a complete approach to the design, introducing its components
+and how they might interact.
+
+#### Parsing shrubberies
+
+```
+‹group›	::= ‹term›* ‹tail›
+
+‹tail› 	::= ‹term›
+       	 |  ‹block›
+       	 |  ‹alts›
+       	 |  ‹block› ‹alts›
+
+‹block›	::= `:` ‹group›*
+
+‹alts› 	::= `|` ‹block›*
+```
+
+```
+_group	= (group _term ... _tail)
+
+_tail 	= _term
+      	| _block
+      	| _alts
+      	| _block _alts
+
+_block	= (block _group ...)
+
+_alts 	= (alts _block ...)
+```
+
+For a shrubbery like:
+
+```
+a:
+  b
+| c
+```
+
+To parse as:
+
+```
+(group a
+       (block (group b))
+       (alts (block (group c))))
+```
+
+The indentation of the `|` before `c` must be greater-than-or-equal-to the indentation of `a`, and less than the indentation of `b`. If it's less than `a`, then it might belong to a parent of `a` instead of `a`'s group. If it's at `b` or more, then it would belong to `b`'s group instead of `a`'s group.
+
+#### Parsing written/armored forms of shrubberies
+
+The current code in `rhombus-prototype/shrubbery/write.rkt` is already good.
+
+However, the parser isn't good enough to handle what `write-shrubbery` produces: 
+
+```
+a:
+  b
+| c
+```
+
+Is parsed into `(group (block (group b)) (alts (block (group c))))`
+which gets written as `a:« b » |« c »`,
+but then the current parser implementation isn't good enough to read that back yet.
+
+#### Modifying Rhombus forms to use block-alts
+
+In general, Rhombus forms that currently have the shape:
+```
+main_id:
+  option; ...
+  other_id
+  | case
+  | ...
+```
+
+Where `other_id` is something bland like `pattern` or `match`, can be simplified to:
+
+```
+main_id:
+  option; ...
+| case
+| ...
+```
+
+For example this `syntax_class` form:
+
+```
+syntax_class id maybe_args:
+  stxclass_option; ...
+  pattern
+  | pattern_case
+  | ...
+```
+
+Could by simplified to:
+
+```
+syntax_class id maybe_args:
+  stxclass_option; ...
+| pattern_case
+| ...
+```
+
+More concretely:
+
+```
+syntax_class result:
+  kind: ~sequence
+| '$(mode :: result_mode): $body':
+    field [suffix, ...]: []
+| '$(mode :: result_mode) $g ...':
+    field body: '$g ...'
+    field [suffix, ...]: []
+| '~completes':
+    field mode: '~completes'
+    field body: '#void'
+    field [suffix, ...]: ['#void']
+```
+
+This `operator` form:
+
+```
+operator op_or_id_path:
+  option; ...
+  match
+  | op_case
+  | ...
+```
+
+Could by simplified to:
+
+```
+operator op_or_id_path:
+  option; ...
+| op_case
+| ...
+```
+
+More concretely:
+
+```
+operator ^^^:
+  ~weaker_than: +
+| x ^^^ y:
+    x +& y +& x
+| ^^^ y:
+    "--" +& y +& "--"
+```
+
+This `macro` form:
+
+```
+macro op_or_id_path:
+  option; ...
+  match
+  | macro_case
+  | ...
+```
+
+Could by simplified to:
+
+```
+macro op_or_id_path:
+  option; ...
+| macro_case
+| ...
+```
+
+And this `fun` form:
+
+```
+fun maybe_res_annot:
+  match
+  | case_maybe_kw
+  | ...
+```
+
+Could be simplified to:
+
+```
+fun maybe_res_annot
+| case_maybe_kw
+| ...
+```
+
+If a syntax-parse form is added with parse options before the cases, that could be expressed like this:
+
+```
+syntax_parse stx_expr:
+  parse_option; ...
+| pattern_case
+| ...
+```
+
+Instead of needing some identifier like `pattern` or `match` separating the options from the cases.
+
+Evaluation and Tradeoffs
+--------------
+
+If/when more options are added,
+Explain the tradeoffs between the various options.
+
+Prior art and References
+---------
+
+Some inspiration from [Lean function cases](https://leanprover.github.io/functional_programming_in_lean/getting-to-know/conveniences.html#pattern-matching-definitions):
+
+```
+def length : List α → Nat
+| [] => 0
+| y :: ys => Nat.succ (length ys)
+```
+
+Leading to a [discord discussion between sorawee, Alex Knauth, and notjack on 2023-03-31](https://discord.com/channels/571040468092321801/871953739982995547/1091533258329706569) on forms from `fun` to `operator`, `syntax_class`, and `syntax-parse`.
+
+Also some inspiration from using `syntax-parse` in [unnwraith](https://github.com/AlexKnauth/unnwraith):
+
+```
+define (parse stx):
+  syntax-parse stx:
+    ~datum-literals [λ]
+  | x
+    ~declare x id
+    Var (symbol->string (syntax-e 'x'))
+  | λ x: b
+    ~declare x id
+    Lam (symbol->string (syntax-e 'x')) (parse 'b')
+  | f a
+    App (parse 'f') (parse 'a')
+  | f a ...+ b
+    App (parse 'f a ...') (parse 'b')
+```
+
+Drawbacks and Unresolved questions
+----------------------------------
+
+Cases like:
+
+```
+a:
+  b
+  | c
+```
+
+vs.
+
+```
+a:
+  b
+ | c
+```
+
+Have the potential to be confusing, as they are visually similar but parse completely differently.
+
+Contributors
+------------
+
+* sorawee
+* Alex Knauth
+* notjack

--- a/design/block-alts/block-alts.md
+++ b/design/block-alts/block-alts.md
@@ -400,11 +400,11 @@ Instead of needing some identifier like `pattern` or `match` separating the opti
 Evaluation and Tradeoffs
 --------------
 
-## Good of A:
+### Good of A:
 
 Option A fits better into the existing parser which allows `|` on the same indentation level as the head of the group it's a part of. All existing code that uses `|` in that way will continue to parse the same way. Option A also has less "rightward drift" required.
 
-## Bad of A:
+### Bad of A:
 
 Cases like:
 
@@ -426,7 +426,7 @@ Have the potential to be confusing, as they are visually similar but parse compl
 
 To someone unfamiliar with how Rhombus deals with `|` alts, those might both look like the `|` alts belong to `a`'s group and not `b`'s group like the first one currently does.
 
-## Good of B
+### Good of B
 
 Option B may be easier to read, with the children of a group clearly indented more than the head of the group. This:
 
@@ -456,7 +456,7 @@ a:
 
 Option B might also allow the lexer and parser code to be simpler: the half-integer column values for `|` alts could be turned into simple integers.
 
-## Bad of B
+### Bad of B
 
 Changing existing Rhombus programs will require some effort.
 Especially existing programs that currently use:

--- a/design/block-alts/block-alts.md
+++ b/design/block-alts/block-alts.md
@@ -561,6 +561,12 @@ Simple enough that an automatic tool similar to resyntax
 could probably do it.
 But it will still take more than zero effort.
 
+### Choice
+
+Option C is the one we've decided to try for now.
+
+An implementation of option C is at: https://github.com/mflatt/rhombus-prototype/tree/alts
+
 Prior art and References
 ---------
 

--- a/design/block-alts/block-alts.md
+++ b/design/block-alts/block-alts.md
@@ -18,10 +18,25 @@ Motivation
 Design Options
 --------------
 
-### Option A
+### Option A: `|` pipe indentation less than preceding block indentation
 
-Describe a complete approach to the design, introducing its components
-and how they might interact.
+For a shrubbery like:
+
+```
+a:
+  b
+| c
+```
+
+To parse as:
+
+```
+(group a
+       (block (group b))
+       (alts (block (group c))))
+```
+
+The indentation of the `|` before `c` must be greater-than-or-equal-to the indentation of `a`, and less than the indentation of `b`. If it's less than `a`, then it might belong to a parent of `a` instead of `a`'s group. If it's at `b` or more, then it would belong to `b`'s group instead of `a`'s group.
 
 #### Parsing shrubberies
 
@@ -50,24 +65,6 @@ _block	= (block _group ...)
 
 _alts 	= (alts _block ...)
 ```
-
-For a shrubbery like:
-
-```
-a:
-  b
-| c
-```
-
-To parse as:
-
-```
-(group a
-       (block (group b))
-       (alts (block (group c))))
-```
-
-The indentation of the `|` before `c` must be greater-than-or-equal-to the indentation of `a`, and less than the indentation of `b`. If it's less than `a`, then it might belong to a parent of `a` instead of `a`'s group. If it's at `b` or more, then it would belong to `b`'s group instead of `a`'s group.
 
 #### Parsing written/armored forms of shrubberies
 
@@ -217,11 +214,278 @@ syntax_parse stx_expr:
 
 Instead of needing some identifier like `pattern` or `match` separating the options from the cases.
 
+### Option B: `|` pipe indentation equal to preceding block indentation
+
+For a shrubbery like:
+
+```
+a:
+  b
+  | c
+```
+
+To parse as:
+
+```
+(group a
+       (block (group b))
+       (alts (block (group c))))
+```
+
+The indentation of the `|` before `c` must be greater-than the indentation of `a`, and equal to the indentation of `b`. If it's less-than-or-equal-to `a`, then it might belong to a parent of `a` instead of `a`'s group.
+If it's between `a` and `b`, then its an indentation error.
+If it's equal to `b` then it parses correctly as above.
+And if it's at indentation greater than `b`, then it would belong to `b`'s group instead of `a`'s group.
+
+#### Parsing shrubberies
+
+The same grammar as option A, but with differences in how indentation is interpreted.
+In particular, for this to work consistently,
+
+```
+a
+| b
+```
+
+Should not be allowed, and instead
+
+```
+a
+ | b
+```
+
+Would be required for it to parse correctly as
+
+```
+(group a
+       (alts (block (group b))))
+```
+
+#### Parsing written/armored forms of shrubberies
+
+This still runs into the same problem option A has with parsing `a:« b » |« c »`.
+
+#### Modifying Rhombus forms to use block-alts
+
+In general, Rhombus forms that currently have the shape:
+```
+main_id:
+  option; ...
+  other_id
+  | case
+  | ...
+```
+
+Where `other_id` is something bland like `pattern` or `match`, can be simplified to:
+
+```
+main_id:
+  option; ...
+  | case
+  | ...
+```
+
+For example this `syntax_class` form:
+
+```
+syntax_class id maybe_args:
+  stxclass_option; ...
+  pattern
+  | pattern_case
+  | ...
+```
+
+Could by simplified to:
+
+```
+syntax_class id maybe_args:
+  stxclass_option; ...
+  | pattern_case
+  | ...
+```
+
+More concretely:
+
+```
+syntax_class result:
+  kind: ~sequence
+  | '$(mode :: result_mode): $body':
+      field [suffix, ...]: []
+  | '$(mode :: result_mode) $g ...':
+      field body: '$g ...'
+      field [suffix, ...]: []
+  | '~completes':
+      field mode: '~completes'
+      field body: '#void'
+      field [suffix, ...]: ['#void']
+```
+
+This `operator` form:
+
+```
+operator op_or_id_path:
+  option; ...
+  match
+  | op_case
+  | ...
+```
+
+Could by simplified to:
+
+```
+operator op_or_id_path:
+  option; ...
+  | op_case
+  | ...
+```
+
+More concretely:
+
+```
+operator ^^^:
+  ~weaker_than: +
+  | x ^^^ y:
+      x +& y +& x
+  | ^^^ y:
+      "--" +& y +& "--"
+```
+
+This `macro` form:
+
+```
+macro op_or_id_path:
+  option; ...
+  match
+  | macro_case
+  | ...
+```
+
+Could by simplified to:
+
+```
+macro op_or_id_path:
+  option; ...
+  | macro_case
+  | ...
+```
+
+And this `fun` form:
+
+```
+fun maybe_res_annot:
+  match
+  | case_maybe_kw
+  | ...
+```
+
+Could be simplified to:
+
+```
+fun maybe_res_annot
+  | case_maybe_kw
+  | ...
+```
+
+If a syntax-parse form is added with parse options before the cases, that could be expressed like this:
+
+```
+syntax_parse stx_expr:
+  parse_option; ...
+  | pattern_case
+  | ...
+```
+
+Instead of needing some identifier like `pattern` or `match` separating the options from the cases.
+
 Evaluation and Tradeoffs
 --------------
 
-If/when more options are added,
-Explain the tradeoffs between the various options.
+## Good of A:
+
+Option A fits better into the existing parser which allows `|` on the same indentation level as the head of the group it's a part of. All existing code that uses `|` in that way will continue to parse the same way. Option A also has less "rightward drift" required.
+
+## Bad of A:
+
+Cases like:
+
+```
+a:
+  b
+  | c
+```
+
+vs.
+
+```
+a:
+  b
+ | c
+```
+
+Have the potential to be confusing, as they are visually similar but parse completely differently.
+
+To someone unfamiliar with how Rhombus deals with `|` alts, those might both look like the `|` alts belong to `a`'s group and not `b`'s group like the first one currently does.
+
+## Good of B
+
+Option B may be easier to read, with the children of a group clearly indented more than the head of the group. This:
+
+```
+a and stuff
+  | b and more stuff
+  | c and even more
+```
+
+Is clearer about indentation grouping than what option A allows.
+
+Making `|` alts indentation between `a` and `b` an error prevents the problem in Bad of A. If
+
+```
+a:
+  b
+ | c
+```
+
+Is an indentation error, then there's no confusion between that and 
+
+```
+a:
+  b
+  | c
+```
+
+Option B might also allow the lexer and parser code to be simpler: the half-integer column values for `|` alts could be turned into simple integers.
+
+## Bad of B
+
+Changing existing Rhombus programs will require some effort.
+Especially existing programs that currently use:
+
+```
+a:
+  b
+  | c
+```
+
+to mean
+
+```
+(group a
+       (block (group b
+                     (alts (block (group c))))))
+```
+
+Might "silently" fail, with the parser interpreting the same text as a different tree structure:
+
+```
+(group a
+       (block (group b))
+       (alts (block (group c))))
+```
+
+Instead of giving an error or some other immediate feedback to prompt users to fix their code.
+
+Rightward drift may also become a problem with option B, when programs get larger, more complicated, and more nested, the little bits of extra indentation that option B forces on `|` alts may start to add up.
 
 Prior art and References
 ---------
@@ -257,23 +521,7 @@ define (parse stx):
 Drawbacks and Unresolved questions
 ----------------------------------
 
-Cases like:
-
-```
-a:
-  b
-  | c
-```
-
-vs.
-
-```
-a:
-  b
- | c
-```
-
-Have the potential to be confusing, as they are visually similar but parse completely differently.
+See "Bad of A" and "Bad of B" in the Evaluation and Tradeoffs section.
 
 Contributors
 ------------
@@ -281,3 +529,4 @@ Contributors
 * sorawee
 * Alex Knauth
 * notjack
+* mflatt

--- a/design/block-alts/block-alts.md
+++ b/design/block-alts/block-alts.md
@@ -272,8 +272,8 @@ In general, Rhombus forms that currently have the shape:
 main_id:
   option; ...
   other_id
-  | case
-  | ...
+    | case
+    | ...
 ```
 
 Where `other_id` is something bland like `pattern` or `match`, can be simplified to:
@@ -291,8 +291,8 @@ For example this `syntax_class` form:
 syntax_class id maybe_args:
   stxclass_option; ...
   pattern
-  | pattern_case
-  | ...
+    | pattern_case
+    | ...
 ```
 
 Could by simplified to:
@@ -326,8 +326,8 @@ This `operator` form:
 operator op_or_id_path:
   option; ...
   match
-  | op_case
-  | ...
+    | op_case
+    | ...
 ```
 
 Could by simplified to:
@@ -356,8 +356,8 @@ This `macro` form:
 macro op_or_id_path:
   option; ...
   match
-  | macro_case
-  | ...
+    | macro_case
+    | ...
 ```
 
 Could by simplified to:
@@ -374,8 +374,8 @@ And this `fun` form:
 ```
 fun maybe_res_annot:
   match
-  | case_maybe_kw
-  | ...
+    | case_maybe_kw
+    | ...
 ```
 
 Could be simplified to:

--- a/rhombus/private/function-parse.rkt
+++ b/rhombus/private/function-parse.rkt
@@ -155,11 +155,13 @@
              #:attr default #'#f))
 
   (define-syntax-class :not-block
-    #:datum-literals (op parens braces)
+    #:datum-literals (op parens braces brackets quotes)
     (pattern _:identifier)
     (pattern (op . _))
     (pattern (parens . _))
-    (pattern (braces . _)))
+    (pattern (braces . _))
+    (pattern (brackets . _))
+    (pattern (quotes . _)))
 
   (define-splicing-syntax-class :ret-annotation
     #:attributes (static-infos ; can be `(#%values (static-infos ...))` for multiple results

--- a/rhombus/private/macro.rkt
+++ b/rhombus/private/macro.rkt
@@ -55,13 +55,12 @@
                                        #f #f
                                        #'() #'()))]
          [(form-id main-op::operator-or-identifier
-                   (_::block
-                    ~!
-                    (~var main-options (:all-operator-options #f))
-                    (group _::match+1
-                           (_::alts (_::block (group q::operator-syntax-quote
-                                                     (~and rhs (_::block body ...))))
-                                    ...+))))
+                   (~optional (_::block
+                               (~var main-options (:all-operator-options #f))))
+                   (_::alts ~!
+                            (_::block (group q::operator-syntax-quote
+                                             (~and rhs (_::block body ...))))
+                            ...+))
           (list
            (parse-operator-definitions #'form-id
                                        'rule
@@ -70,8 +69,10 @@
                                        (syntax->list #'(rhs ...))
                                        '#f
                                        #'rules-rhs
-                                       #'main-op.name #'#f
-                                       #'main-options.prec #'main-options.assc))]
+                                       (if (attribute main-op) #'main-op.name #'#f)
+                                       #'#f
+                                       (if (attribute main-options) #'main-options.prec #'())
+                                       (if (attribute main-options) #'main-options.assc #'())))]
          [(form-id q::operator-syntax-quote
                    (~and rhs (_::block body ...)))
           (list

--- a/rhombus/private/match.rkt
+++ b/rhombus/private/match.rkt
@@ -16,9 +16,6 @@
 
 (provide match)
 
-(module+ for-match-id
-  (provide (for-syntax :match)))
-
 (begin-for-syntax
   (define-syntax-class :pattern-clause
     #:attributes ([bind 1] rhs)
@@ -30,14 +27,7 @@
     (datum->syntax #f (map (lambda (x) #f) (cons 'b (syntax->list l-stx)))))
 
   (define (l1falses l-stx)
-    (datum->syntax #f (map (lambda (x) '(#f)) (cons 'b (syntax->list l-stx)))))
-  
-  (define-syntax-class :match
-    #:description "match form"
-    #:opaque
-    #:attributes ()
-    (pattern name::name
-             #:when (free-identifier=? #'name.name (expr-quote match)))))
+    (datum->syntax #f (map (lambda (x) '(#f)) (cons 'b (syntax->list l-stx))))))
 
 (define-syntax match
   (expression-transformer

--- a/rhombus/scribblings/conditional.scrbl
+++ b/rhombus/scribblings/conditional.scrbl
@@ -114,18 +114,12 @@ case with the right number of arguments.
 
 To write a result annotation just once in a function definition with
 multiple cases, use the function name after @rhombus(fun), then
-@rhombus(::) or @rhombus(:~), the annotation, and then a block that
-contains the cases in a @rhombus(match) form:
+@rhombus(::) or @rhombus(:~), the annotation, and then the cases:
 
 @demo(
   ~defn:
     fun fib :: PosInt:
-      match
-      | fib(0): 1
-      | fib(1): 1
-      | fib(n :: NonnegInt): fib(n-1) + fib(n-2)
+    | fib(0): 1
+    | fib(1): 1
+    | fib(n :: NonnegInt): fib(n-1) + fib(n-2)
 )
-
-This notation is a slight abuse of @rhombus(match), since it's not
-really a @rhombus(match) form, but it's meant to be suggestive of the
-underlying matching process.

--- a/rhombus/scribblings/notation.scrbl
+++ b/rhombus/scribblings/notation.scrbl
@@ -83,7 +83,7 @@ fair game for an operator:
 )
 
 The @litchar{:} and @litchar{|} characters can be used as part of an
-operator, even though they have a special meaning along; to avoid
+operator, even though the characters have a special meaning when used alone. To avoid
 confusion with @tech{blocks}, an operator cannot end with @litchar{:}
 unless it contains only @litchar{:} characters. Similarly, to avoid
 potential confusion with operators alongside numbers, an operator that
@@ -140,18 +140,23 @@ list-structured S-expression that uses immediate parentheses, however.
 
 Shrubbery notation is whitespace-sensitive, and it uses line breaks and
 indentation for grouping. A line with more indentation starts a
-@deftech{block}, and it’s always after a line that ends @litchar{:}, that
-ends @litchar{|} (much less commonly), or that starts @litchar{|}. You
-can think of a more-indented @litchar{|} as being preceded implicitly by
-a @litchar{:} at the end of the previous line. A @litchar{|} counts as
-being indented by half a column, so the @litchar{|}s below are indented
-even when they are written right under @rhombus(if), @rhombus(match), or
-@rhombus(cond):
+@deftech{block}, and it’s always after a line that ends @litchar{:}. A
+@litchar{|} alternative also starts a block, and the @litchar{|} itself
+can start a new line, in which case it must line up with the start
+of its enclosing form. So, the @litchar{|}s below are written with the
+same indentation as @rhombus(if), @rhombus(match), or @rhombus(cond) to
+create the alternative cases within those forms:
+
+@margin_note{In DrRacket, hit Tab to cycle through the possible
+ indentations for a line (based on preceding lines). The indentation
+ possibilities can be different if a line starts with @litchar{|}. If
+ multiple lines are selected, then Tab cycles through possibilities for
+ the first selected line and shifts remaining lines by same amount.}
 
 @rhombusblock(
   block:
-    group within block
-    another group within block
+    println("group within block")
+    println("another group within block")
 
   if is_rotten(apple)
   | get_another()
@@ -178,19 +183,12 @@ even when they are written right under @rhombus(if), @rhombus(match), or
       wear_hat()
 )
 
-@margin_note{In DrRacket, hit Tab to cycle through the possible
- indentations for a line (based on preceding lines). If multiple lines
- are selected, then Tab cycles through possibilities for the first
- selected line and shifts remaining lines by same amount.}
-
-A @litchar{|} is allowed only within a block, and it also starts a
-subblock on the right-hand side of the @litchar{|}. Each subsequent
-@litchar{|} at the same indentation creates a new subblock. Shrubbery
-notation allows @litchar{|} only within a block whose groups all contain
-an immediate @litchar{|} subblock. A block of @litchar{|} subblocks is
-an @deftech{alts-block}. A @litchar{:} isn’t needed or allowed before
-the first @litchar{|} in an alts-block, because the @litchar{|} itself
-is enough of an indication that a alts-block is starting.
+A @litchar{:} isn’t needed before the first @litchar{|} in an
+alts-block, because the @litchar{|} itself is enough of an indication
+that a sequence of alternatives is starting, but a @litchar{:} is
+allowed. Some forms support the combination of a @litchar{:} followed by
+a sequence of @litchar{|} alternatives, but most forms have either a
+@litchar{:} block or a sequence of @litchar{|} alternatives.
 
 Each line within a block forms a @deftech{group}. Groups are important,
 because parsing and macro expansion are constrained to operate on groups
@@ -198,12 +196,13 @@ because parsing and macro expansion are constrained to operate on groups
 level of indentation as a previous line continue that group’s block. A
 @litchar{|} can have multiple groups in the subblock to its right, but
 the block started by @litchar{|} turns out to be the only thing in its
-own group.
+own group. A @litchar{:} block or sequence of @litchar{|} alternatives
+can only be at the end of an enclosing group.
 
 A @litchar{:} doesn’t have to be followed by a new line, but it starts a
-new block, anyway. Similarly, a @litchar{|} that starts a block doesn’t
-have to be on a new line. These examples parse the same as the previous
-examples:
+new block, anyway. Similarly, a @litchar{|} that starts an alternative
+doesn’t have to be on a new line. These examples parse the same as the
+previous examples:
 
 @rhombusblock(
   block: group within block

--- a/rhombus/scribblings/operator.scrbl
+++ b/rhombus/scribblings/operator.scrbl
@@ -135,9 +135,8 @@ When multiple cases for an operator are provided using @vbar, then only
 the first case for prefix, infix, or postfix can have options.
 Precedence for prefix and infix/postfix can be independent in that form.
 Alternatively, put the operator name directly after @rhombus(operator),
-then start a block that contains @rhombus(match); precedence and
-associativity that applies to all cases can be written within the block
-and before @rhombus(match). Also similar to this notation for
+then start a block that contains precedence and
+associativity that applies to all cases. Similar to this notation for
 @rhombus(fun), a result annotation can be written before the block.
 
 @demo(
@@ -146,11 +145,10 @@ and before @rhombus(match). Also similar to this notation for
     operator <> :: Posn:
       ~weaker_than: * / + -
       ~associativity: ~right
-      match
-      | (x <> y):
-          Posn(x, y)
-      | (<> n):
-          Posn(n, n)
+    | (x <> y):
+        Posn(x, y)
+    | (<> n):
+        Posn(n, n)
   ~repl:
     1 <> 2 * 3
     1 <> 2 <> 3

--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -111,28 +111,25 @@ normally bound to implement function calls.
     map_bind: def bind
     repet_bind: def bind
 
-  ~literal: match
   defn.macro 'fun $id_path($bind, ...):
                 $body
                 ...'
   defn.macro 'fun $id_path $case_maybe_kw_opt'
-  defn.macro 'fun | $id_path $case_maybe_kw
-                  | ...'
-  defn.macro 'fun $id_path $maybe_res_annot:
-                match | $id_path $case_maybe_kw
-                      | ...'
+  defn.macro 'fun
+              | $id_path $case_maybe_kw
+              | ...'
+  defn.macro 'fun $id_path $maybe_res_annot
+              | $id_path $case_maybe_kw
+              | ...'
 
   expr.macro 'fun ($bind, ...):
                 $body
                 ...'
   expr.macro 'fun $case_maybe_kw_opt'
 
-  expr.macro 'fun | $case_maybe_kw
-                  | ...'
-
-  expr.macro 'fun $maybe_res_annot:
-                match | $case_maybe_kw
-                      | ...'
+  expr.macro 'fun $maybe_res_annot
+              | $case_maybe_kw
+              | ...'
 
   grammar case_maybe_kw_opt:
     ($bind_maybe_kw_opt, ..., $rest, ...) $maybe_res_annot:
@@ -242,15 +239,8 @@ normally bound to implement function calls.
 )
 
  When alternatives are specified with multiple @vbar clauses, the
- clauses can be provided immediately after @rhombus(fun), or they may be
- nested in a @rhombus(match) for in a block after @rhombus(fun). The use
- of @rhombus(match) in this way is not a normal @rhombus(match)
- expression form (which would need an expression after @rhombus(match)
- itself), but merely suggestive of the expression form. With or without
- @rhombus(match), the
- alternatives are tried in order when the function is called. The
- alternatives can differ by number of arguments as well as keywords,
- annotations, and binding patterns.
+ clauses can be provided immediately after @rhombus(fun) or after the
+ name and a @rhombus(maybe_res_annot) as described further below.
 
 @examples(
   ~defn:
@@ -317,8 +307,7 @@ Only one @rhombus(~& map_bind) can appear in a @rhombus(rest) sequence.
  function's body is @emph{not} in tail position with respect to a call to
  the function, since a check will be applied to the function's result.
  When @rhombus(maybe_res_annot) is present for a function declared with
- cases under @rhombus(match), a @rhombus(maybe_res_annot) before the block
- containing @rhombus(match) applies to all cases, in addition to any
+ cases afterward, a @rhombus(maybe_res_annot) applies to all cases, in addition to any
  @rhombus(maybe_res_annot) supplied for a specific case. A
  @rhombus(maybe_res_annot) that has a parenthesized sequence of
  @rhombus(annot)s (with our without @rhombus(values)) describes
@@ -326,23 +315,21 @@ Only one @rhombus(~& map_bind) can appear in a @rhombus(rest) sequence.
 
 @examples(
   ~defn:
-    fun hello :: String:
-      match
-      | hello(name):
-          "Hello, " +& name
-      | hello():
-          #false
+    fun hello :: String
+    | hello(name):
+        "Hello, " +& name
+    | hello():
+        #false
   ~repl:
     hello("World")
     ~error:
       hello()
   ~defn:
-    fun things_to_say :: values(String, String):
-      match
-      | things_to_say():
-          values("Hi", "Bye")
-      | things_to_say(more):
-          values("Hi", "Bye", more)
+    fun things_to_say :: values(String, String)
+    | things_to_say():
+        values("Hi", "Bye")
+    | things_to_say(more):
+        values("Hi", "Bye", more)
   ~repl:
     things_to_say()
     ~error:
@@ -363,12 +350,9 @@ Only one @rhombus(~& map_bind) can appear in a @rhombus(rest) sequence.
                        ...'
   entry_point.macro 'fun $case_maybe_kw_opt'
 
-  entry_point.macro 'fun | $case_maybe_kw
-                         | ...'
-
-  entry_point.macro 'fun $maybe_res_annot:
-                       match | $case_maybe_kw
-                             | ...'
+  entry_point.macro 'fun $maybe_res_annot
+                     | $case_maybe_kw
+                     | ...'
 ){
 
  The @tech{entry point} form of @rhombus(fun, ~entry_point) is the same as the

--- a/rhombus/scribblings/ref-macro.scrbl
+++ b/rhombus/scribblings/ref-macro.scrbl
@@ -19,9 +19,8 @@
               | ...'
   defn.macro 'macro $op_or_id_path:
                 $option; ...
-                match
-                | $macro_case
-                | ...'
+              | $macro_case
+              | ...'
 
   expr.macro 'macro $macro_case'
   expr.macro 'macro 
@@ -160,9 +159,8 @@
  most @rhombus(option)s are allowed only in the first case, but
  @rhombus(~op_stx) is allowed and separate in each case.
 
- When multiple cases are written with @vbar, they can be nested in a
- @rhombus(match) form, similar to @rhombus(operator) and @rhombus(fun).
- In that case, @rhombus(option) keywords can be written to apply to all
+ When multiple cases are written with @vbar, they can appear after a block
+ that supplies @rhombus(option)s that apply to all
  cases, the same as in @rhombus(operator).
 
 @examples(

--- a/rhombus/scribblings/ref-operator.scrbl
+++ b/rhombus/scribblings/ref-operator.scrbl
@@ -17,11 +17,10 @@
   defn.macro 'operator 
               | $op_case
               | ...'
-  defn.macro 'operator $op_or_id_path:
+  defn.macro 'operator $op_or_id_path $maybe_res_annot:
                 $option; ...
-                match
-                | $op_case
-                | ...'
+              | $op_case
+              | ...'
 
   grammar op_case:  
     $op_or_id_path $bind_term $impl_block
@@ -90,19 +89,18 @@
  postfix). The prefix cases and infix/postfix cases can be mixed in any
  order, but when the operator is used as a prefix or infix/postfix
  operator, cases are tried in the relative order that they are written.
- Similar to the @rhombus(form) form, multiple cases can be placed under
- @rhombus(match) within a block, with the advantage that a result
- annotation can be written once for all cases.
+ Similar to the @rhombus(fun) form the operator name and a result
+ annotation can be written before the @vbar cases to appply for all cases.
 
  At the start of an operator body, @rhombus(option)s can declare
  precedence and, in the case of an infix operator, an associativity for
  the operator. Each @rhombus(option) keyword can appear at most once. In
  a precedence specification, @rhombus(~other) stands for any operator not
- otherwise mentioned. When multiple cases are povided using @vbar, then
+ otherwise mentioned. When multiple cases are povided using an immediate @vbar, then
  only the first prefix case and the first infix/postfix case can supply
- options; alternatively, when cases are nested under @rhombus(match),
- then options that apply to all cases can be written before
- @rhombus(match). Options can appear both before @rhombus(match) and in
+ options; alternatively, when the operator name (maybe with a result annotation)
+ is written before @vbar, options that apply to all cases can be supplied in
+ a block before the cases. Options can appear both before the cases and in
  individual clauses, as long as all precedence and all associatvity
  options are in one or the other.
 
@@ -144,11 +142,10 @@
   ~defn:
     operator ^^^:
       ~weaker_than: +
-      match
-      | x ^^^ y:
-          x +& y +& x
-      | ^^^ y:
-          "--" +& y +& "--"
+    | x ^^^ y:
+        x +& y +& x
+    | ^^^ y:
+        "--" +& y +& "--"
   ~repl:
     1 ^^^ 2 + 3
     ^^^ 4 + 5

--- a/rhombus/scribblings/syntax.scrbl
+++ b/rhombus/scribblings/syntax.scrbl
@@ -110,8 +110,25 @@ to form a repetition of matches:
  must thread potentially long sequences into and out of macro
  transformers.}
 
-A @rhombus($)-escaped variable in a @quotes pattern matches one
-term among other terms in the group. Keep in mind that @quotes
+A @rhombus($)-escaped variable in a @quotes pattern matches one term
+among other terms in the group. A block created with @litchar{:} counts
+as a single term of its enclosing group, and a sequence of @litchar{|}
+alternatives (not an individual alternative) similarly counts as one term.
+
+@demo(
+  ~defn:
+    def '$x $y' = 'block: 1 2 3'
+  ~repl:
+    x
+    y
+  ~defn:
+    def '$z $w' = 'cond | is_ok: "good" | ~else: "bad"'
+  ~repl:
+    z
+    w
+)
+
+Keep in mind that @quotes
 creates syntax objects containing shrubberies that are not yet parsed,
 so a variable will @emph{not} be matched to a multi-term sequence that would be
 parsed as an expression. For example, a pattern variable @rhombus(y) by
@@ -177,7 +194,7 @@ group or by itself in a multi-group position.
     'fun (): $body'
 )
 
-There is no contraint that the original and destination contexts have
+There is no constraint that the original and destination contexts have
 the same shape, so a match from a block-like context can be put into a
 brackets context, for example.
 

--- a/rhombus/tests/expr-macro.rhm
+++ b/rhombus/tests/expr-macro.rhm
@@ -88,11 +88,10 @@ block:
 block:
   macro listly:
     ~stronger_than: +&
-    match
-    | '$a listly $b':
-        '[$a, $b]'
-    | 'listly $c':
-        '[$c]'
+  | '$a listly $b':
+      '[$a, $b]'
+  | 'listly $c':
+      '[$c]'
 
   check:
     1 listly 5 +& 7
@@ -188,18 +187,16 @@ check:
 
 check:
   ~eval
-  macro prefix:
-    match
-    | 'prefix': 'ok'
-    | 'preeefix': 'oops'
+  macro prefix
+  | 'prefix': 'ok'
+  | 'preeefix': 'oops'
   ~raises "case operator does not match the declared operator"
 
 check:
   ~eval
   macro prefix:
     ~associativity: ~left
-    match
-    | 'prefix': 'ok'
+  | 'prefix': 'ok'
   ~raises "associativity specified without infix cases"
 
 check:

--- a/rhombus/tests/fun.rhm
+++ b/rhombus/tests/fun.rhm
@@ -36,8 +36,8 @@ check:
 
 fun add1(x) :: Int:
   match x
-   | n :: Int : x + 1
-   | ~else: x
+  | n :: Int : x + 1
+  | ~else: x
 
 check:
   add1(100)
@@ -84,15 +84,14 @@ check:
 // `match` variant
 
 fun size2 :: Int:
-  match
-  | size2("wrong"):
-      "oops"
-  | size2(n :: Int):
-      n
-  | size2(p :: Posn):
-      p.x + p.y
-  | size2(a, b):
-      a+b
+| size2("wrong"):
+    "oops"
+| size2(n :: Int):
+    n
+| size2(p :: Posn):
+    p.x + p.y
+| size2(a, b):
+    a+b
 
 check:
   size2(10) ~is 10
@@ -102,11 +101,10 @@ check:
 block:
   use_static
   fun flip :: Posn:
-    match
-    | flip(Posn(x, y)):
-        Posn(y,x)
-    | flip(x):
-        Posn(0, x)
+  | flip(Posn(x, y)):
+      Posn(y,x)
+  | flip(x):
+      Posn(0, x)
   check:
     flip(Posn(1, 2)) ~is Posn(2, 1)
     flip(Posn(1, 2)).y ~is 1
@@ -114,18 +112,15 @@ block:
 
 check:
   fun size3:
-    match
-    | size3(_): "not yet implemented"
+  | size3(_): "not yet implemented"
   size3(10)
   ~is "not yet implemented"
 
 block:
-  def long_form_one = (fun:
-                         match
+  def long_form_one = (fun
+                       | (): 1)
+  def longer_form_one = (fun :: Int
                          | (): 1)
-  def longer_form_one = (fun :: Int:
-                           match
-                           | (): 1)
   check:
     long_form_one() ~is 1
     longer_form_one() ~is 1

--- a/rhombus/tests/operator.rhm
+++ b/rhombus/tests/operator.rhm
@@ -36,9 +36,8 @@ block:
   operator ++*:
     ~weaker_than: *
     ~associativity: ~right
-    match
-    | (a ++* b):
-        (a + b) * b
+  | (a ++* b):
+      (a + b) * b
   
   check:
     3 ++* 4 * 2 ++* 5 ~is 4420
@@ -47,10 +46,9 @@ block:
 block:
   operator ++*:
     ~weaker_than: *
-    match
-    | (a ++* b):
-        ~associativity: ~right
-        (a + b) * b
+  | (a ++* b):
+      ~associativity: ~right
+      (a + b) * b
   
   check:
     3 ++* 4 * 2 ++* 5 ~is 4420
@@ -59,10 +57,9 @@ block:
 block:
   operator ++*:
     ~associativity: ~right
-    match
-    | (a ++* b):
-        ~weaker_than: *
-        (a + b) * b
+  | (a ++* b):
+      ~weaker_than: *
+      (a + b) * b
   
   check:
     3 ++* 4 * 2 ++* 5 ~is 4420
@@ -191,9 +188,8 @@ check:
 check:
   ~eval
   operator **:
-    match
-    | (0 ** a): 0
-    | (1 ??): 1
+  | (0 ** a): 0
+  | (1 ??): 1
   ~raises "case operator does not match the declared operator"
 
 check:
@@ -227,9 +223,8 @@ check:
   ~eval
   operator **:
     ~associativity: ~none
-    match
-    | (** 0): 0
-    | (** 1): 1
+  | (** 0): 0
+  | (** 1): 1
   ~raises "associativity specified without infix cases"
 
 check:

--- a/rhombus/tests/rest-args.rhm
+++ b/rhombus/tests/rest-args.rhm
@@ -91,9 +91,9 @@ block:
 // Match & rest on mutable maps produces an immutable copy
 block:
   def m = MutableMap{"a": 1, "b": 2}
-  def r = match m
-          | MapView{"a": a, & rst}: rst
-          | _: #false
+  def r: match m
+         | MapView{"a": a, & rst}: rst
+         | _: #false
   m["b"] := 3
   check r ~is {"b": 2}
 

--- a/rhombus/tests/rx-space.rhm
+++ b/rhombus/tests/rx-space.rhm
@@ -104,13 +104,12 @@ regexp.macro '$left ?':
 // and curly braces
 regexp.macro #%comp:
   ~stronger_than: #%juxtapose #%call
-  match
-  | '$left #%comp {$(min :: Int), _}':
-      '$(atomic(left.unwrap()) ++ "{" +& min.unwrap() ++ ",}")'
-  | '$left #%comp {$(min :: Int), $(max :: Int)}':
-      '$(atomic(left.unwrap()) ++ "{" +& min.unwrap() ++ "," +& max.unwrap() ++ "}")'
-  | '$left #%comp {$(count :: Int)}':
-      '$(atomic(left.unwrap()) ++ "{" +& count.unwrap() ++ "}")'
+| '$left #%comp {$(min :: Int), _}':
+    '$(atomic(left.unwrap()) ++ "{" +& min.unwrap() ++ ",}")'
+| '$left #%comp {$(min :: Int), $(max :: Int)}':
+    '$(atomic(left.unwrap()) ++ "{" +& min.unwrap() ++ "," +& max.unwrap() ++ "}")'
+| '$left #%comp {$(count :: Int)}':
+    '$(atomic(left.unwrap()) ++ "{" +& count.unwrap() ++ "}")'
 
 regexp.macro
 | '^ $right':

--- a/shrubbery/indentation.rkt
+++ b/shrubbery/indentation.rkt
@@ -316,7 +316,7 @@
              ;; indentation under the block operator is valid unless armored
              (define next-candidate (col-of (add1 next-s) start delta))
              ;; a `|` cannot appear just after a `:`, so look before that block
-             (define adj-block-col (if as-bar? (sub1 block-col) block-col))
+             (define adj-block-col block-col) ;; (if as-bar? (sub1 block-col) block-col))
              ;; look further outside this block, and don't consider anything
              ;; that would appear to be nested in the block:
              (define outer-candidates (if (or candidate

--- a/shrubbery/scribblings/at-notation.scrbl
+++ b/shrubbery/scribblings/at-notation.scrbl
@@ -1,8 +1,10 @@
 #lang scribble/rhombus/manual
+@(import:
+    "quote.rhm" open)
 
 @title(~tag: "at-notation"){At-Notation Using @litchar("@")}
 
-Groups and blocks provide a convenient general notation for structured
+Groups, blocks, and alternatives provide a convenient general notation for structured
 forms, such as typical elements of programming language. Basic
 shrubbery elements are less well suited for representing blocks of
 free-form text, however. String literals work well enough for simple
@@ -27,7 +29,7 @@ is equivalent to
   typeset(["Write \"hello\" to C:\\greet.txt."])
 )
 
-Note that text in @litchar("{}") in this example did not need escapes
+Note that text in @braces in this example did not need escapes
 for the literal quotes and backslashes. The conversion puts the
 literal string in a list, where the list has more elements in the case
 of multiline text or escapes.
@@ -78,7 +80,7 @@ before parenthesized @italic{arg}s. The @italic{command} and
 is in text mode and converted to @italic{converted_text}. The
 @italic{converted_text} translation includes elements that are not
 string literals in places where @italic{text} has escapes. An
-@litchar("@") form can have multiple @litchar("{}") @italic{text}
+@litchar("@") form can have multiple @braces @italic{text}
 blocks, in which case the translation has multiple
 @italic{converted_list} list arguments.
 
@@ -105,7 +107,7 @@ Some additional @litchar("@") rules:
 
 @itemlist(
 
- @item{When multiple lines of text are within @litchar("{}"), then
+ @item{When multiple lines of text are within @braces, then
        leading indentation common to all lines is discarded.},
 
  @item{While the @italic{command} component itself can be parenthesized, it

--- a/shrubbery/scribblings/at-parsing.scrbl
+++ b/shrubbery/scribblings/at-parsing.scrbl
@@ -23,7 +23,7 @@ one of these forms:
 
       The allowed form of @italic{command} is described in
       @secref("token-parsing") as @nonterm{command}, and it always
-      corresponds to a group. A group that ends in a block is
+      corresponds to a group. A group that ends in a block or sequence of alternatives is
       disallowed. Each @italic{argument} is also a group, with no
       additional constraints, but the separating @litchar{,} is
       optional for arguments that are newline-separated groups.
@@ -76,7 +76,7 @@ one of these forms:
 
       The allowed forms of @italic{command} are the same as for the
       preceding cases of @litchar("@"), except that @italic{command}
-      is allowed to be a group that ends in a block if the
+      is allowed to be a group that ends in a block or sequence of alternatives if the
       @litchar("@") is at the end of the enclosing group. If
       parentheses or a @italic{braced_text} follow @italic{command},
       then one of the preceding @litchar("@") cases applies, instead.},
@@ -89,13 +89,13 @@ one of these forms:
       }
 
       where @italic{command} is allowed to be any group (but ending in
-      a block only when @litchar("@") is at the end of the enclosing
+      a block or sequence of alternatives only when @litchar("@") is at the end of the enclosing
       group), and space is allowed between @litchar("@(«") and
       @italic{command} or between @italic{command} and @litchar("»)").},
 
  @item{@bseq(@litchar("@//"), @italic{braced_text})
 
-       A block-comment form, but allowed only within a
+       A comment form, but allowed only within a
        @italic{braced_text}. No space is allowed between
        @litchar("@//") and @italic{braced_text}.},
 

--- a/shrubbery/scribblings/grammar-s-exp.rkt
+++ b/shrubbery/scribblings/grammar-s-exp.rkt
@@ -5,22 +5,23 @@
 (provide shrubbery_s_expression_grammar)
 
 (define shrubbery_s_expression_grammar
-  (BNF (list @nonterm{parsed}
+  (BNF (list @nonterm{document}
              @racket[(top @#,nonterm{group} ...)])
        (list @nonterm{group}
-             @racket[(group @#,nonterm{term} ... @#,nonterm{tail-term})])
-       (list @nonterm{term}
+             @racket[(group @#,nonterm{item} ... @#,nonterm{item})]
+             @racket[(group @#,nonterm{item} ... @#,nonterm{block})]
+             @racket[(group @#,nonterm{item} ... @#,nonterm{alts})]
+             @racket[(group @#,nonterm{item} ... @#,nonterm{block} @#,nonterm{alts})])
+       (list @nonterm{item}
              @nonterm{atom}
              @racket[(parens @#,nonterm{group} ...)]
              @racket[(brackets @#,nonterm{group} ...)]
              @racket[(braces @#,nonterm{group} ...)]
              @racket[(quotes @#,nonterm{group} ...)])
-       (list @nonterm{tail-term}
-             @nonterm{term}
-             @nonterm{block}
-             @racket[(alts @#,nonterm{block} ...)])
        (list @nonterm{block}
-             @racket[(block @#,nonterm{group} ...)])))
+             @racket[(block @#,nonterm{group} ...)])
+       (list @nonterm{alts}
+             @racket[(alts @#,nonterm{block} ...)])))
              
 
              

--- a/shrubbery/scribblings/grammar.rhm
+++ b/shrubbery/scribblings/grammar.rhm
@@ -5,13 +5,18 @@ import:
   lib("scribble/bnf.rkt"):
     rename: #{BNF-seq} as bseq
             #{BNF-alt} as balt
-            optional as boptional
-    expose: nonterm bseq balt kleenestar kleeneplus boptional
+    expose: nonterm bseq balt kleenestar kleeneplus
 
 export:
   bnf
-  bseq balt boptional nonterm kleenestar kleeneplus boptional
+  bseq balt boptional nonterm kleenestar kleeneplus boptional bgroup
   bis bor
 
 def bis: @elem{@hspace(1)::=@hspace(1)}
 def bor: @elem{@hspace(1) | @hspace(1)}
+
+fun boptional(content, ...):
+  [content, ..., @italic{?}]
+
+fun bgroup(content, ...):
+  [@elem{( }, content, ..., @elem{ )}]

--- a/shrubbery/scribblings/parsed-representation.scrbl
+++ b/shrubbery/scribblings/parsed-representation.scrbl
@@ -1,7 +1,8 @@
 #lang scribble/rhombus/manual
 @(import:
     "grammar.rhm" open
-    "grammar-s-exp.rkt" open)
+    "grammar-s-exp.rkt" open
+    "quote.rhm" open)
 
 @title(~tag: "parsed-rep"){Parsed Representation}
 
@@ -10,39 +11,40 @@ The parse of a shrubbery can be represented by an S-expression:
 @itemlist(
 
  @item{Each group is represented as a list that starts @litchar{'group}, and
-   the rest of the list are the elements of the group.},
+   the rest of the list are the elements of the group.}
 
  @item{Atom elements are represented as “themselves” within a group,
    including identifers a symbols, except that an operator is
    represented as a 2-element list that is @litchar{'op} followed by the operator name
-   as a symbol.},
+   as a symbol.}
 
- @item{A group sequence is represented as a list of @litchar{'group} lists.},
+ @item{A group sequence is represented as a list of @litchar{'group} lists.}
 
- @item{An element created by @litchar{()} is represented by @litchar{'parens} consed
-   onto a group-sequence list.},
+ @item{An element created by @parens is represented by @litchar{'parens} consed
+   onto a group-sequence list.}
    
- @item{An element created by @litchar{[]} is represented by @litchar{'brackets} consed
-   onto a group-sequence list.},
+ @item{An element created by @brackets is represented by @litchar{'brackets} consed
+   onto a group-sequence list.}
 
- @item{An element created by @litchar{{}} is represented by @litchar{'braces} consed
-   onto a group-sequence list.},
+ @item{An element created by @braces is represented by @litchar{'braces} consed
+   onto a group-sequence list.}
 
- @item{An element created by @litchar{''} is represented by @litchar{'quotes} consed
-   onto a group-sequence list.},
+ @item{An element created by @quotes is represented by @litchar{'quotes} consed
+   onto a group-sequence list.}
 
- @item{A block is represented as either @litchar{'block} or @litchar{'alts} consed onto a
-   group-sequence list. The representation uses @litchar{'alts} if the content
-   of the block is a squence of groups started with @litchar{|}, and it's
-   @litchar{'block} otherwise.},
+ @item{A block is represented as @litchar{'block} consed onto a
+   group-sequence list. A @litchar{'block} list appears only at the end of
+   a group list or just before an @litchar{'alts} list that is at the end
+   of the group list.}
 
- @item{A block created to follow @litchar{|} appears immediately in an @litchar{'alts}
-   list.}
+ @item{A sequence of alternatives is represented as @litchar{'alts}
+   consed onto a list of @litchar{'block} lists, where each
+   @litchar{'block} list represents a @litchar{|} alternative. An
+   @litchar{'alts} list appears only at the end of a group list.}
 
 )
 
-Note that a block can only appear immediately in a @litchar{'group} or @litchar{'alts}
-list, and only at the end within a @litchar{'group} list. Note also that there is no possibility of confusion between
+Note that there is no possibility of confusion between
 symbol atoms in the input and @litchar{'group}, @litchar{'block}, etc., at the start
 of a list in an S-expression representation, because symbol atoms will
 always appear as non-initial items in a @litchar{'group} list.
@@ -54,23 +56,24 @@ Overall, the grammar of S-expression representations is as follows:
 Here's the same grammar, but expressed using Rhombus constructors:
 
 @nested(~style: #'inset,
-        bnf.BNF([@nonterm{parsed},
+        bnf.BNF([@nonterm{document},
                  @rhombus([#'top, #,(@nonterm{group}), ...])],
                 [@nonterm{group},
-                 @rhombus([#'group, #,(@nonterm{term}), ..., #,(@nonterm{tail-term})])],
-                [@nonterm{term},
+                 @rhombus([#'group, #,(@nonterm{item}), ..., #,(@nonterm{item})]),
+                 @rhombus([#'group, #,(@nonterm{item}), ..., #,(@nonterm{block})]),
+                 @rhombus([#'group, #,(@nonterm{item}), ..., #,(@nonterm{alts})]),
+                 @rhombus([#'group, #,(@nonterm{item}), ..., #,(@nonterm{block}), #,(@nonterm{alts})])],
+                [@nonterm{item},
                  @nonterm{atom},
                  @rhombus([#'op, #,(@nonterm{symbol})]),
                  @rhombus([#'parens, #,(@nonterm{group}), ...]),
                  @rhombus([#'brackets, #,(@nonterm{group}), ...]),
                  @rhombus([#'braces, #,(@nonterm{group}), ...]),
                  @rhombus([#'quotes, #,(@nonterm{group}), ...])],
-                [@nonterm{tail-term},
-                 @nonterm{term},
-                 @nonterm{block},
-                 @rhombus([#'alts, #,(@nonterm{block}), ...])],
                 [@nonterm{block},
-                 @rhombus([#'block, #,(@nonterm{group}), ...])]))
+                 @rhombus([#'block, #,(@nonterm{group}), ...])],
+                [@nonterm{alts},
+                 @rhombus([#'alts, #,(@nonterm{block}), ...])]))
 
 Here are some example shrubberies with their S-expression parsed
 representations:

--- a/shrubbery/scribblings/prior-art.scrbl
+++ b/shrubbery/scribblings/prior-art.scrbl
@@ -1,4 +1,6 @@
 #lang scribble/rhombus/manual
+@(import:
+    "quote.rhm" open)
 
 @title{Prior Art}
 
@@ -10,10 +12,10 @@ Sampling notation's rules relating indentation, lines, @litchar{;}, and
 @hyperlink("https://github.com/tonyg/racket-something"){#lang something}
 reader, which also targets an underlying expander that
 further groups tokens. Shrubbery notation evolved away from using
-@litchar{{}} for blocks, however, because @litchar{:} was nearly always
+@braces for blocks, however, because @litchar{:} was nearly always
 preferred in experiments with the notation. For the very rare case that
-explicit grouping is needed for a block, @litchar{«} and @litchar{»} can
-be used. Freeing @litchar{{}} from use for blocks, meanwhile, allows its
+explicit grouping is needed for a block, @guillemets can
+be used. Freeing @braces from use for blocks, meanwhile, allows its
 use for set and map notations.
 
 Shrubbery notation is also based on
@@ -21,7 +23,7 @@ Shrubbery notation is also based on
 particularly its use of @litchar{|}. Lexprs use mandatory @litchar{:} and @litchar{|} tokens
 as a prefix for indentation, and it absorbs an additional line after
 an indented section to allow further chaining of the group. Although
-@litchar{«»} can be used to form multiple subgroups within a shrubbery group,
+@guillemets can be used to form multiple subgroups within a shrubbery group,
 the notation discourages that style in favor of further nesting (or,
 in the case of @litchar{if}, in favor of @litchar{|} notation like other
 conditionals).

--- a/shrubbery/scribblings/quote.rhm
+++ b/shrubbery/scribblings/quote.rhm
@@ -1,0 +1,24 @@
+#lang rhombus
+import:
+  scribble/rhombus/manual
+  lib("scribble/base.rkt") as scribble
+
+export:
+  parens
+  brackets
+  braces
+  s_exp_braces
+  quotes
+  guillemets
+  block_comment
+
+fun open_close(o, c):
+  @scribble.elem{@manual.litchar(o)…@manual.litchar(c)}
+
+def parens = @open_close("(", ")")
+def brackets = @open_close("[", "]")
+def braces = @open_close("{", "}")
+def s_exp_braces = @open_close("#{", "}")
+def quotes = @open_close("'", "'")
+def block_comment = @open_close("/*", "*/")
+def guillemets = @open_close("«", "»")

--- a/shrubbery/scribblings/rationale.scrbl
+++ b/shrubbery/scribblings/rationale.scrbl
@@ -38,10 +38,22 @@ it's possible for bad indentation to inadvertently cause an operator to
 be treated as continuing a group, but hopefully that will be rare.
 Always requiring a preceding @litchar{:} before an indented @litchar{|}
 line would be consistent, but it adds extras @litchar{:}s where
-@litchar{|} already provides one consistency check. Allowing an optional
-@litchar{:} before @litchar{|} would work, but programmers may then
-choose differently on omitting or including the @litchar{:}, leading to
-subtly divergent conventions.
+@litchar{|} already provides one consistency check.
+
+A @litchar{:} block or @litchar{|} alternatives must appear at the end
+of a group, because @litchar{:} and @litchar{|} lack a specific closing
+character. Forms that expect both a @litchar{:} block and @litchar{|}
+alternatives in a group seem unlikely to be common, but allowing both
+supports certain syntactic forms (e.g., an operator that is defined
+through multiple pattern-matching cases, but with a block before all
+cases to specify precedence and associativity). Allowing the
+combination, in turn, naturally leads to allowing an empty-block
+@litchar{:} before a sequence of @litchar{|} alternatives, effectively
+making a @litchar{:} before @litchar{|} optional. Normalizing to drop
+the empty block in that case, instead of preserving it before the
+sequence of alternatives, makes shrubbery notation feel more consistent
+without burdening consumers of shrubbery forms to explicitly accomodate
+an empty block.
 
 Explicit block grouping via @litchar{«} and @litchar{»} is expected to
 be rare. The grouping characters were intentionally chosen from the

--- a/shrubbery/tests/armor.rkt
+++ b/shrubbery/tests/armor.rkt
@@ -52,6 +52,7 @@
 (check "simple" "a: 1 2" '(top (group a (block (group 1) (group 2)))))
 (check 1 input1 expected1)
 (check '1a input1a expected1a #:unarmor? #f)
+(check '1b input1a expected1a #:unarmor? #f)
 (check 2 input2 expected2 #:unarmor? #f) ; unarmor not right yet for continuing
 (check 3 input3 expected3)
 (check 4 input4 expected4)

--- a/shrubbery/tests/color.rkt
+++ b/shrubbery/tests/color.rkt
@@ -63,6 +63,7 @@
 
 (color-test 1 input1)
 (color-test "1a" input1a)
+(color-test "1b" input1b)
 (color-test 2 input2)
 (color-test 3 input3)
 (color-test 4 input4)

--- a/shrubbery/tests/incremental.rkt
+++ b/shrubbery/tests/incremental.rkt
@@ -162,6 +162,7 @@
       [i (in-naturals)])
   (try-input (format "1[~a]" i) input1))
 (try-input '1a input1a)
+(try-input '1b input1b)
 (try-input 2 input2)
 (try-input 3 input3)
 (try-input 4 input4)

--- a/shrubbery/tests/indent.rkt
+++ b/shrubbery/tests/indent.rkt
@@ -108,12 +108,17 @@
 
  @e{define fib(n):
      cond | n == 0: 0
-          ^         ^|}
+    ^     ^ ^       ^|}
+
+ @e{define fib(n):
+     cond | n == 0:
+              0
+    ^     ^ ^ ^|}
 
  @e{define fib(n):
      log_error("fib called")
      cond | n == 0: 0
-          ^         ^|}
+    ^     ^ ^       ^|}
  
  @e{define
      | fib(0): 0
@@ -131,7 +136,7 @@
      lambda (n):
        cond
        | n == 0: 0
-       ^         ^| n == 1: 1}
+    ^^ ^ ^       ^| n == 1: 1}
 
  @e|{define fib(n):
       match n { | 0 { 0 }
@@ -160,12 +165,12 @@
  @e{define go():
       hello
       | world
-      ^ ^|}
+    ^ ^ ^|}
 
  @e{define go():
       define more(m):
         if m == 0 | "done"
-                  ^ ^|}
+    ^ ^           ^ ^|}
 
  @e{define go():
       define more(m):
@@ -177,7 +182,7 @@
       match x
       | something(v): lambda
                       | (): v
-      ^               ^     ^| (n): v+n}
+    ^ ^ ^             ^ ^   ^| (n): v+n}
 
  @e{define colors:
      list(
@@ -206,7 +211,7 @@
 
  @e{this is | one: a \
                     long result
-            ^      ^| two}
+            ^ ^    ^| two}
 
  @e{this is | one: a \
                     long result
@@ -296,11 +301,11 @@
     ^)}
 
  @e{(match v
-      | cons(bv, av):
-          define values(is_a_match, ar):
-            ¿a_pred(av)
-          if is_a_match
-      ^   ^| define}
+     | cons(bv, av):
+         define values(is_a_match, ar):
+           ¿a_pred(av)
+         if is_a_match
+     ^ ^ ^| define}
 
  @e{a  |« b»
     ^ c}
@@ -350,7 +355,7 @@
  @e{z:
       a:«x»
       b
-      ^|x}
+    ^ ^|x}
 
  @e{(1,
      a:

--- a/shrubbery/tests/input.rkt
+++ b/shrubbery/tests/input.rkt
@@ -7,6 +7,9 @@
          input1a
          expected1a
 
+         input1b
+         expected1b
+
          input2
          expected2
 
@@ -44,22 +47,22 @@ define fib(n):
        | else: fib(n-1) + fib(n-2)
 
 define
- | fib(0): 0
- | fib(1): 1
- | fib(n): fib(n-1) + fib(n-2)
+| fib(0): 0
+| fib(1): 1
+| fib(n): fib(n-1) + fib(n-2)
 
 define
- | fib(0): 0
- | fib(1): 1
- | fib(n): fib(n-1)
-             + fib(n-2)
+| fib(0): 0
+| fib(1): 1
+| fib(n): fib(n-1)
+            + fib(n-2)
 
 define fib:
   lambda (n):
     cond
-     | n == 0: 0
-     | n == 1: 1
-     | else: fib(n-1) + fib(n-2)
+    | n == 0: 0
+    | n == 1: 1
+    | else: fib(n-1) + fib(n-2)
 
 // Ok to add `:` before `|`. This parses the
 // same as the prevous example, but this is not the standard
@@ -67,9 +70,9 @@ define fib:
 define fib:
   lambda (n):
     cond
-     | n == 0: 0
-     | n == 1: 1
-     | else: fib(n-1) + fib(n-2)
+    | n == 0: 0
+    | n == 1: 1
+    | else: fib(n-1) + fib(n-2)
 
 // Adding parentheses is ok, at least with the obvious handling
 // of parentheses by the use of sapling notation, but the
@@ -77,9 +80,9 @@ define fib:
 (define fib:
   (lambda (n):
     (cond
-      | (n == 0): 0
-      | (n == 1): 1
-      | else: (fib(n-1) + fib(n-2)))))
+     | (n == 0): 0
+     | (n == 1): 1
+     | else: (fib(n-1) + fib(n-2)))))
 
 // For maximal noise, you could add parentheses and trailing colons.
 // But we won't.
@@ -93,15 +96,15 @@ INPUT
 
 define fib(n):
   match n
-   | 0: 0
-   | 1: 1
-   | n: fib(n-1) + fib(n-2)
+  | 0: 0
+  | 1: 1
+  | n: fib(n-1) + fib(n-2)
 
 define fib(n):
   match n
-   | 0: 0
-   | 1: 1
-   | n: fib(n-1) + fib(n-2)
+  | 0: 0
+  | 1: 1
+  | n: fib(n-1) + fib(n-2)
 
 define fib(n):
   match n | 0: 0
@@ -110,12 +113,12 @@ define fib(n):
 
 define fib(n):
   match n
-   | 0:
-       0
-   | 1:
-       1
-   | n:
-       fib(n-1) + fib(n-2)
+  | 0:
+      0
+  | 1:
+      1
+  | n:
+      fib(n-1) + fib(n-2)
 
 // END equivalent `fib` definitions
 
@@ -126,16 +129,16 @@ define make_adder(n):
 
 define analyze(n):
   if n == 0
-   | printf("zero\n")
-   | printf("other\n")
+  | printf("zero\n")
+  | printf("other\n")
   printf("done\n")
 
 define analyze(n):
   if n == 0
-   | printf("zero\n")
-     printf("done saying zero\n")
-   | printf("other\n")
-     printf("done saying other\n")
+  | printf("zero\n")
+    printf("done saying zero\n")
+  | printf("other\n")
+    printf("done saying other\n")
 
 struct posn(x, y)
 
@@ -197,8 +200,8 @@ define fourth(n :: Int):
 
 define exp(n :: Int, ~base: base = 2.718281828459045):
   if (n == 1)
-   | base
-   | base * exp(n-1, ~base: base)
+  | base
+  | base * exp(n-1, ~base: base)
 
 define positive_p(n): if n > 0 | true | false
 
@@ -212,34 +215,34 @@ define go():
 
 define approx(x):
   match x
-   | something(v):
-       printf("got it\n")
-       v
-   | nothing: 0
+  | something(v):
+      printf("got it\n")
+      v
+  | nothing: 0
 
 // With two `:`s on one line, there's no way to
 // add to the first `:`
 define approx_thunk(x):
   match x
-   | something(v): lambda (): v
-   | nothing: lambda (): 0
+  | something(v): lambda (): v
+  | nothing: lambda (): 0
 
 // Enough indentation for `v` means that it continues the
 // implicit second `:`, so the `lambda` body has `v`:
 define approx_thunk(x):
   match x
-   | something(v): lambda ():
-                      v
-   | nothing: lambda (): 0
+  | something(v): lambda ():
+                     v
+  | nothing: lambda (): 0
 
 define approx_thunk(x):
   match x
-   | something(v): lambda
-                    | (): v
-                    | (n): v+n
-   | nothing: lambda
-               | (): 0
-               | (n): n
+  | something(v): lambda
+                  | (): v
+                  | (n): v+n
+  | nothing: lambda
+             | (): 0
+             | (n): n
 
 #' #, #; #: #|
 
@@ -281,8 +284,8 @@ define f(x_something,
 define sum(l):
   let loop(l = l):
     if is_null(l)
-     | 0
-     | first(l) + loop(rest(l))
+    | 0
+    | first(l) + loop(rest(l))
 
 define show_all(l):
   for (x = in_list(l)):
@@ -316,8 +319,8 @@ define partition(l, pred):
             result (reverse(yes), reverse(no))):
    with (x = in_list(l)):
      if pred(x)
-      | (cons(x, yes), no)
-      | (yes, cons(x, no))
+     | (cons(x, yes), no)
+     | (yes, cons(x, no))
 
 local:
   with:
@@ -1293,7 +1296,157 @@ INPUT
     (group top_f)
     (group if t (alts (block (group x)) (block (group y) (group z))))
     (group a (parens (group 1) (group 2)))))
-  
+
+;; mixture of `:` and `|`
+(define input1b
+#<<INPUT
+a:
+  option
+| case 1
+| case 2
+
+b: option
+| case 1
+
+c:
+| case 1
+| case 2
+
+d:
+| case 1
+
+nested
+| a:
+    option
+  | case 1
+  | case 2
+
+nested:
+| a:
+    option
+  | case 1
+  | case 2
+
+one line:«option; also» | case 1 | case 2
+
+many lines:«option; also»
+| case 1
+| case 2
+
+a | b: «c» | d
+
+a |«b: «c»»| d
+
+a:«b | c: d  | e »
+
+a:«b | c:«d» | e »
+
+a:«b |«c:«d»»|«e»»
+
+a:«»
+| b
+
+a:«» | b
+
+a:
+  b; c
+| d
+
+a:
+  b;« c »
+| d
+
+a:
+  b; (c)
+| d
+
+a: b; cc
+| d
+
+a: b;« cc »
+| d
+
+a: b; (cc)
+| d
+
+a:
+  b
+#//
+| c
+
+a:
+  b
+#//
+| c
+| d
+
+a:«»
+#//
+| c
+
+a:«»
+#//
+| c
+| d
+
+a:
+  b
+  #//
+  | c
+
+a:
+  b
+  #//
+  | c
+| d
+
+a:
+  #//
+  b
+| c
+| d
+
+#//
+a:
+  b
+| c
+| d
+
+INPUT
+  )
+
+(define expected1b
+  '(top
+    (group a (block (group option)) (alts (block (group case 1)) (block (group case 2))))
+    (group b (block (group option)) (alts (block (group case 1))))
+    (group c (alts (block (group case 1)) (block (group case 2))))
+    (group d (alts (block (group case 1))))
+    (group nested (alts (block (group a (block (group option)) (alts (block (group case 1)) (block (group case 2)))))))
+    (group nested (alts (block (group a (block (group option)) (alts (block (group case 1)) (block (group case 2)))))))
+    (group one line (block (group option) (group also)) (alts (block (group case 1)) (block (group case 2))))
+    (group many lines (block (group option) (group also)) (alts (block (group case 1)) (block (group case 2))))
+    (group a (alts (block (group b (block (group c)))) (block (group d))))
+    (group a (alts (block (group b (block (group c)))) (block (group d))))
+    (group a (block (group b (alts (block (group c (block (group d)))) (block (group e))))))
+    (group a (block (group b (alts (block (group c (block (group d)))) (block (group e))))))
+    (group a (block (group b (alts (block (group c (block (group d)))) (block (group e))))))
+    (group a (block) (alts (block (group b))))
+    (group a (block) (alts (block (group b))))
+    (group a (block (group b) (group c)) (alts (block (group d))))
+    (group a (block (group b) (group c)) (alts (block (group d))))
+    (group a (block (group b) (group (parens (group c)))) (alts (block (group d))))
+    (group a (block (group b) (group cc)) (alts (block (group d))))
+    (group a (block (group b) (group cc)) (alts (block (group d))))
+    (group a (block (group b) (group (parens (group cc)))) (alts (block (group d))))
+    (group a (block (group b)))
+    (group a (block (group b)) (alts (block (group d))))
+    (group a (block))
+    (group a (block) (alts (block (group d))))
+    (group a (block (group b)))
+    (group a (block (group b)) (alts (block (group d))))
+    (group a (alts (block (group c)) (block (group d))))))
+
+
 (define input2
 #<<INPUT
 
@@ -1352,9 +1505,9 @@ this: \
              foo
 
 foo
- | more \
- | again:
-              sub
+| more \
+| again:
+             sub
 
 a
 |
@@ -1368,16 +1521,16 @@ something:
   more stuff
 
 define
- | fib(0) = 0
- | fib(1) = 1
- | fib(n) =
-   fib(n-1) + fib(n-2)
+| fib(0) = 0
+| fib(1) = 1
+| fib(n) =
+  fib(n-1) + fib(n-2)
 
 define
- | fib(0) = 0
- | fib(1) = 1
- | fib(n) = fib(n-1) + fib(n-2)
- | more
+| fib(0) = 0
+| fib(1) = 1
+| fib(n) = fib(n-1) + fib(n-2)
+| more
 
 nonsense:
   hello | there 4.5
@@ -1438,14 +1591,14 @@ x | indentize
 
 define fib(n):
  match n
-  | 0
-    : 0
-  | 1
-    : 1
-  | n
-    : fib(n-1)
-      + fib(n-2)
-      more
+ | 0
+   : 0
+ | 1
+   : 1
+ | n
+   : fib(n-1)
+     + fib(n-2)
+     more
 
 begin:
   dictionary = [
@@ -1919,10 +2072,6 @@ alone
 | only alt gone
 
 alone
-  #//
-  | only alt gone
-
-alone
 #//
 | first alt gone
 #//
@@ -1973,7 +2122,6 @@ INPUT
        (block
         (group val x (block (group f (parens (group 1) (group 2 (op +) 3)))))
         (group match x (alts (block (group 1 (block (group (quotes (group one)))))) (block (group 2 (block (group (quotes (group two))))))))))))
-    (group alone)
     (group alone)
     (group alone)
     (group (parens (group ok)))

--- a/shrubbery/tests/parse.rkt
+++ b/shrubbery/tests/parse.rkt
@@ -76,6 +76,7 @@
 
 (check 1 input1 expected1)
 (check '1a input1a expected1a)
+(check '1b input1b expected1b)
 (check 2 input2 expected2)
 (check 3 input3 expected3)
 (check 4 input4 expected4)


### PR DESCRIPTION
A design proposal for an addition to Shrubbery to allow `|` alts after the end of a `:` block.

Design document: [design/block-alts/block-alts.md](https://github.com/AlexKnauth/rhombus-prototype/blob/block-alts/design/block-alts/block-alts.md)

An implementation of option A is at: https://github.com/AlexKnauth/rhombus-prototype/tree/block-alts-impl-A

An implementation of option C is at: https://github.com/mflatt/rhombus-prototype/tree/alts

Option C is the one we've decided to try for now.