### PR TITLE
rhombus/draw: `Point`, `Size`, and `Rect`

### DIFF
--- a/gui_demo.rhm
+++ b/gui_demo.rhm
@@ -6,9 +6,9 @@ import:
 // ----------------------------------------
 
 fun draw_face(dc :: draw.DC, config :: Map):
-  let [w, h] = dc.size
+  let draw.Size(w, h) = dc.size
   let s = math.max(10, math.min(w, h) - 20)
-  
+
   let scale = config["scale"] / 50
   let w = w / scale
   let h = h / scale
@@ -22,60 +22,64 @@ fun draw_face(dc :: draw.DC, config :: Map):
     dc.scale(scale)
 
     let background: if config["mood"] == "Happy"
-                    | draw.RadialGradient(w/2, h/2, s/2,
-                                          w/2, h/2, math.max(w, h),
+                    | def center = [w/2, h/2]
+                      draw.RadialGradient([center, s/2],
+                                          [center, math.max(w, h)],
                                           [[0, draw.Color("white")],
                                            [1, draw.Color("yellow")]])
-                    | draw.LinearGradient(0, 0,
-                                          0, h,
+                    | draw.LinearGradient([0, 0],
+                                          [0, h],
                                           [[0.5, draw.Color("white")],
                                            [1, draw.Color("darkblue")]])
 
     // draw a gradient backround
     dc.pen := draw.Pen.none
     dc.brush := draw.Brush(~gradient: background)
-    dc.rectangle(0, 0, w, h)
+    dc.rectangle([0, 0, w, h])
 
     // draw keyed text
-    dc.text(config["keyed"], 0, 0)
+    dc.text(config["keyed"])
 
     // draw ghost dots (showing recent mouse movements)
     dc.brush := draw.Brush(~color: draw.Color(0, 0, 0, 0.25))
+    def dot_size = [4, 4]
     for:
       each [x, y]: (config["ghosts"] :: List)
       let x = x/scale
       let y = y/scale
-      dc.ellipse(x-2, y-2, 4, 4)
+      dc.ellipse([[x-2, y-2], dot_size])
 
     // face shape    
     dc.brush := draw.Brush(~color: "orange")
+    def face_rect = [x, y, s, s]
     match config["shape"]
-    | "Square": dc.rectangle(x, y, s, s)
-    | "Rounded": dc.rounded_rectangle(x, y, s, s)
-    | ~else dc.ellipse(x, y, s, s)
+    | "Square": dc.rectangle(face_rect)
+    | "Rounded": dc.rounded_rectangle(face_rect)
+    | ~else dc.ellipse(face_rect)
 
     // mouth
     dc.pen := draw.Pen(~color: "Black")
     dc.brush := draw.Brush.none
     if config["mood"] == "Happy"
-    | dc.arc(x + 0.2*s, y + 0.2*s, 0.6*s, 0.6*s, π * -3/4, π * -1/4)
-    | dc.arc(x + 0.2*s, y + 0.7*s, 0.6*s, 0.6*s, π * 1/4, π * 3/4)
+    | dc.arc([x + 0.2*s, y + 0.2*s, 0.6*s, 0.6*s], π * -3/4, π * -1/4)
+    | dc.arc([x + 0.2*s, y + 0.7*s, 0.6*s, 0.6*s], π * 1/4, π * 3/4)
 
     // eyes
     when config["eyes"]
     | dc.pen := draw.Pen.none
       dc.brush := draw.Brush(~color: "black")
-      dc.ellipse(x+0.3*s, y+0.3*s, 0.1*s, 0.1*s)
-      dc.ellipse(x+0.6*s, y+0.3*s, 0.1*s, 0.1*s)
+      let eye_size = [0.1*s, 0.1*s]
+      dc.ellipse([[x+0.3*s, y+0.3*s], eye_size])
+      dc.ellipse([[x+0.6*s, y+0.3*s], eye_size])
 
     // moustache
     when config["moustache"]
     | let p = draw.Path()
-      p.move_to(0, 0)
-      p.curve_to(20, -10,  80, -10,  100, 0)
-      p.curve_to(120, 10,  180, 0,  200, -20)
-      p.curve_to(180, 20,  120, 40, 90, 30)
-      p.curve_to(60, 20, 20, 20, 0, 0)
+      p.move_to([0, 0])
+      p.curve_to([20, -10], [80, -10], [100, 0])
+      p.curve_to([120, 10], [180, 0],  [200, -20])
+      p.curve_to([180, 20], [120, 40], [90, 30])
+      p.curve_to([60, 20],  [20, 20],  [0, 0])
       p.close()
       p.scale(s/500, s/500)
       dc.pen := draw.Pen.none

--- a/rhombus/draw.rhm
+++ b/rhombus/draw.rhm
@@ -1,5 +1,8 @@
 #lang rhombus
 import:
+  "draw/private/point.rhm"
+  "draw/private/size.rhm"
+  "draw/private/rect.rhm"
   "draw/private/color.rhm"
   "draw/private/pen.rhm"
   "draw/private/brush.rhm"
@@ -10,6 +13,9 @@ import:
   "draw/private/bitmap.rhm"
 
 export:
+  all_from(.point)
+  all_from(.size)
+  all_from(.rect)
   all_from(.color)
   all_from(.pen)
   all_from(.brush)

--- a/rhombus/draw/private/bitmap-interface.rhm
+++ b/rhombus/draw/private/bitmap-interface.rhm
@@ -1,4 +1,6 @@
 #lang rhombus/static/and_meta
+import:
+  "type.rhm" open
 
 export:
   Bitmap
@@ -9,5 +11,6 @@ class Bitmap(hand):
   property handle: hand
   abstract property width
   abstract property height
+  abstract property size :: Size
 
 annot.delayed_declare BitmapForward

--- a/rhombus/draw/private/bitmap.rhm
+++ b/rhombus/draw/private/bitmap.rhm
@@ -1,6 +1,7 @@
 #lang rhombus/static/and_meta
 import:
   "rkt.rhm"
+  "type.rhm" open
   "dc.rhm".DC
   "dc.rhm"!internal.SomeDC
   "bitmap-interface.rhm" as intf
@@ -38,6 +39,9 @@ class Bitmap():
 
   override property height:
     rkt.send handle.#{get-height}()
+
+  override property size:
+    Size(width, height)
 
   property backing_scale:
     rkt.send handle.#{get-backing-scale}()

--- a/rhombus/draw/private/brush.rhm
+++ b/rhombus/draw/private/brush.rhm
@@ -1,6 +1,7 @@
 #lang rhombus/static/and_meta
 import:
   "rkt.rhm"
+  "type.rhm" open
   "color.rhm".Color
   "color.rhm"!private._Color
   "color.rhm"!private.unwrap_color
@@ -22,34 +23,34 @@ submodule private:
 class LinearGradient(handle):
   opaque
   internal _LinearGradient
-  constructor (x0 :: Real, y0 :: Real,
-               x1 :: Real, y1 :: Real,
+  constructor (pt1 :: PointLike,
+               pt2 :: PointLike,
                [[stop :: Real.in(0.0, 1.0), color :: Color], ...]):
     _LinearGradient(rkt.make_object(rkt.#{linear-gradient%},
-                                    x0, y0,
-                                    x1, y1,
+                                    pt1.x, pt1.y,
+                                    pt2.x, pt2.y,
                                     [[stop, color.handle], ...]))
-  property line:
-    let values(x0, y0, x1, y1): rkt.send handle.#{get-line}()
-    [x0, y0, x1, y1]
-  property stops:
+  property line :: List.of(Point):
+    let values(x1, y1, x2, y2): rkt.send handle.#{get-line}()
+    [Point(x1, y1), Point(x2, y2)]
+  property stops :: List.of(matching([_ :: Real, _ :: Color])):
     def [[stop, c], ...] = rkt.send handle.#{get-stops}()
     [[stop, _Color(c)], ...]
   
 class RadialGradient(handle):
   opaque
   internal _RadialGradient
-  constructor (x0 :: Real, y0 :: Real, r0 :: Real,
-               x1 :: Real, y1 :: Real, r1 :: Real,
+  constructor ([pt1 :: PointLike, r1 :: Real],
+               [pt2 :: PointLike, r2 :: Real],
                [[stop :: Real.in(0.0, 1.0), color :: Color], ...]):
     _RadialGradient(rkt.make_object(rkt.#{radial-gradient%},
-                                    x0, y0, r0,
-                                    x1, y1, r1,
+                                    pt1.x, pt1.y, r1,
+                                    pt2.x, pt2.y, r2,
                                     [[stop, color.handle], ...]))
-  property circles:
+  property circles:: List.of(matching([_ :: Point, _ :: Real])):
     let values(x0, y0, r0, x1, y1, r1): rkt.send handle.#{get-circles}()
-    [x0, y0, r0, x1, y1, r1]
-  property stops:
+    [[Point(x0, y0), r0], [Point(x1, y1), r1]]
+  property stops :: List.of(matching([_ :: Real, _ :: Color])):
     def [[stop, c], ...] = rkt.send handle.#{get-stops}()
     [[stop, _Color(c)], ...]
     

--- a/rhombus/draw/private/dc.rhm
+++ b/rhombus/draw/private/dc.rhm
@@ -1,6 +1,7 @@
 #lang rhombus/static/and_meta
 import:
   "rkt.rhm"
+  "type.rhm" open
   "dc-interface.rhm".DC as DCer
   "dc-interface.rhm"._DC as _DCer
   "dc-interface.rhm".DCForward
@@ -48,13 +49,12 @@ interface DC:
     | _:
         Syntax.error("expected a block afterward", head)
 
-  property size :: matching([_ :: NonnegReal,
-                             _ :: NonnegReal]):
+  property size :: Size:
     def (w, h) = rkt.send get_dc().#{get-size}()
-    [w, h]
+    Size(w, h)
 
-  property width: size[0]
-  property height: size[1]
+  property width: size.width
+  property height: size.height
 
   method save()
   method restore()
@@ -90,78 +90,78 @@ interface DC:
   | clipping_region := region :: Maybe(Region):
       rkt.send get_dc().#{set-clipping-region}(region && Region.handle(region))
     
-  method copy(x :: Real, y :: Real,
-              width :: NonnegReal, height :: NonnegReal,
-              x2 :: Real, y2 :: Real):
-    rkt.send get_dc().copy(x, y, width, height, x2, y2)
+  method copy(src :: RectLike,
+              dest :: PointLike):
+    rkt.send get_dc().copy(src.x, src.y, src.width, src.height, dest.x, dest.y)
 
-  method point(x :: Real, y :: Real):
-    rkt.send get_dc().#{draw-point}(x, y)
+  method point(pt :: PointLike):
+    rkt.send get_dc().#{draw-point}(pt.x, pt.y)
 
-  method line(x :: Real, y :: Real,
-              x2 :: Real, y2 :: Real):
-    rkt.send get_dc().#{draw-line}(x, y, x2, y2)
+  method line(pt1 :: PointLike,
+              pt2 :: PointLike):
+    rkt.send get_dc().#{draw-line}(pt1.x, pt1.y, pt2.x, pt2.y)
     
-  method lines([[x :: Real, y :: Real], ...],
+  method lines([pt :: PointLike, ...],
+               ~dpt: dpt :: PointLike = Point.zero,
                ~dx: dx :: Real = 0.0,
                ~dy: dy :: Real = 0.0):
-    rkt.send get_dc().#{draw-lines}([Pair(x, y), ...], dx, dy)
+    rkt.send get_dc().#{draw-lines}([Pair(pt.x, pt.y), ...], dpt.x + dx, dpt.y + dy)
 
-  method polygon([[x :: Real, y :: Real], ...],
+  method polygon([pt :: PointLike, ...],
+                 ~dpt: dpt :: PointLike = Point.zero,
                  ~dx: dx :: Real = 0.0,
                  ~dy: dy :: Real = 0.0,
                  ~fill: fill :: Region.Fill = #'odd_even):
-    rkt.send get_dc().#{draw-polygon}([Pair(x, y), ...], dx, dy, fill_convert(fill))
+    rkt.send get_dc().#{draw-polygon}([Pair(pt.x, pt.y), ...], dpt.x + dx, dpt.y + dy,
+                                      fill_convert(fill))
 
   method path(p :: Path,
+              ~dpt: dpt :: PointLike = Point.zero,
               ~dx: dx :: Real = 0.0,
               ~dy: dy :: Real = 0.0,
               ~fill: fill :: Region.Fill = #'odd_even):
-    rkt.send get_dc().#{draw-path}(p.hand, dx, dy, fill_convert(fill))
+    rkt.send get_dc().#{draw-path}(p.hand, dpt.x + dx, dpt.y + dy, fill_convert(fill))
 
-  method rectangle(x :: Real, y :: Real,
-                   width :: NonnegReal, height :: NonnegReal):
-    rkt.send get_dc().#{draw-rectangle}(x, y, width, height)
+  method rectangle(r :: RectLike):
+    rkt.send get_dc().#{draw-rectangle}(r.x, r.y, r.width, r.height)
     
-  method rounded_rectangle(x :: Real, y :: Real,
-                           width :: NonnegReal, height :: NonnegReal,
+  method rounded_rectangle(r :: RectLike,
                            radius :: Real = -0.25):
-    rkt.send get_dc().#{draw-rounded-rectangle}(x, y, width, height, radius)
+    rkt.send get_dc().#{draw-rounded-rectangle}(r.x, r.y, r.width, r.height, radius)
     
-  method ellipse(x :: Real, y :: Real,
-                 width :: NonnegReal, height :: NonnegReal):
-    rkt.send get_dc().#{draw-ellipse}(x, y, width, height)
+  method ellipse(r :: RectLike):
+    rkt.send get_dc().#{draw-ellipse}(r.x, r.y, r.width, r.height)
     
-  method arc(x :: Real, y :: Real,
-             width :: NonnegReal, height :: NonnegReal,
+  method arc(r :: RectLike,
              start :: Real, end :: Real):
-    rkt.send get_dc().#{draw-arc}(x, y, width, height, start, end)
+    rkt.send get_dc().#{draw-arc}(r.x, r.y, r.width, r.height, start, end)
 
-  method spline(x1 :: Real, y1 :: Real,
-                x2 :: Real, y2 :: Real,
-                x3 :: Real, y3 :: Real):
-    rkt.send get_dc().#{draw-spline}(x1, y1, x2, y2, x3, y3)
+  method spline(pt1 :: PointLike,
+                pt2 :: PointLike,
+                pt3 :: PointLike):
+    rkt.send get_dc().#{draw-spline}(pt1.x, pt1.y, pt2.x, pt2.y, pt3.x, pt3.y)
 
   method bitmap(b :: Bitmap,
-                x :: Real, y :: Real,
-                ~source_x: source_x :: Real = 0,
-                ~source_y: source_y :: Real = 0,
-                ~source_width: source_width :: NonnegReal = b.width,
-                ~source_height: source_height :: NonnegReal = b.height,
+                ~dpt: dpt :: PointLike = Point.zero,
+                ~dx: dx :: Real = 0,
+                ~dy: dy :: Real = 0,
+                ~source: source :: RectLike = Rect(Point.zero, b.size),
                 ~style: style :: DC.BitmapOverlay = #'solid,
                 ~color: color :: Color = Color("black"),
                 ~mask: mask :: Maybe(Bitmap) = #false):
-    rkt.send get_dc().#{draw-bitmap-section}(b.handle, x, y,
-                                             source_x, source_y,
-                                             source_width, source_height,
+    rkt.send get_dc().#{draw-bitmap-section}(b.handle, dpt.x + dx, dpt.y + dy,
+                                             source.x, source.y,
+                                             source.width, source.height,
                                              style, color.handle, mask)
     #void
 
   method text(str :: String,
-              x :: Real, y :: Real,
+              ~dpt: dpt :: Point = Point.zero,
+              ~dx: dx :: Real = 0,
+              ~dy: dy :: Real = 0,
               ~combine: combine :: DC.TextCombine = #'kern,
               ~angle: angle :: Real = 0.0):
-    rkt.send get_dc().#{draw-text}(str, x, y,
+    rkt.send get_dc().#{draw-text}(str, dpt.x + dx, dpt.y + dy,
                                    match combine
                                    | #'kern: #true
                                    | #'grapheme: #'grapheme
@@ -173,8 +173,10 @@ interface DC:
              rkt.send get_dc().#{scale}(sx, sy)
          | scale(s :: Real):
              rkt.send get_dc().#{scale}(s, s)
-  method translate(dx :: Real, dy :: Real):
-    rkt.send get_dc().#{translate}(dx, dy)
+  method | translate(dx :: Real, dy :: Real):
+             rkt.send get_dc().#{translate}(dx, dy)
+         | translate(dpt :: PointLike):
+             rkt.send get_dc().#{translate}(dpt.x, dpt.y)
   method rotate(radians :: Real):
     rkt.send get_dc().#{rotate}(radians)
   method transform(a :: Transformation):

--- a/rhombus/draw/private/path.rhm
+++ b/rhombus/draw/private/path.rhm
@@ -1,6 +1,7 @@
 #lang rhombus/static/and_meta
 import:
   "rkt.rhm"
+  "type.rhm" open
   "symbol_map.rhm":
     expose: symbol_map_annot
 
@@ -21,43 +22,41 @@ class Path(hand):
   method reset():
     rkt.send hand.reset()
 
-  method scale(x :: Real, y :: Real):
-    rkt.send hand.#{scale}(x, y)
+  method | scale(s :: Real):
+             rkt.send hand.#{scale}(s, s)
+         | scale(sx :: Real, sy :: Real):
+             rkt.send hand.#{scale}(sx, sy)
   method rotate(radians :: Real):
     rkt.send hand.#{rotate}(radians)
 
-  method curve_to(x1 :: Real, y1 :: Real,
-                  x2 :: Real, y2 :: Real,
-                  x3 :: Real, y3 :: Real):
-    rkt.send hand.#{curve-to}(x1, y1, x2, y2, x3, y3)
+  method curve_to(pt1 :: PointLike,
+                  pt2 :: PointLike,
+                  pt3 :: PointLike):
+    rkt.send hand.#{curve-to}(pt1.x, pt1.y, pt2.x, pt2.y, pt3.x, pt3.y)
 
-  method line_to(x :: Real, y :: Real):
-    rkt.send hand.#{line-to}(x, y)
+  method line_to(pt :: PointLike):
+    rkt.send hand.#{line-to}(pt.x, pt.y)
 
-  method move_to(x :: Real, y :: Real):
-    rkt.send hand.#{move-to}(x, y)
+  method move_to(pt :: PointLike):
+    rkt.send hand.#{move-to}(pt.x, pt.y)
 
-  method rectangle(x :: Real, y :: Real,
-                   width :: NonnegReal, height :: NonnegReal):
-    rkt.send hand.#{rectangle}(x, y, width, height)
+  method rectangle(r :: RectLike):
+    rkt.send hand.#{rectangle}(r.x, r.y, r.width, r.height)
 
-  method rounded_rectangle(x :: Real, y :: Real,
-                           width :: NonnegReal, height :: NonnegReal,
+  method rounded_rectangle(r :: RectLike,
                            radius :: Real):
-    rkt.send hand.#{rounded-rectangle}(x, y, width, height, radius)
+    rkt.send hand.#{rounded-rectangle}(r.x, r.y, r.width, r.height, radius)
 
-  method ellipse(x :: Real, y :: Real,
-                 width :: NonnegReal, height :: NonnegReal):
-    rkt.send hand.#{ellipse}(x, y, width, height)
+  method ellipse(r :: RectLike):
+    rkt.send hand.#{ellipse}(r.x, r.y, r.width, r.height)
 
-  method arc(x :: Real, y :: Real,
-             width :: NonnegReal, height :: NonnegReal,
+  method arc(r :: RectLike,
              start_radians :: Real, end_radians :: Real,
              ~clockwise = #false):
-    rkt.send hand.#{arc}(x, y, width, height, start_radians, end_radians, !clockwise)
+    rkt.send hand.#{arc}(r.x, r.y, r.width, r.height, start_radians, end_radians, !clockwise)
 
-  method polygon([[x :: Real, y :: Real], ...],
-                 dx :: Real = 0.0,
-                 dy :: Real = 0.0):
-    rkt.send hand.#{lines}([Pair(x, y), ...], dx, dy)
-
+  method polygon([[pt :: PointLike], ...],
+                 ~dpt: dpt :: PointLike = Point.zero,
+                 ~dx: dx :: Real = 0,
+                 ~dy: dy :: Real = 0):
+    rkt.send hand.#{lines}([Pair(pt.x, pt.y), ...], dpt.x + dx, dpt.y + dy)

--- a/rhombus/draw/private/point.rhm
+++ b/rhombus/draw/private/point.rhm
@@ -1,0 +1,22 @@
+#lang rhombus/static/and_meta
+
+export:
+  Point
+  PointLike
+  PointLikeAsPoint
+
+class Point(x :: Real, y :: Real):
+  export:
+    zero
+
+def zero = Point(0, 0)
+
+annot.macro 'PointLike':
+  'Point
+     || matching([_ :: Real, _ :: Real])
+     || matching({#'x: _ :: Real, #'y: _ :: Real})'
+
+annot.macro 'PointLikeAsPoint':
+  'Point
+     || converting(fun ([x :: Real, y :: Real]) :: Point: Point(x, y))
+     || converting(fun ({#'x: x :: Real, #'y: y :: Real}) :: Point: Point(x, y))'

--- a/rhombus/draw/private/rect.rhm
+++ b/rhombus/draw/private/rect.rhm
@@ -1,0 +1,44 @@
+#lang rhombus/static/and_meta
+import:
+  "point.rhm" open:
+    except: PointLike
+    rename: PointLikeAsPoint as PointLike
+  "size.rhm" open:
+    except: SizeLike
+    rename: SizeLikeAsSize as SizeLike
+
+export:
+  Rect
+  RectLike
+  RectLikeAsRect
+
+class Rect(x :: Real, y :: Real, width :: NonnegReal, height :: NonnegReal):
+  constructor
+  | (x :: Real, y :: Real, width :: NonnegReal, height :: NonnegReal):
+      super(x, y, width, height)
+  | (topleft :: PointLike, size :: SizeLike):
+      super(topleft.x, topleft.y, size.width, size.height)
+      
+  property point :: Point: Point(x, y)
+  property size :: Size: Size(width, height)
+
+  export:
+    zero
+
+def zero = Rect(0, 0, 0, 0)
+
+annot.macro 'RectLike':
+  'Rect
+     || matching([_ :: Real, _ :: Real, _ :: NonnegReal, _ :: NonnegReal])
+     || matching([_ :: Point, _ :: Size])
+     || matching({#'x: _ :: Real, #'y: _ :: Real, #'width: _ :: NonnegReal, #'height: _ :: NonnegReal})
+     || matching({#'point: _ :: topleft, #'size: _ :: Size})'
+
+annot.macro 'RectLikeAsRect':
+  'Rect
+     || converting(fun ([x :: Real, y :: Real, w :: NonnegReal, h :: NonnegReal]) :: Rect: Rect(x, y, w, h))
+     || converting(fun ([topleft :: PointLike, size :: SizeLike]) :: Rect: Rect(topleft.x, topleft.y, size.width, size.height))
+     || converting(fun ({#'x: x :: Real, #'y: y :: Real, #'width: w :: NonnegReal, #'height: h :: NonnegReal}) :: Rect:
+                     Rect(x, y, w, h))
+     || converting(fun ({#'point: topleft :: PointLike, #'size: size :: SizeLike}) :: Rect:
+                     Rect(topleft.x, topleft.y, size.width, size.height))'

--- a/rhombus/draw/private/region.rhm
+++ b/rhombus/draw/private/region.rhm
@@ -1,6 +1,7 @@
 #lang rhombus/static/and_meta
 import:
   "rkt.rhm"
+  "type.rhm" open
   "dc-interface.rhm".DCForward as DC
   "dc-interface.rhm"._DC
   "region-interface.rhm" as intf
@@ -30,38 +31,36 @@ class Region():
   method is_empty():
     rkt.send hand.#{is-empty?}()
 
-  method contains(x :: Real, y :: Real):
-    rkt.send hand.#{in-region?}(x, y)
+  method contains(pt :: PointLike):
+    rkt.send hand.#{in-region?}(pt.x, pt.y)
 
-  method rectangle(x :: Real, y :: Real,
-                   width :: NonnegReal, height :: NonnegReal):
-    rkt.send hand.#{set-rectangle}(x, y, width, height)
+  method rectangle(r :: RectLike):
+    rkt.send hand.#{set-rectangle}(r.x, r.y, r.width, r.height)
 
-  method rounded_rectangle(x :: Real, y :: Real,
-                           width :: NonnegReal, height :: NonnegReal,
+  method rounded_rectangle(r :: RectLike,
                            radius :: Real = -0.25):
-    rkt.send hand.#{set-rounded-rectangle}(x, y, width, height, radius)
+    rkt.send hand.#{set-rounded-rectangle}(r.x, r.y, r.width, r.height, radius)
 
-  method ellipse(x :: Real, y :: Real,
-                 width :: NonnegReal, height :: NonnegReal):
-    rkt.send hand.#{set-ellipse}(x, y, width, height)
+  method ellipse(r :: RectLike):
+    rkt.send hand.#{set-ellipse}(r.x, r.y, r.width, r.height)
 
-  method arc(x :: Real, y :: Real,
-             width :: NonnegReal, height :: NonnegReal,
+  method arc(r :: RectLike,
              start_radians :: Real, end_radians :: Real):
-    rkt.send hand.#{set-arc}(x, y, width, height, start_radians, end_radians)
+    rkt.send hand.#{set-arc}(r.x, r.y, r.width, r.height, start_radians, end_radians)
 
-  method polygon([[x :: Real, y :: Real], ...],
-                 dx :: Real = 0.0,
-                 dy :: Real = 0.0,
+  method polygon([pt :: PointLike, ...],
+                 ~dpt: dpt :: PointLike = Point.zero,
+                 ~dx: dx :: Real = 0,
+                 ~dy: dy :: Real = 0,
                  fill :: Region.Fill = #'odd_even):
-    rkt.send hand.#{set-polygon}([Pair(x, y), ...], dx, dy, fill_convert(fill))
+    rkt.send hand.#{set-polygon}([Pair(pt.x, pt.y), ...], dpt.x + dx, dpt.y + dy, fill_convert(fill))
 
   method path(p :: Path,
+              ~dpt: dpt :: PointLike = Point.zero,
               ~dx: dx :: Real = 0.0,
               ~dy: dy :: Real = 0.0,
               ~fill: fill :: Region.Fill = #'odd_even):
-    rkt.send hand.#{set-path}(p, dx, dy, fill_convert(fill))
+    rkt.send hand.#{set-path}(p, dpt.x + dx, dpt.y + dy, fill_convert(fill))
 
   method union(region :: Region):
     rkt.send hand.#{union}(region.hand)

--- a/rhombus/draw/private/size.rhm
+++ b/rhombus/draw/private/size.rhm
@@ -1,0 +1,22 @@
+#lang rhombus/static/and_meta
+
+export:
+  Size
+  SizeLike
+  SizeLikeAsSize
+
+class Size(width :: NonnegReal, height :: NonnegReal):
+  export:
+    zero
+
+def zero = Size(0, 0)
+
+annot.macro 'SizeLike':
+  'Size
+     || matching([_ :: NonnegReal, _ :: NonnegReal])
+     || matching({#'width: _ :: NonnegReal, #'height: _ :: NonnegReal})'
+
+annot.macro 'SizeLikeAsSize':
+  'Size
+     || converting(fun ([width :: NonnegReal, height :: NonnegReal]) :: Size: Size(width, height))
+     || converting(fun ({#'width: width :: NonnegReal, #'height: height :: NonnegReal}) :: Size: Size(width, height))'

--- a/rhombus/draw/private/type.rhm
+++ b/rhombus/draw/private/type.rhm
@@ -1,0 +1,21 @@
+#lang rhombus/static/and_meta
+
+// Rename `XLikeAsX` to `XLike` so that argument
+// error are reported as `XLike`, but we get the
+// conversions of `XLikeAsX`
+
+import:
+  "point.rhm":
+    except: PointLike
+    rename: PointLikeAsPoint as PointLike
+  "size.rhm":
+    except: SizeLike
+    rename: SizeLikeAsSize as SizeLike
+  "rect.rhm":
+    except: RectLike
+    rename: RectLikeAsRect as RectLike
+
+export:
+  all_from(.point)
+  all_from(.size)
+  all_from(.rect)

--- a/rhombus/draw/scribblings/bitmap.scrbl
+++ b/rhombus/draw/scribblings/bitmap.scrbl
@@ -17,6 +17,7 @@
 @doc(
   property (bm :: Bitmap).width :: PosInt
   property (bm :: Bitmap).height :: PosInt
+  property (bm :: Bitmap).size :: Size
   property (bm :: Bitmap).backing_scale :: Real.above(0.0)
   property (bm :: Bitmap).depth :: NonnegInt
   property (bm :: Bitmap).has_color :: Boolean
@@ -24,7 +25,9 @@
   property (bm :: Bitmap).is_ok :: Boolean
 ){
 
- Properties to access bitmap components.
+ Properties to access bitmap components. The @rhombus(Bitmap.size)
+ property combines the @rhombus(Bitmap.width) and @rhombus(Bitmap.height)
+ properties.
 
 }
 

--- a/rhombus/draw/scribblings/brush.scrbl
+++ b/rhombus/draw/scribblings/brush.scrbl
@@ -66,14 +66,13 @@
 
 @doc(
   class LinearGradient():
-    constructor (x0 :: Real, y0 :: Real,
-                 x1 :: Real, y1 :: Real,
+    constructor (pt1 :: PointLike,
+                 pt2 :: PointLike,
                  [[stop :: Real.in(0.0, 1.0), color :: Color], ...])
   property (grad :: LinearGradient).line
-    :: matching([_ :: Real, _ :: Real,
-                 _ :: Real, _ :: Real])
+    :: matching([_ :: Point, _ :: Point])
   property (grad :: LinearGradient).stops
-    :: List.of(matching([_ :: Real, _ :: Color]))
+    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: Color]))
 ){
 
  A linear gradient for a @rhombus(Brush, ~class).
@@ -82,14 +81,14 @@
 
 @doc(
   class RadialGradient():
-    constructor (x0 :: Real, y0 :: Real, r0 :: Real,
-                 x1 :: Real, y1 :: Real, r1 :: Real,
+    constructor ([[pt1 :: PointLike], r1 :: Real],
+                 [[pt2 :: PointLike], r2 :: Real],
                  [[stop :: Real.in(0.0, 1.0), color :: Color], ...])
   property (grad :: RadialGradient).circles
-    :: matching([_ :: Real, _ :: Real, _ :: Real,
-                 _ :: Real, _ :: Real, _ :: Real])
+    :: matching([[_ :: PointLike, _ :: Real],
+                 [_ :: PointLike, _ :: Real]])
   property (grad :: RadialGradient).stops
-    :: List.of(matching([_ :: Real, _ :: Color]))
+    :: List.of(matching([_ :: Real.in(0.0, 1.0), _ :: Color]))
 ){
 
  A radial gradient for a @rhombus(Brush, ~class).

--- a/rhombus/draw/scribblings/dc.scrbl
+++ b/rhombus/draw/scribblings/dc.scrbl
@@ -22,8 +22,7 @@
 @doc(
   property (dc :: DC).width :: NonnegReal
   property (dc :: DC).height :: NonnegReal
-  property (dc :: DC).size :: matching([_ :: NonnegReal,
-                                        _ :: NonnegReal])
+  property (dc :: DC).size :: Size
 ){
 
  The size of the drawing area: width, height, or both.
@@ -58,6 +57,7 @@
 @doc(
   method (dc :: DC).scale(s :: Real) :: Void
   method (dc :: DC).scale(sx :: Real, sy :: Real) :: Void
+  method (dc :: DC).translate(dpt :: PointLike) :: Void
   method (dc :: DC).translate(dx :: Real, dy :: Real) :: Void
   method (dc :: DC).rotate(radians :: Real) :: Void
   method (dc :: DC).transform(t :: DC.Transformation) :: Void
@@ -91,33 +91,28 @@
 }
 
 @doc(
-  method (dc :: DC).point(x :: Real, y :: Real) :: Void
-  method (dc :: DC).line(x :: Real, y :: Real,
-                         x2 :: Real, y2 :: Real) :: Void
-  method (dc :: DC).lines([[x :: Real, y :: Real], ...],
-                          ~dx: dx :: Real = 0.0,
-                          ~dy: dy :: Real = 0.0) :: Void
-  method (dc :: DC).polygon([[x :: Real, y :: Real], ...],
-                            ~dx: dx :: Real = 0.0,
-                            ~dy: dy :: Real = 0.0,
+  method (dc :: DC).point(pt :: PointLike) :: Void
+  method (dc :: DC).line(pt1 :: PointLike,
+                         pt2 :: PointLike) :: Void
+  method (dc :: DC).lines([[pt :: PointLike], ...],
+                          ~dpt dpt :: PointLike = Point.zero,
+                          ~dx: dx :: Real = 0,
+                          ~dy: dy :: Real = 0) :: Void
+  method (dc :: DC).polygon([[pt :: PointLike], ...],
+                            ~dpt dpt :: PointLike = Point.zero,
+                            ~dx: dx :: Real = 0,
+                            ~dy: dy :: Real = 0,
                             ~fill: fill :: DC.Fill = #'even_odd) :: Void
-  method (dc :: DC).rectangle(x :: Real, y :: Real,
-                              width :: NonnegReal,
-                              height :: NonnegReal) :: Void
-  method (dc :: DC).rounded_rectangle(x :: Real, y :: Real,
-                                      width :: NonnegReal,
-                                      height :: NonnegReal,
+  method (dc :: DC).rectangle(r :: RectLike) :: Void
+  method (dc :: DC).rounded_rectangle(r :: RectLike,
                                       radius :: Real = -0.25) :: Void
-  method (dc :: DC).ellipse(x :: Real, y :: Real,
-                            width :: NonnegReal,
-                            height :: NonnegReal) :: Void
-  method (dc :: DC).arc(x :: Real, y :: Real,
-                        width :: NonnegReal,
-                        height :: NonnegReal,
+  method (dc :: DC).ellipse(r :: RectLike) :: Void
+  method (dc :: DC).arc(r :: RectLike,
                         start :: Real, end :: Real) :: Void
   method (dc :: DC).path(p :: Path,
-                         ~dx: dx :: Real = 0.0,
-                         ~dy: dy :: Real = 0.0,
+                         ~dpt dpt :: PointLike = Point.zero,
+                         ~dx: dx :: Real = 0,
+                         ~dy: dy :: Real = 0,
                          ~fill: fill :: DC.Fill = #'odd_even) :: Void
 ){
 
@@ -125,11 +120,16 @@
  of drawing a polygon, rectangle, rounded rectangle, ellipse, or arc, a
  shape is fulled using the current brush, too.
 
+ Offsets through @rhombus(dpt) and also @rhombus(dx) or @rhombus(dy) are
+ combined.
+
 }
 
 @doc(
   method (dc:: DC).text(str :: String,
-                        x :: Real, y :: Real,
+                        ~dpt dpt :: PointLike = Point.zero,
+                        ~dx: dx :: Real = 0,
+                        ~dy: dy :: Real = 0,
                         ~combine: combine :: DC.TextCombine = #'kern,
                         ~angle: angle :: Real = 0.0) :: Void
 ){
@@ -141,26 +141,24 @@
 @doc(
   method (dc :: DC).bitmap(
     bm :: Bitmap,
-    dest_x :: Real, dest_y :: Real,
-    ~source_x: source_x :: Real = 0,
-    ~source_y: source_y :: Real = 0,
-    ~source_width: source_width :: NonnegReal = Bitmap.width(bm),
-    ~source_height: source_height :: NonnegReal = Bitmap.height(bm),
+    ~dpt: dpt :: PointLike = Point.zero,
+    ~dx: dx :: Real = 0,
+    ~dy: dy :: Real = 0,
+    ~source: source :: RectLike = Rect(Point.zero, Bitmap.size(bm)),
     ~style: style :: DC.BitmapOverlay = #'solid,
     ~color: color :: Color = Color("black"),
     ~mask: mask :: Maybe(Bitmap) = #false
   ) :: Void
 ){
 
- Draws a bitmap into the drawing context.
+ Draws a region of a bitmap into the drawing context. The default
+ @rhombus(source) region is the entire bitmap.
 
 }
 
 @doc(
-  method (dc :: DC).copy(source_x :: Real, source_y :: Real,
-                         width :: NonnegReal,
-                         height :: NonnegReal,
-                         dest_x2 :: Real, dest_y :: Real) :: Void
+  method (dc :: DC).copy(source :: RectLike,
+                         dest :: PointLike) :: Void
 ){
 
  Copies a portion of the draw context's content to another portion of

--- a/rhombus/draw/scribblings/path.scrbl
+++ b/rhombus/draw/scribblings/path.scrbl
@@ -29,11 +29,11 @@
 }
 
 @doc(
-  method (path :: Path).move_to(x :: Real, y :: Real)
-  method (path :: Path).line_to(x :: Real, y :: Real)
-  method (path :: Path).curve_to(x1 :: Real, y1 :: Real,
-                                 x2 :: Real, y2 :: Real,
-                                 x3 :: Real, y3 :: Real)
+  method (path :: Path).move_to(pt :: PointLike)
+  method (path :: Path).line_to(pt :: PointLike)
+  method (path :: Path).curve_to(pt1 :: PointLike,
+                                 pt2 :: PointLike,
+                                 pt3 :: PointLike)
 ){
 
  Sets a starting poin for an open path, or extends an open path with a
@@ -43,22 +43,15 @@
 
 
 @doc(
-  method (path :: Path).polygon([[x :: Real, y :: Real], ...],
-                                ~dx: dx :: Real = 0.0,
-                                ~dy: dy :: Real = 0.0) :: Void
-  method (path :: Path).rectangle(x :: Real, y :: Real,
-                                  width :: NonnegReal,
-                                  height :: NonnegReal) :: Void
-  method (path :: Path).rounded_rectangle(x :: Real, y :: Real,
-                                          width :: NonnegReal,
-                                          height :: NonnegReal,
+  method (path :: Path).polygon([pt :: PointLike, ...],
+                                ~dpt: dpt :: PointLike = Point.zero,
+                                ~dx: dx :: Real = 0,
+                                ~dy: dy :: Real = 0) :: Void
+  method (path :: Path).rectangle(r :: RectLike) :: Void
+  method (path :: Path).rounded_rectangle(r :: RectLike,
                                           radius :: Real = -0.25) :: Void
-  method (path :: Path).ellipse(x :: Real, y :: Real,
-                                width :: NonnegReal,
-                                height :: NonnegReal) :: Void
-  method (path :: Path).arc(x :: Real, y :: Real,
-                            width :: NonnegReal,
-                            height :: NonnegReal,
+  method (path :: Path).ellipse(r :: RectLike) :: Void
+  method (path :: Path).arc(r :: RectLike,
                             start :: Real, end :: Real) :: Void
 ){
 
@@ -67,7 +60,8 @@
 }
 
 @doc(
-  method (path :: Path).scale(x :: Real, y :: Real) :: Void
+  method (path :: Path).scale(s :: Real) :: Void
+  method (path :: Path).scale(sx :: Real, sy :: Real) :: Void
   method (path :: Path).rotate(radians :: Real) :: Void
 ){
 

--- a/rhombus/draw/scribblings/point-et-al.scrbl
+++ b/rhombus/draw/scribblings/point-et-al.scrbl
@@ -1,0 +1,148 @@
+#lang scribble/rhombus/manual
+@(
+  import:
+    "common.rhm" open
+    meta_label:
+      lib("racket/draw.rkt"):
+        expose:
+          #{color-database<%>}
+)
+
+@(def x_sym = @rhombus(#'x))
+@(def y_sym = @rhombus(#'y))
+@(def width_sym = @rhombus(#'width))
+@(def height_sym = @rhombus(#'height))
+@(def point_sym = @rhombus(#'point))
+@(def size_sym = @rhombus(#'size))
+
+@title(~tag: "point-et-al"){Point, Size, and Rectangle}
+
+@doc(
+  class Point(x :: Real, y :: Real)
+  annot.macro 'PointLike'
+  annot.macro 'PointLikeAsPoint'
+  def Point.zero :: Point = Point(0, 0)
+){
+
+ The @rhombus(Point, ~class) class represents a point in two dimensions.
+
+ Methods that expect a point typically accept a value satisfying
+ @rhombus(PointLike, ~annot), which is any of the following:
+
+@itemlist(
+
+ @item{@rhombus(Point, ~annot): a @rhombus(Point, ~class) instance;}
+
+ @item{@rhombus(matching([_ :: Real, _ :: Real]), ~annot): a
+  @rhombus(List) containing two @rhombus(Real, ~annot) values; or}
+
+ @item{@rhombus(matching({#'x: _ :: Real, #'y: _ :: Real}), ~annot):
+  a @rhombus(Map) containing at least the keys @x_sym and
+  @y_sym, each mapped to a @rhombus(Real, ~annot) value.}
+
+)
+
+ The @rhombus(PointLikeAsPoint, ~annot) annotation is satified by any
+ value that satisfis @rhombus(PointLike, ~annot), and the value is
+ converted to an equivalent @rhombus(Point, ~class) object if it is not one
+ already.
+
+ @rhombus(Point.zero) is a @rhombus(Point, ~class) object with @rhombus(0)
+ values.
+
+}
+
+
+@doc(
+  class Size(width :: NonnegReal, height :: NonnegReal)
+  annot.macro 'SizeLike'
+  annot.macro 'SizeLikeAsSize'
+  def Size.zero :: Size = Size(0, 0)
+){
+
+ The @rhombus(Size, ~class) class represents a size in two dimensions.
+
+ Methods that expect a size typically accept a value satisfying
+ @rhombus(SizeLike, ~annot), which is any of the following:
+
+@itemlist(
+
+ @item{@rhombus(Size, ~annot); a @rhombus(Size, ~class) instance;}
+
+ @item{@rhombus(matching([_ :: NonnegReal, _ :: NonnegReal]), ~annot):
+  a @rhombus(List) containing two @rhombus(NonnegReal, ~annot)
+  values; or}
+
+ @item{@rhombus(matching({#'width: _ :: NonnegReal, #'height: _ :: NonnegReal}), ~annot):
+  a @rhombus(Map) containing at least the keys @width_sym and
+  @height_sym, each mapped to a @rhombus(NonnegReal, ~annot) value.}
+
+)
+
+ The @rhombus(SizeLikeAsSize, ~annot) annotation is satified by any
+ value that satisfis @rhombus(SizeLike, ~annot), and the value is
+ converted to an equivalent @rhombus(Size, ~class) object if it is not one
+ already.
+
+ @rhombus(Size.zero) is a @rhombus(Size, ~class) object with @rhombus(0)
+ values.
+
+}
+
+
+@doc(
+  class Rect(x :: Real, y :: Real, width :: NonnegReal, height :: NonnegReal):
+    constructor
+    | (x :: Real, y :: Real, width :: NonnegReal, height :: NonnegReal)
+    | (point :: PointLike, size :: SizeLike)
+  annot.macro 'RectLike'
+  annot.macro 'RectLikeAsRect'
+  property (r :: Rect).point :: Point
+  property (r :: Rect).size :: Size
+  def Rect.zero :: Rect = Rect(0, 0, 0, 0)
+){
+
+ The @rhombus(Rectangle) class represents a rectagular region, where
+ @rhombus(x) and @rhombus(y) correspond to the top-left of the rectangle.
+ The @rhombus(Rect.point) property produces @rhombus(x) and @rhombus(y)
+ in a @rhombus(Point), while @rhombus(Rect.size) property produces
+ @rhombus(width) and @rhombus(height) in a @rhombus(Size).
+
+ Methods that expect a rectangle typically accept a value satisfying
+ @rhombus(RectLike, ~annot), which is any of the following:
+
+@itemlist(
+
+ @item{a @rhombus(Rect, ~class) instance;}
+
+ @item{@rhombus(matching([_ :: Real, _ :: Real, _ :: NonnegReal, _ :: NonnegReal]), ~annot):
+  a @rhombus(List) containing two @rhombus(Real, ~annot) values for the top-left point
+  followed by two @rhombus(NonnegReal, ~annot) values for the size;}
+
+ @item{@rhombus(matching([_ :: PointLike, _ :: SizeLike]), ~annot):
+  a @rhombus(List) containing a @rhombus(PointLike, ~annot) value
+  followed by a @rhombus(SizeLike, ~annot) value;}
+
+ @item{@rhombus(matching({#'x: _ :: Real, #'y: _ :: Real, #'width: _ :: NonnegReal, #'height: _ :: NonnegReal}), ~annot):
+  a @rhombus(Map) containing at least the keys @x_sym,
+  @y_sym, @width_sym, and @height_sym, where each of
+  the first two are mapped to a @rhombus(Real, ~annot) value, and each of
+  the last two are mapped to a @rhombus(NonnegReal, ~annot) value; or}
+
+ @item{@rhombus(matching({#'point: _ :: PointLike, #'size: _ :: SizeLike}), ~annot):
+  a @rhombus(Map) containing at least the keys @point_sym
+  and @size_sym, where the first is mapped to a
+  @rhombus(PointLike, ~annot) value and the second is mapped to a
+  @rhombus(SizeLike, ~annot) value.}
+
+)
+
+ The @rhombus(RectLikeAsRect, ~annot) annotation is satified by any
+ value that satisfis @rhombus(RectLike, ~annot), and the value is
+ converted to an equivalent @rhombus(Rect, ~class) object if it is not one
+ already.
+
+ @rhombus(Rect.zero) is a @rhombus(Rect, ~class) object with @rhombus(0)
+ values.
+
+}

--- a/rhombus/draw/scribblings/region.scrbl
+++ b/rhombus/draw/scribblings/region.scrbl
@@ -27,7 +27,7 @@
 
 @doc(
   method (rgn :: Region).is_empty() :: Boolean
-  method (rgn :: Region).contains(x :: Real, y :: Real) :: Boolean
+  method (rgn :: Region).contains(pt :: PointLike) :: Boolean
 ){
 
   Queries the content represented by the region.
@@ -35,27 +35,21 @@
 }
 
 @doc(
-  method (rgn :: Region).polygon([[x :: Real, y :: Real], ...],
-                                 ~dx: dx :: Real = 0.0,
-                                 ~dy: dy :: Real = 0.0,
+  method (rgn :: Region).polygon([pt :: PointLike, ...],
+                                 ~dpt: dpt :: PointLike = Point.zero,
+                                 ~dx: dx :: Real = 0,
+                                 ~dy: dy :: Real = 0,
                                  ~fill: fill :: Region.Fill = #'even_odd) :: Void
-  method (rgn :: Region).rectangle(x :: Real, y :: Real,
-                                   width :: NonnegReal,
-                                   height :: NonnegReal) :: Void
-  method (rgn :: Region).rounded_rectangle(x :: Real, y :: Real,
-                                           width :: NonnegReal,
-                                           height :: NonnegReal,
+  method (rgn :: Region).rectangle(r :: RectLike) :: Void
+  method (rgn :: Region).rounded_rectangle(r :: RectLike,
                                            radius :: Real = -0.25) :: Void
-  method (rgn :: Region).ellipse(x :: Real, y :: Real,
-                                 width :: NonnegReal,
-                                 height :: NonnegReal) :: Void
-  method (rgn :: Region).arc(x :: Real, y :: Real,
-                             width :: NonnegReal,
-                             height :: NonnegReal,
+  method (rgn :: Region).ellipse(r :: RectLike) :: Void
+  method (rgn :: Region).arc(r :: RectLike,
                              start :: Real, end :: Real) :: Void
   method (rgn :: Region).path(p :: Path,
-                              ~dx: dx :: Real = 0.0,
-                              ~dy: dy :: Real = 0.0,
+                              ~dpt: dpt :: PointLike = Point.zero,
+                              ~dx: dx :: Real = 0,
+                              ~dy: dy :: Real = 0,
                               ~fill: fill :: Region.Fill = #'odd_even) :: Void
 ){
 

--- a/rhombus/draw/scribblings/rhombus-draw.scrbl
+++ b/rhombus/draw/scribblings/rhombus-draw.scrbl
@@ -16,3 +16,4 @@
 @include_section("region.scrbl")
 @include_section("path.scrbl")
 @include_section("bitmap.scrbl")
+@include_section("point-et-al.scrbl")

--- a/rhombus/gui/scribblings/common.rhm
+++ b/rhombus/gui/scribblings/common.rhm
@@ -6,6 +6,9 @@ import:
     rhombus/gui open
     rhombus/draw open:
       except: Path
+              Size
+              Point
+              Rect
     lib("racket/gui/easy.rkt") open:
       except:
         render


### PR DESCRIPTION
... and `PointLike`, etc. Drawing methods take `PointLike` values. See the updated "gui_demo.rhm" for examples in the style of using `PointLike` lists instead of explicit constructions of `Point`, etc.

A `PointLike` is either:

 * a `Point`

   Has fields `x` and `y`, which are `Real`s and supplied by position to the `Point` constructor. (The convention and ordering `x` then `y` is so established that keyword arguments seems unneecssary and possibly counterproductive.)

 * a list containing two `Real`s

   The lightweight `[]` syntax for lists makes this about as much to type as the `racket/draw`-style plain seqeuence of number arguments, as in `p.curve_to([20, -10], [80, -10], [100, 0])`.

 * a map with (at least) `#'x` and `#'y` mapped to `Real`s

   The intent here is to support Clojure-like data patterns, which is convenient and flexible for some kinds of applications.

The `PointLikeAsPoint` annotation accepts anything that `PointLike` accepts, but it converts to a `Point`. That conversion makes the glue methods much easier to write. The conversation is also an internal detail, and when the wrong kind of value is supplied to a method, the error message should be about `PointLike`, not `PointLikeAsPoint`. To achieve that goal, the implementation says `PointLike`, but in a context that imports `PointLikeAsPoint` with the name `PointLike`. So, the conversion happens as needed, but error messages (which are based on the source text of the annotation) say "PointLike". This is a little tricky, so there's room for confusion, but it works so nicely that it may be a good general pattern.

A `Size` has fields `width` and `height` (by position) that are `NonnegReal`s.

A `Rect` has fields `x`, `y`, `width`, and `height`, but also a `point` property that returns `Point(x, y)` and a `size` property that returns `Size(width, height)`. While most names here are meant to immitate NextStep (`NSPoint`, `NSSize`, and `NSRect`), I have always found `NSRect`'s name `origin` for the point to be weird and not in parallel to the `size` field. The name `topleft` would be more descriptive of what the point means for the rectangle, but `point` still seems more consistent and easier to remember. Also, I always find it tedious to construct a separate `NSSize` and `NSPoint` to create an `NSRect`, so that's why `Rect` supplies all four parts directly, and its constructor is overloaded with a 4-argument and 2-argument version. Similarly, a `RectLike` can be a list of four numbers, a list of a `PointLike` and `SizeLike`, etc. A case could be made that the `point` then `size` order is less obvious that `x` then `y` or `width` then `height`, and so keyword arguments would make sense, but a consistent order plays better with `RectLike` constructions as easy-to-write lists.

The `RadialGradient` and `LinearGradient` constructors take combinations of `PointLike` and `NonegReal` or `Real.in(0.0, 1.0)` and `Color`, still expressed as plain lists. They seem too niche to bother whole additional classes and converters.

Probably `Point` and similar classes will get new methods in the future.