### PR TITLE
collections: import .rkt and check ~is

### DIFF
--- a/rhombus/data/private/regular_immutable_list.rhm
+++ b/rhombus/data/private/regular_immutable_list.rhm
@@ -9,7 +9,7 @@ import:
   rhombus/data/private/list.List
   rhombus/data/private/persistent_list.PersistentList
   rhombus/data/sequence.Iterator
-  lib("racket/base").error
+  lib("racket/base.rkt").error
 
 
 class RegularImmutableList(storage :: Array):

--- a/rhombus/data/tests/list.rhm
+++ b/rhombus/data/tests/list.rhm
@@ -3,49 +3,48 @@
 
 import:
   rhombus/data/list.List
-  rhombus/tests/check.check
 
 
 check:
   List.of().size
-  0
+  ~is 0
 
 check:
   List.of("foo").size
-  1
+  ~is 1
 
 check:
   List.of("foo", "bar", "baz").size
-  3
+  ~is 3
 
 check:
   List.of("foo").get(0)
-  "foo"
+  ~is "foo"
   
 check:
   List.of("foo", "bar", "baz").get(0)
-  "foo"
+  ~is "foo"
 
 check:
   List.of("foo", "bar", "baz").get(1)
-  "bar"
+  ~is "bar"
 
 check:
   List.of("foo", "bar", "baz").get(2)
-  "baz"
+  ~is "baz"
 
 check:
   List.of().isEmpty()
-  #true
+  ~is #true
 
 check:
   List.of(1, 2, 3).contains(2)
-  #true
+  ~is #true
 
 check:
   List.of(1, 2, 3).contains(4)
-  #false
+  ~is #false
 
 check:
   List.builder().build().size
-  0
+  ~is 0


### PR DESCRIPTION
On the `collections` branch, fixes an import of `lib("racket/base")` to `lib("racket/base.rkt")`, and fixes `check` to use `~is`.