### PR TITLE
add docs for ways to type guillemets

### DIFF
--- a/shrubbery/scribblings/example.scrbl
+++ b/shrubbery/scribblings/example.scrbl
@@ -66,7 +66,7 @@ way, too, and it's intended for quoting shrubbery terms.
 A @litchar{;} or @litchar{,} acts as a group
 separator, even within a single line. A @litchar{:} or @litchar{|}
 treats remaining item on the same line like a new indented line, which
-forms a block of nested groups. A guillemot pair @litchar{«} and @litchar{»} can be
+forms a block of nested groups. A guillemet pair @litchar{«} and @litchar{»} can be
 used in rare cases to explicitly bracket subgroups formed by
 @litchar{:} and @litchar{|} without line breaks. A @litchar{\} continues
 a line, effectively shifting all columns on the next line as if they

--- a/shrubbery/scribblings/group-and-block.scrbl
+++ b/shrubbery/scribblings/group-and-block.scrbl
@@ -593,10 +593,11 @@ Ways to type @guillemets, depending on platform or editor:
   @item{DrRacket:
         Typing @litchar{\guillemetleft} for @litchar{«}
         or @litchar{\guillemetright} for @litchar{»},
-        then hitting Control + @litchar{\}.
-        Typing @litchar{\gui}, hitting Control + @litchar{\},
+        then hitting Control or Alt + @litchar{\}.
+        Typing @litchar{\gui}, hitting Control or Alt + @litchar{\},
         then typing @litchar{l} for @litchar{«} or @litchar{r} for @litchar{»},
-        and then hitting Control + @litchar{\} again also works via autocomplete.}
+        and then hitting Control or Alt + @litchar{\} again
+        also works via autocomplete.}
   @item{Mac:
         Hitting Option + @litchar{\} for @litchar{«},
         or Option + Shift + @litchar{|} for @litchar{»}.}

--- a/shrubbery/scribblings/group-and-block.scrbl
+++ b/shrubbery/scribblings/group-and-block.scrbl
@@ -587,6 +587,31 @@ its enclosing group or have only @litchar{|} alternatives afterward.
 inside:« fruit » more
 }
 
+Ways to type @guillemets, depending on platform or editor:
+
+@itemlist(
+  @item{DrRacket:
+        Typing @litchar{\guillemetleft} for @litchar{«}
+        or @litchar{\guillemetright} for @litchar{»},
+        then hitting Control + @litchar{\}.
+        Typing @litchar{\gui}, hitting Control + @litchar{\},
+        then typing @litchar{l} for @litchar{«} or @litchar{r} for @litchar{»},
+        and then hitting Control + @litchar{\} again also works via autocomplete.}
+  @item{Mac:
+        Hitting Option + @litchar{\} for @litchar{«},
+        or Option + Shift + @litchar{|} for @litchar{»}.}
+  @item{Windows:
+        Holding Alt while typing 174 on the numpad for @litchar{«},
+        or 175 on the numpad for @litchar{»}.}
+  @item{GNU/Linux, BSD:
+        Hitting Control + Shift + U,
+        then typing 00AB for @litchar{«} or 00BB for @litchar{»},
+        and then hitting Enter.}
+)
+
+Or see the
+@hyperlink("https://en.wikipedia.org/wiki/Guillemet#Keyboard_entry"){
+Keyboard Entry section of the Guillemet article on Wikipedia}.
 
 @section(~tag: "continuing-backslash"){Continuing a Line with @litchar{\}}
 

--- a/shrubbery/scribblings/group-and-block.scrbl
+++ b/shrubbery/scribblings/group-and-block.scrbl
@@ -606,8 +606,10 @@ Ways to type @guillemets, depending on platform or editor:
         or 175 on the numpad for @litchar{»}.}
   @item{GNU/Linux, BSD:
         Hitting Control + Shift + U,
-        then typing 00AB for @litchar{«} or 00BB for @litchar{»},
-        and then hitting Enter.}
+        then typing 00AB for @litchar{«} or 00BB for @litchar{»}.}
+  @item{Compose key on Unix/Linux/etc:
+        Hitting Compose,
+        then typing @litchar{<<} for @litchar{«} or @litchar{>>} for @litchar{»}.}
 )
 
 Or see the


### PR DESCRIPTION
Relies on https://github.com/racket/gui/pull/297 and https://github.com/racket/scribble/pull/367

The DrRacket way works only with the above PRs.

The Mac way and the Windows way work on my Mac and Windows machines.

I do not have a keyboard with AltGr on it, so I don't think I can test whether AltGr + `[` or AltGr + `]` work on Windows, or whether AltGr + `Z` or AltGr + `X` work on Linux either.

Edit:

I have tested the GNU/Linux, BSD way on a Linux computer, and found that I did not need to press Enter, it entered `«` as soon as I finished typing `00AB`, and entered `»` as soon as I finished typing `00BB`. Pressing Enter after that behaved as normal Enter, not as "finish hex code sequence".

On that Linux computer I also tested the Compose key versions found in https://en.wikipedia.org/wiki/Guillemet#Keyboard_entry. Although I had to go into the keyboard settings to set the Compose key to something, it worked as expected after that.