### PR TITLE
add `recur` as a named-let form

### DIFF
--- a/enforest/main.rkt
+++ b/enforest/main.rkt
@@ -123,7 +123,9 @@
          tl-decl ...
          (define-syntax-class form-class
            #:attributes (parsed)
-           (pattern ((~datum group) . tail) #:attr parsed (transform-out (enforest (transform-in #'tail)))))
+           (pattern ((~datum group) . tail)
+                    #:cut
+                    #:attr parsed (transform-out (enforest (transform-in #'tail)))))
 
          ;; For reentering the enforestation loop within a group, stopping when
          ;; the group ends or when an operator with weaker precedence than `op`

--- a/rhombus/main.rkt
+++ b/rhombus/main.rkt
@@ -3,6 +3,7 @@
 
 (bounce "private/core.rkt"
         "private/core-macro.rkt"
+        "private/recur.rhm"
         "private/check.rhm"
         "private/maybe.rhm"
         "private/string.rhm"

--- a/rhombus/private/pack.rkt
+++ b/rhombus/private/pack.rkt
@@ -42,9 +42,11 @@
          
          pack-term*
          unpack-term*
+         unpack-maybe-term*
          unpack-term-list*
          pack-group*
          unpack-group*
+         unpack-maybe-group*
          pack-multi*
          pack-tagged-multi*
          pack-block*
@@ -257,6 +259,11 @@
 (define (unpack-term* qs r depth)
   (unpack* qs r depth unpack-term))
 
+(define (unpack-maybe-term* qs r depth)
+  (unpack* qs r depth (lambda (form who at-stx)
+                        (and form
+                             (unpack-term form who at-stx)))))
+
 (define (unpack-term-list* qs r depth)
   (unpack* qs r depth unpack-term-list))
 
@@ -267,6 +274,11 @@
 ;; "Unpacks" to a `group` form, which is really more about coercsions
 (define (unpack-group* qs r depth)
   (unpack* qs r depth unpack-group))
+
+(define (unpack-maybe-group* qs r depth)
+  (unpack* qs r depth (lambda (form who at-stx)
+                        (and form
+                             (unpack-group form who at-stx)))))
 
 ;; Packs to a `multi` form
 (define (pack-multi* stxes depth)

--- a/rhombus/private/recur.rhm
+++ b/rhombus/private/recur.rhm
@@ -1,0 +1,128 @@
+#lang rhombus/private/core
+import:
+  "core-meta.rkt" open
+  lib("racket/unsafe/undefined.rkt").#{unsafe-undefined}
+
+export:
+  recur
+
+expr.macro 'recur $(name :: Identifier) ($(arg :: bind_meta.Argument),
+                                         ...) $(r :: bind_meta.Result):
+              $body
+              ...':
+  ~op_stx self_id
+  for:
+    each:
+      arg: [arg, ...]
+      expr: [arg.maybe_expr, ...]
+    unless expr
+    | syntax_meta.error("missing initial-value expression",
+                        self_id,
+                        arg)
+  def loop_name = Syntax.make_id(name +& "_recur")
+  def [arg_info, ...]: [bind_meta.get_info(arg.parsed, '()'), ...]
+  // if all the bindings are immediate (as opposed to more complex patterns),
+  // then we expand similar to Racket's named `let`. Otherwise, to avoid
+  // duplicating the binding machinery for the initial call and recursive calls,
+  // we'll expand in a way that uses `#{unsafe-undefined}` on the initial call
+  def all_immediate: for values(immed = #true):
+                       each info: [arg_info, ...]
+                       immed && bind_meta.is_immediate(info)
+  def ['($_, $a_name, $_, ...)', ...]: [bind_meta.unpack_info(arg_info), ...]
+  def [arg_id, ...] = [Syntax.make_id(a_name +& "_arg"), ...]
+  def [avail_id, ...] = [Syntax.make_id(a_name +& "_ready_arg"), ...]
+  def [recur_arg, ...] = (for List:
+                            each:
+                              kw: [arg.maybe_keyword, ...]
+                              id: [arg_id, ...]
+                              avail_id: [avail_id, ...]
+                            if kw
+                            | '$kw: $id = $avail_id'
+                            | '$id')
+  def body_expr:
+    wrap_converter('block:
+                      fun $name($recur_arg, ...):
+                        $loop_name($arg_id, ...)
+                      $body
+                      ...',
+                   r.count, r.maybe_converter, r.annotation_string, name)
+  fun
+  | make_binds_plus_body(mode, [], [], [], [], inside):
+      inside
+  | make_binds_plus_body(mode,
+                         [arg_info, & arg_infos],
+                         [arg_id, & arg_ids],
+                         [avail_id, & avail_ids],
+                         [init_expr, & init_exprs],
+                         inside):
+      def '($ann_str, $a_name, $sis, (($id, $_, $si), ...), $matcher, $committer, $binder, $data)':
+        bind_meta.unpack_info(arg_info)
+      def next:
+          '«block:
+              $committer($avail_id, $data)
+              $binder($avail_id, $data)
+              statinfo.macro '$id': '$si'
+              ...
+              $(make_binds_plus_body(mode, arg_infos, arg_ids, avail_ids, init_exprs, inside))»'
+      '«block:
+          def $avail_id: $(match mode
+                           | #'immediate: arg_id
+                           | #'general:
+                               'if $arg_id === #{unsafe-undefined}
+                                | $init_expr
+                                | $arg_id'
+                           | #'initial: init_expr)
+          $matcher($avail_id, $data, if, $next, no_match(#' $name, #%literal $ann_str, $avail_id))»'
+  fun make_binds_plus_body_for(mode, inside):
+    make_binds_plus_body(mode,
+                         [arg_info, ...],
+                         [arg_id, ...],
+                         [avail_id, ...],
+                         [arg.maybe_expr, ...],
+                         inside)
+  fun undefined(id): '#{unsafe-undefined}'
+  def expr:
+    'block:
+       fun $loop_name($arg_id, ...):
+         $(make_binds_plus_body_for(if all_immediate | #'immediate | #'general,
+                                    body_expr))
+       $(if all_immediate
+         | make_binds_plus_body_for(#'initial,
+                                    '$loop_name($(arg.maybe_expr), ...)')
+         | '$loop_name($(undefined(arg_id)), ...)')'
+  statinfo_meta.wrap(expr, r.static_info)
+
+fun no_match(who, ann_str, what):
+  error(who,
+        "value does not match annotation\n"
+          +& "  annotation: " +& ann_str +& "\n"
+          +& "  value: " +& what)
+
+meta:
+  fun wrap_converter(expr, count, maybe_converter, annotation_string, name):
+    if maybe_converter
+    | if count == 1
+      | '$maybe_converter($expr,
+                          fun (v): v,
+                          fun (): bad_result(#' $name,
+                                             #%literal $annotation_string))'
+      | def [arg, ...]:
+          for List:
+            each i: 0..count
+            Syntax.make_id("arg" +& i)
+        'block:
+           fun fail(): bad_result(#' $name, #%literal $annotation_string)
+           call_with_values(
+             fun (): $expr,
+             fun
+             | ($arg, ...):
+                 $maybe_converter($arg, ..., values, fail)
+             | (& args): fail()
+           )'
+    | expr
+
+fun bad_result(who, ann_str):
+  error(who,
+        "result does not match annotation\n"
+          +& "  annotation: " +& ann_str)
+

--- a/rhombus/private/static-info-macro.rkt
+++ b/rhombus/private/static-info-macro.rkt
@@ -24,7 +24,8 @@
          "append-key.rkt"
          "index-key.rkt"
          "index-result-key.rkt"
-         "dot-provider-key.rkt")
+         "dot-provider-key.rkt"
+         "values-key.rkt")
 
 (provide (for-syntax (for-space rhombus/namespace
                                 statinfo_meta)))
@@ -38,6 +39,8 @@
     #:fields
     (pack
      unpack
+     pack_group
+     unpack_group
      wrap
      lookup
      
@@ -48,7 +51,8 @@
      [map_ref_key index_get_key] ; temporary
      [map_set_key index_set_key] ; temporary
      append_key
-     dot_provider_key)))
+     dot_provider_key
+     values_key)))
 
 (define-for-syntax (make-static-info-macro-macro in-space)
   (definition-transformer
@@ -74,6 +78,15 @@
 (define-for-syntax (unpack v)
   (unpack-static-infos v))
 
+(define-for-syntax (pack_group v)
+  (datum->syntax
+   #f
+   (map (lambda (v) (pack-static-infos v 'statinfo_meta.pack_group))
+        (cdr (syntax->list (unpack-group v 'statinfo_meta.pack_group #f))))))
+
+(define-for-syntax (unpack_group v)
+  #`(group . #,(map unpack-static-infos (syntax->list v))))
+
 (define-for-syntax (wrap form info)
   (pack-term #`(parsed #,(wrap-static-info* (wrap-expression form)
                                             (pack info)))))
@@ -98,3 +111,4 @@
 (define-for-syntax index_set_key #'#%index-set)
 (define-for-syntax append_key #'#%append)
 (define-for-syntax dot_provider_key #'#%dot-provider)
+(define-for-syntax values_key #'#%values)

--- a/rhombus/private/syntax-object.rkt
+++ b/rhombus/private/syntax-object.rkt
@@ -271,7 +271,7 @@
   (pack-multi (for/list ([e (in-list v)])
                 (do-make 'Syntax.make_sequence e ctx-stx #t #t))))
 
-(define/arity (make_id str ctx)
+(define/arity (make_id str [ctx #f])
   #:static-infos ((#%call-result #,syntax-static-infos))
   (unless (string? str)
     (raise-argument-error* 'Syntax.make_id rhombus-realm "StringView" str))

--- a/rhombus/private/unquote-binding-primitive.rkt
+++ b/rhombus/private/unquote-binding-primitive.rkt
@@ -381,7 +381,7 @@
           (compat #'pack-block* #'unpack-multi-as-term*)]
          [else (incompat)])]
       [else
-       (error "unrecognized kind" kind)])))
+       (error "unrecognized kind"  (rhombus-syntax-class-kind rsc))])))
 
 (define-for-syntax (normalize-id form)
   (if (identifier? form)

--- a/rhombus/private/values.rkt
+++ b/rhombus/private/values.rkt
@@ -14,7 +14,11 @@
                       rhombus/bind
                       rhombus/reducer
                       rhombus/statinfo)
-                     values))
+                     values)
+         (for-spaces (#f
+                      rhombus/statinfo)
+                     (rename-out
+                      [call-with-values call_with_values])))
 
 (define-binding-syntax values
   (binding-prefix-operator
@@ -47,3 +51,6 @@
 
 (define-static-info-syntax values
   (#%function-arity -1))
+
+(define-static-info-syntax call-with-values
+  (#%function-arity 4))

--- a/rhombus/scribblings/ref-bind-macro.scrbl
+++ b/rhombus/scribblings/ref-bind-macro.scrbl
@@ -228,6 +228,21 @@
 
 }
 
+
+@doc(
+  fun bind_meta.is_immediate(info :: Syntax) :: Boolean
+){
+
+ @provided_meta()
+
+ Takes the initialized binding-form expansion produced by
+ @rhombus(bind_meta.get_info) and restports whether the binding is
+ immediate in the same sense as just a variable: the binding always
+ matches, and no work is required to convert or unpack the matched value.
+
+}
+
+
 @doc(
   defn.macro '«bind.matcher '$id($id_pattern, $data_pattern,
                                  $IF_pattern, $success_pattern, $fail_pattern)':
@@ -317,6 +332,81 @@
  @provided_meta()
 
  Analogous to @rhombus(expr_meta.Parsed, ~stxclass), etc., but for bindings.
+
+}
+
+@doc(
+  ~nonterminal:
+    bind_maybe_kw_opt: fun
+
+  syntax_class bind_meta.Argument:
+    kind: ~group
+    field parsed
+    field maybe_keyword
+    field maybe_expr
+){
+
+ @provided_meta()
+
+ Matches forms that combine a binding with an optional kyword and
+ optional default-value expression, like @rhombus(bind_maybe_kw_opt) for
+ @rhombus(fun).
+
+@itemlist(
+
+  @item{The @rhombus(parsed) field holds a parsed binding form.}
+
+  @item{The @rhombus(maybe_keyword) field is @rhombus(#false) if no
+  keyword is present, otherwise it is a keyword syntax object.}
+
+  @item{The @rhombus(maybe_expr) field is @rhombus(#false) if no
+  default-value expression is provided, otherwise it is a group syntax
+  object for the expression.}
+
+)
+
+}
+
+@doc(
+  ~nonterminal:
+    maybe_res_annot: fun
+
+  syntax_class bind_meta.Result:
+    kind: ~sequence
+    field count
+    field maybe_converter
+    field static_info
+    field annotation_string
+){
+
+ @provided_meta()
+
+ Matches a sequence of terms (possibly empty) for a result annotation,
+ like @rhombus(maybe_res_annot) for @rhombus(fun).
+
+ @itemlist(
+
+  @item{The @rhombus(count) field holds an integer for the number of
+  expected results.}
+
+  @item{The @rhombus(maybe_converter) field is @rhombus(#false) if no
+  annotation is declared or if it is unchecked, otherwise it is a syntax
+  object for a function expression; the resulting function expects
+  @rhombus(count) plus two arguments: each original result followed by a
+  success procedure of @rhombus(count) arguments and a failure procedure
+  of zero arguments.}
+
+  @item{The @rhombus(static_info) field holds static information for the
+  result (in unpacked form; see @rhombus(static_info.pack)); when
+  @rhombus(count) is not @rhombus(1), then @rhombus(static_info) has a
+  single key @rhombus(statinfo_meta.values_key) whose value is (packed)
+  static information for each value (see
+  @rhombus(statinfo_meta.pack_group)).}
+
+  @item{The @rhombus(annotation_string) field describes the annotation,
+  which is useful for raising an exception when conversion fails.}
+
+)
 
 }
 

--- a/rhombus/scribblings/ref-recur.scrbl
+++ b/rhombus/scribblings/ref-recur.scrbl
@@ -1,0 +1,70 @@
+#lang scribble/rhombus/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@(def dots: @rhombus(..., ~bind))
+@(def dots_expr: @rhombus(...))
+
+@title(~tag: "ref-recur"){Recursion}
+
+Rhombus functions defined with @rhombus(fun) can be recursive, of
+course, but the @rhombus(recur) form offers a shorthand for the case
+that a recurive function would be used just once and is better written
+inline. Iteration with @rhombus(for) is also a kind of recursion, but
+@rhombus(recur) supports non-tail recursion, instead of only iterative
+loops.
+
+@doc(
+  ~nonterminal:
+    bind_maybe_kw_opt: fun
+    maybe_res_annot: fun
+
+  expr.macro 'recur $id($bind_maybe_kw_opt, ...) maybe_res_annot:
+                $body
+                ...'
+){
+
+ Similar to defining @rhombus(id) as a function and immediately calling
+ it, where @rhombus(id) is bound only within the @rhombus(body) block for
+ recursive calls. The intent is to implement a recursive calculation ``in
+ place,'' instead of defining a recurive function and then calling
+ it---including cases where the recursion is not in tail position or
+ where @rhombus(for) is not a good fit for some other reason.
+
+ @margin_note{Racket and Scheme programmers will recognize this form as
+  a kind of ``@as_index{named let}.''}
+
+ To enable the immediate call of @rhombus(id), each
+ @rhombus(bind_maybe_kw_opt) must include a ``default'' expression, and
+ the immediate call is like supplying zero arguments. Thus, each
+ ``default'' expression is really an initial-value expression. The
+ binding of @rhombus(id) within the @rhombus(body) block, however, is a
+ function where only keyword arguments are optional. The default value
+ for a keyword argument in a recursive call, meanwhile, is whatever was
+ supplied for the enclosing call, with the effect that keyword arguments
+ are automatically propogated in a recursive call.
+
+ Beware that when @rhombus(maybe_res_annot) specifies a result
+ annotation using @rhombus(::, ~bind), the annotation is checked on every
+ recursive call. In that case, no recursive calls are in tail position.
+
+@examples(
+  ~repl:
+    recur nest_to(n = 5):
+      match n
+      | 0: [0]
+      | ~else: [n, nest_to(n-1)]
+  ~repl:
+    recur sum_halves(l = [1, 2, 3, -4, 5, -6],
+                     ~pos_sum: pos_sum = 0,
+                     ~neg_sum: neg_sum = 0):
+      match l
+      | []: values(pos_sum, neg_sum)
+      | [n, & ns]:
+          if n > 0
+          | sum_halves(ns, ~pos_sum: pos_sum + n)
+          | sum_halves(ns, ~neg_sum: neg_sum + n)
+)
+
+}

--- a/rhombus/scribblings/ref-static-info.scrbl
+++ b/rhombus/scribblings/ref-static-info.scrbl
@@ -86,6 +86,25 @@
 }
 
 @doc(
+  fun statinfo_meta.pack_group(statinfo_stx :: Syntax) :: Syntax
+  fun statinfo_meta.unpack_group(statinfo_stx :: Syntax) :: Syntax
+){
+
+ @provided_meta()
+
+ Analogous to @rhombus(statinfo_meta.pack) and
+ @rhombus(statinfo_meta.unpack), but for a sequence of static information
+ sets, such as one set of static information per value produced by a
+ multiple-value expression (see @rhombus(statinfo_meta.values_key).
+
+ An unpacked sequence is represented as a group syntax object, where
+ each term in the group is unpacked static information in the sense of
+ @rhombus(statinfo_meta.pack).
+
+}
+
+
+@doc(
   fun statinfo_meta.lookup(expr_stx :: Syntax, key :: Identifier)
 ){
 
@@ -120,6 +139,7 @@
   def statinfo_meta.index_set_key
   def statinfo_meta.append_key
   def statinfo_meta.dot_provider_key
+  def statinfo_meta.values_key
 ){
 
  @provided_meta()
@@ -156,6 +176,10 @@
         bound to a @rhombus(dot.macro) or
         @rhombus(dot.macro_more_static) to implement the expression's
         behavior as a @tech{dot provider}}
+
+  @item{@rhombus(statinfo_meta.values_key) --- a packed group of
+        static infoformation (see @rhombus(statinfo_meta.pack_group)),
+        one for each value produced by a multiple-value expression}
 
 )
 

--- a/rhombus/scribblings/ref-values.scrbl
+++ b/rhombus/scribblings/ref-values.scrbl
@@ -40,3 +40,38 @@
  are the final values of the @rhombus(id)s.
 
 }
+
+
+@doc(
+  fun call_with_values(producer :: Function.of_arity(0),
+                       consumer :: Function)
+){
+
+ Calls @rhombus(producer) with no arguments, and then calls
+ @rhombus(consumer) with the result value(s) from @rhombus(producer).
+
+ Use @rhombus(call_with_values) to dispatch on the number of values that
+ are produced by an expression. The @rhombus(match) form cannot make that
+ distinction, because it always expects a single result value from its
+ initial subexpression.
+
+@examples(
+  ~defn:
+    fun get_fruit(n :: NonnegInt):
+      match n
+      | 0: values()
+      | 1: "apple"
+      | 2: values("apple", "banana")
+      | ~else values("apple", n +& " bananas")
+    fun
+    | show(): println("nothing")
+    | show(s): println(s)
+    | show(a, b): println(a +& " and " +& b)
+  ~repl:
+    call_with_values(fun (): get_fruit(0), show)
+    call_with_values(fun (): get_fruit(1), show)
+    call_with_values(fun (): get_fruit(2), show)
+    call_with_values(fun (): get_fruit(3), show)
+)
+
+}

--- a/rhombus/scribblings/reference.scrbl
+++ b/rhombus/scribblings/reference.scrbl
@@ -23,10 +23,11 @@
 
 @include_section("ref-repetition.scrbl")
 
+@include_section("ref-block.scrbl")
 @include_section("ref-cond.scrbl")
 @include_section("ref-match.scrbl")
 @include_section("ref-for.scrbl")
-@include_section("ref-block.scrbl")
+@include_section("ref-recur.scrbl")
 @include_section("ref-parameter.scrbl")
 @include_section("ref-exn.scrbl")
 @include_section("ref-control.scrbl")

--- a/rhombus/tests/recur.rhm
+++ b/rhombus/tests/recur.rhm
@@ -1,0 +1,96 @@
+#lang rhombus
+
+use_static
+
+check:
+  recur f(x = 1): x
+  ~is 1
+
+check:
+  (recur f(x = 1): x) ~is 1
+  (recur f(x = 1, y = [x]): y) ~is [1]
+  (recur f(x = 1, y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(x = 1, ~y: y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(~x: x = 1, ~y: y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(~x: x = 1, ~y: y = [x], ~z: z = [x, y]): z) ~is [1, [1]]
+
+// argument pattern triggers more general transformation
+check:
+  (recur f([x] = [1]): x) ~is 1
+  (recur f([x] = [1], y = [x]): y) ~is [1]
+  (recur f([x] = [1], y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f([x] = [1], ~y: y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(~x: [x] = [1], ~y: y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(~x: [x] = [1], ~y: y = [x], ~z: z = [x, y]): z) ~is [1, [1]]
+
+check:
+  recur f(x = 2, ~y: y = x):
+    if x == 0
+    | y
+    | f(0)
+  ~is 2
+
+check:
+  recur f(x = 2, ~y: y = x):
+    match x
+    | 0: y
+    | 1: f(0)
+    | ~else: f(x-1, ~y: y+1)
+  ~is 3
+
+check:
+  recur f([x] = [2], ~y: y = x):
+    if x == 0
+    | y
+    | f([0])
+  ~is 2
+
+check:
+  recur f([x] = [2], ~y: y = x):
+    match x
+    | 0: y
+    | 1: f([0])
+    | ~else: f([x-1], ~y: y+1)
+  ~is 3
+
+check:
+  ~eval
+  recur f(x): x
+  ~raises "missing initial-value expression"
+
+check:
+  ~eval
+  recur f(~x: x): x
+  ~raises "missing initial-value expression"
+
+check:
+  recur loop(x :: String = "a"):
+    x.length()
+  ~is 1
+
+check:
+  recur loop(x :: String = 10):
+    x.length()
+  ~raises "value does not match annotation"
+
+check:
+  (recur loop(x :: String = "abs") :: String:
+     x).length()
+  ~is 3
+
+check:
+  def (s, x):
+    recur loop(x :: String = "abs") :: (String, Int):
+      values(x, 0)
+  s.length()
+  ~is 3
+
+check:
+  recur loop(x :: String = "abs") :: String:
+    0
+  ~raises "result does not match annotation"
+
+check:
+  recur loop(x :: String = "abs") :: (String, Int):
+    0
+  ~raises "result does not match annotation"

--- a/rhombus/tests/statinfo-macro.rhm
+++ b/rhombus/tests/statinfo-macro.rhm
@@ -24,3 +24,19 @@ check:
   use_static
   ((two list_of_zero)[0])[0]
   ~is 0
+
+block:
+  import:
+    meta -1: rhombus/meta open
+  check:
+    statinfo_meta.unpack(statinfo_meta.pack('((x, y))'))
+    ~prints_like '((x, y))'
+  check:
+    statinfo_meta.unpack(statinfo_meta.pack('((x, y), (z, w))'))
+    ~prints_like '((x, y), (z, w))'
+  check:
+    statinfo_meta.unpack_group(statinfo_meta.pack_group('((x, y))'))
+    ~prints_like '((x, y))'
+  check:
+    statinfo_meta.unpack_group(statinfo_meta.pack_group('((x, y)) ((z, w))'))
+    ~prints_like '((x, y)) ((z, w))'

--- a/scribble/rhombus.rkt
+++ b/scribble/rhombus.rkt
@@ -9,7 +9,8 @@
                     [verbatim base:verbatim]
                     [table-of-contents table_of_contents]
                     [local-table-of-contents local_table_of_contents]
-                    [margin-note margin_note])
+                    [margin-note margin_note]
+                    [as-index as_index])
          scribble/private/manual-defaults
          "private/rhombus.rhm"
          "private/rhombus_typeset.rhm"


### PR DESCRIPTION
Differences from Scheme named `let`:

 * Initial-value expressions can refer to earlier argument variables, which makes things more consistent with default-value expressions for `fun` arguments.

 * Keyword arguments are allowed, and they are optional in recursive calls. When not supplied, each keyword argument defaults to its value from the enclosing call, which means that keyword-argument values are automatically propagated in recursive calls.

Example from the docs:

```
  > recur sum_halves(l = [1, 2, 3, -4, 5, -6],
                     ~pos_sum: pos_sum = 0,
                     ~neg_sum: neg_sum = 0):
      match l
      | []: values(pos_sum, neg_sum)
      | [n, & ns]:
          if n > 0
          | sum_halves(ns, ~pos_sum: pos_sum + n)
          | sum_halves(ns, ~neg_sum: neg_sum + n)
  11
  -10
```

A further tweak on keyword arguments might include an expression or update function that is applied to the current iteration's argument for the next iteration. In the interest of keeping things simpler, this commit doesn't do that.

Besides `recur`, the commit adds a few things that are need to implement `recur` in Rhombus, such as the `bind_meta.Argument` syntax class.
