### PR TITLE
Fix arity for `current_output_port` and `current_error_port`

### DIFF
--- a/rhombus/private/print.rkt
+++ b/rhombus/private/print.rkt
@@ -21,6 +21,7 @@
                      displayln
                      print_to_string
                      (rename-out
+                      [current-input-port current_input_port]
                       [current-output-port current_output_port]
                       [current-error-port current_error_port])))
 
@@ -226,5 +227,5 @@
   (lambda (r op mode)
     (racket-print (racket-print-redirect-val r) op mode)))
 
-(define-static-info-syntaxes (current-output-port current-error-port)
+(define-static-info-syntaxes (current-input-port current-output-port current-error-port)
   (#%function-arity 3))

--- a/rhombus/private/print.rkt
+++ b/rhombus/private/print.rkt
@@ -227,4 +227,4 @@
     (racket-print (racket-print-redirect-val r) op mode)))
 
 (define-static-info-syntaxes (current-output-port current-error-port)
-  (#%function-arity 6))
+  (#%function-arity 3))


### PR DESCRIPTION
Also adds `current_input_port`

I'm not really sure how the static arities work, but this allows `current_output_port` to be usable in a static lookup context.  Otherwise, it fails with incorrect arity.