### PR TITLE
add `all` and `any` as reducers

### DIFF
--- a/enforest/main.rkt
+++ b/enforest/main.rkt
@@ -123,7 +123,9 @@
          tl-decl ...
          (define-syntax-class form-class
            #:attributes (parsed)
-           (pattern ((~datum group) . tail) #:attr parsed (transform-out (enforest (transform-in #'tail)))))
+           (pattern ((~datum group) . tail)
+                    #:cut
+                    #:attr parsed (transform-out (enforest (transform-in #'tail)))))
 
          ;; For reentering the enforestation loop within a group, stopping when
          ;; the group ends or when an operator with weaker precedence than `op`

--- a/rhombus/main.rkt
+++ b/rhombus/main.rkt
@@ -3,6 +3,7 @@
 
 (bounce "private/core.rkt"
         "private/core-macro.rkt"
+        "private/recur.rhm"
         "private/check.rhm"
         "private/maybe.rhm"
         "private/string.rhm"

--- a/rhombus/private/array.rkt
+++ b/rhombus/private/array.rkt
@@ -92,19 +92,22 @@
    (lambda (stx)
      (syntax-parse stx
        [(_ #:length e ...+)
-        (reducer/no-break #'build-array-reduce
-                          #'([i 0])
-                          #'build-array-assign
-                          array-static-infos
-                          #'[dest
-                             (rhombus-expression (group e ...))
-                             i])]
-       [(_)
-        (reducer/no-break #'build-array-reduce-list
-                          #'([accum null])
-                          #'build-array-cons
-                          array-static-infos
-                          #'accum)]))))
+        (values (reducer/no-break #'build-array-reduce
+                                  #'([i 0])
+                                  #'build-array-assign
+                                  array-static-infos
+                                  #'[dest
+                                     (rhombus-expression (group e ...))
+                                     i])
+                '())]
+       [(_ . tail)
+        (values
+         (reducer/no-break #'build-array-reduce-list
+                           #'([accum null])
+                           #'build-array-cons
+                           array-static-infos
+                           #'accum)
+         #'tail)]))))
 
 (define-syntax (build-array-reduce stx)
   (syntax-parse stx

--- a/rhombus/private/array.rkt
+++ b/rhombus/private/array.rkt
@@ -92,19 +92,19 @@
    (lambda (stx)
      (syntax-parse stx
        [(_ #:length e ...+)
-        #`[build-array-reduce
-           ([i 0])
-           build-array-assign
-           #,array-static-infos
-           [dest
-            (rhombus-expression (group e ...))
-            i]]]
+        (reducer/no-break #'build-array-reduce
+                          #'([i 0])
+                          #'build-array-assign
+                          array-static-infos
+                          #'[dest
+                             (rhombus-expression (group e ...))
+                             i])]
        [(_)
-        #`[build-array-reduce-list
-           ([accum null])
-           build-array-cons
-           #,array-static-infos
-           accum]]))))
+        (reducer/no-break #'build-array-reduce-list
+                          #'([accum null])
+                          #'build-array-cons
+                          array-static-infos
+                          #'accum)]))))
 
 (define-syntax (build-array-reduce stx)
   (syntax-parse stx

--- a/rhombus/private/boolean-reducer.rkt
+++ b/rhombus/private/boolean-reducer.rkt
@@ -1,0 +1,63 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     "annotation-string.rkt")
+         "reducer.rkt"
+         "parse.rkt"
+         "static-info.rkt")
+
+(provide (for-space rhombus/reducer
+                    &&
+                    \|\|))
+
+(define-reducer-syntax &&
+  (reducer-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(_)
+        (values (reducer
+                 #'build-result
+                 #'([result #true])
+                 #'build-accum
+                 #f
+                 #'build-stop-false
+                 #'build-accum-result
+                 #'()
+                 #'elem)
+                #'())]))))
+
+(define-reducer-syntax \|\|
+  (reducer-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(_)
+        (values (reducer
+                 #'build-result
+                 #'([result #f])
+                 #'build-accum
+                 #f
+                 #'build-stop-true
+                 #'build-accum-result
+                 #'()
+                 #'elem)
+                #'())]))))
+
+(define-syntax (build-result stx)
+  (syntax-parse stx
+    [(_ _ e) #'e]))
+
+(define-syntax (build-accum stx)
+  (syntax-parse stx
+    [(_ elem e) #'(define elem e)]))
+
+(define-syntax (build-stop-false stx)
+  (syntax-parse stx
+    [(_ elem) #'(not elem)]))
+
+(define-syntax (build-stop-true stx)
+  (syntax-parse stx
+    [(_ elem) #'elem]))
+
+(define-syntax (build-accum-result stx)
+  (syntax-parse stx
+    [(_ elem) #'elem]))

--- a/rhombus/private/core.rkt
+++ b/rhombus/private/core.rkt
@@ -128,6 +128,7 @@
         "parameterize.rkt"
         "boolean-pattern.rkt"
         "boolean-annotation.rkt"
+        "boolean-reducer.rkt"
         "equatable.rkt"
         "sequenceable.rkt"
         "eval.rkt"

--- a/rhombus/private/list.rkt
+++ b/rhombus/private/list.rkt
@@ -230,11 +230,11 @@
    (lambda (stx)
      (syntax-parse stx
        [(_)
-        #`[build-reverse
-           ([accum null])
-           build-accum
-           #,list-static-infos
-           accum]]))))
+        (reducer/no-break #'build-reverse
+                          #'([accum null])
+                          #'build-accum
+                          list-static-infos
+                          #'accum)]))))
 
 (define-syntax (build-reverse stx)
   (syntax-parse stx

--- a/rhombus/private/list.rkt
+++ b/rhombus/private/list.rkt
@@ -229,12 +229,13 @@
   (reducer-transformer
    (lambda (stx)
      (syntax-parse stx
-       [(_)
-        (reducer/no-break #'build-reverse
-                          #'([accum null])
-                          #'build-accum
-                          list-static-infos
-                          #'accum)]))))
+       [(_ . tail)
+        (values (reducer/no-break #'build-reverse
+                                  #'([accum null])
+                                  #'build-accum
+                                  list-static-infos
+                                  #'accum)
+                #'tail)]))))
 
 (define-syntax (build-reverse stx)
   (syntax-parse stx

--- a/rhombus/private/map.rkt
+++ b/rhombus/private/map.rkt
@@ -293,11 +293,11 @@
    (lambda (stx)
      (syntax-parse stx
        [(_)
-        #`[build-map-reduce
-           ([ht #hashalw()])
-           build-map-add
-           #,map-static-info
-           ht]]))))
+        (reducer/no-break #'build-map-reduce
+                          #'([ht #hashalw()])
+                          #'build-map-add
+                          map-static-info
+                          #'ht)]))))
 
 (define-syntax (build-map-reduce stx)
   (syntax-parse stx

--- a/rhombus/private/map.rkt
+++ b/rhombus/private/map.rkt
@@ -292,12 +292,14 @@
   (reducer-transformer
    (lambda (stx)
      (syntax-parse stx
-       [(_)
-        (reducer/no-break #'build-map-reduce
-                          #'([ht #hashalw()])
-                          #'build-map-add
-                          map-static-info
-                          #'ht)]))))
+       [(_ . tail)
+        (values
+         (reducer/no-break #'build-map-reduce
+                           #'([ht #hashalw()])
+                           #'build-map-add
+                           map-static-info
+                           #'ht)
+         #'tail)]))))
 
 (define-syntax (build-map-reduce stx)
   (syntax-parse stx

--- a/rhombus/private/pack.rkt
+++ b/rhombus/private/pack.rkt
@@ -42,9 +42,11 @@
          
          pack-term*
          unpack-term*
+         unpack-maybe-term*
          unpack-term-list*
          pack-group*
          unpack-group*
+         unpack-maybe-group*
          pack-multi*
          pack-tagged-multi*
          pack-block*
@@ -257,6 +259,11 @@
 (define (unpack-term* qs r depth)
   (unpack* qs r depth unpack-term))
 
+(define (unpack-maybe-term* qs r depth)
+  (unpack* qs r depth (lambda (form who at-stx)
+                        (and form
+                             (unpack-term form who at-stx)))))
+
 (define (unpack-term-list* qs r depth)
   (unpack* qs r depth unpack-term-list))
 
@@ -267,6 +274,11 @@
 ;; "Unpacks" to a `group` form, which is really more about coercsions
 (define (unpack-group* qs r depth)
   (unpack* qs r depth unpack-group))
+
+(define (unpack-maybe-group* qs r depth)
+  (unpack* qs r depth (lambda (form who at-stx)
+                        (and form
+                             (unpack-group form who at-stx)))))
 
 ;; Packs to a `multi` form
 (define (pack-multi* stxes depth)

--- a/rhombus/private/pair.rkt
+++ b/rhombus/private/pair.rkt
@@ -9,7 +9,6 @@
          "binding.rkt"
          (submod "annotation.rkt" for-class)
          "static-info.rkt"
-         "reducer.rkt"
          "call-result-key.rkt"
          "function-arity-key.rkt"
          "name-root.rkt"

--- a/rhombus/private/recur.rhm
+++ b/rhombus/private/recur.rhm
@@ -1,0 +1,128 @@
+#lang rhombus/private/core
+import:
+  "core-meta.rkt" open
+  lib("racket/unsafe/undefined.rkt").#{unsafe-undefined}
+
+export:
+  recur
+
+expr.macro 'recur $(name :: Identifier) ($(arg :: bind_meta.Argument),
+                                         ...) $(r :: bind_meta.Result):
+              $body
+              ...':
+  ~op_stx self_id
+  for:
+    each:
+      arg: [arg, ...]
+      expr: [arg.maybe_expr, ...]
+    unless expr
+    | syntax_meta.error("missing initial-value expression",
+                        self_id,
+                        arg)
+  def loop_name = Syntax.make_id(name +& "_recur")
+  def [arg_info, ...]: [bind_meta.get_info(arg.parsed, '()'), ...]
+  // if all the bindings are immediate (as opposed to more complex patterns),
+  // then we expand similar to Racket's named `let`. Otherwise, to avoid
+  // duplicating the binding machinery for the initial call and recursive calls,
+  // we'll expand in a way that uses `#{unsafe-undefined}` on the initial call
+  def all_immediate: for values(immed = #true):
+                       each info: [arg_info, ...]
+                       immed && bind_meta.is_immediate(info)
+  def ['($_, $a_name, $_, ...)', ...]: [bind_meta.unpack_info(arg_info), ...]
+  def [arg_id, ...] = [Syntax.make_id(a_name +& "_arg"), ...]
+  def [avail_id, ...] = [Syntax.make_id(a_name +& "_ready_arg"), ...]
+  def [recur_arg, ...] = (for List:
+                            each:
+                              kw: [arg.maybe_keyword, ...]
+                              id: [arg_id, ...]
+                              avail_id: [avail_id, ...]
+                            if kw
+                            | '$kw: $id = $avail_id'
+                            | '$id')
+  def body_expr:
+    wrap_converter('block:
+                      fun $name($recur_arg, ...):
+                        $loop_name($arg_id, ...)
+                      $body
+                      ...',
+                   r.count, r.maybe_converter, r.annotation_string, name)
+  fun
+  | make_binds_plus_body(mode, [], [], [], [], inside):
+      inside
+  | make_binds_plus_body(mode,
+                         [arg_info, & arg_infos],
+                         [arg_id, & arg_ids],
+                         [avail_id, & avail_ids],
+                         [init_expr, & init_exprs],
+                         inside):
+      def '($ann_str, $a_name, $sis, (($id, $_, $si), ...), $matcher, $committer, $binder, $data)':
+        bind_meta.unpack_info(arg_info)
+      def next:
+          '«block:
+              $committer($avail_id, $data)
+              $binder($avail_id, $data)
+              statinfo.macro '$id': '$si'
+              ...
+              $(make_binds_plus_body(mode, arg_infos, arg_ids, avail_ids, init_exprs, inside))»'
+      '«block:
+          def $avail_id: $(match mode
+                           | #'immediate: arg_id
+                           | #'general:
+                               'if $arg_id === #{unsafe-undefined}
+                                | $init_expr
+                                | $arg_id'
+                           | #'initial: init_expr)
+          $matcher($avail_id, $data, if, $next, no_match(#' $name, #%literal $ann_str, $avail_id))»'
+  fun make_binds_plus_body_for(mode, inside):
+    make_binds_plus_body(mode,
+                         [arg_info, ...],
+                         [arg_id, ...],
+                         [avail_id, ...],
+                         [arg.maybe_expr, ...],
+                         inside)
+  fun undefined(id): '#{unsafe-undefined}'
+  def expr:
+    'block:
+       fun $loop_name($arg_id, ...):
+         $(make_binds_plus_body_for(if all_immediate | #'immediate | #'general,
+                                    body_expr))
+       $(if all_immediate
+         | make_binds_plus_body_for(#'initial,
+                                    '$loop_name($(arg.maybe_expr), ...)')
+         | '$loop_name($(undefined(arg_id)), ...)')'
+  statinfo_meta.wrap(expr, r.static_info)
+
+fun no_match(who, ann_str, what):
+  error(who,
+        "value does not match annotation\n"
+          +& "  annotation: " +& ann_str +& "\n"
+          +& "  value: " +& what)
+
+meta:
+  fun wrap_converter(expr, count, maybe_converter, annotation_string, name):
+    if maybe_converter
+    | if count == 1
+      | '$maybe_converter($expr,
+                          fun (v): v,
+                          fun (): bad_result(#' $name,
+                                             #%literal $annotation_string))'
+      | def [arg, ...]:
+          for List:
+            each i: 0..count
+            Syntax.make_id("arg" +& i)
+        'block:
+           fun fail(): bad_result(#' $name, #%literal $annotation_string)
+           call_with_values(
+             fun (): $expr,
+             fun
+             | ($arg, ...):
+                 $maybe_converter($arg, ..., values, fail)
+             | (& args): fail()
+           )'
+    | expr
+
+fun bad_result(who, ann_str):
+  error(who,
+        "result does not match annotation\n"
+          +& "  annotation: " +& ann_str)
+

--- a/rhombus/private/reducer.rkt
+++ b/rhombus/private/reducer.rkt
@@ -16,18 +16,35 @@
 (begin-for-syntax
   (provide (property-out reducer-transformer)
            :reducer
-           :reducer-form)
+           :reducer-form
+           reducer
+           reducer/no-break)
 
   (property reducer-transformer transformer)
 
   (define-syntax-class :reducer-form
-    (pattern [wrapper
-              ([id:identifier init-expr] ...)
-              body-wrapper
+    (pattern [wrapper:id
+              (~and binds ([id:identifier init-expr] ...))
+              body-wrapper:id
+              break-whener
+              final-whener
+              finisher:id
               static-infos
-              data]
-             #:attr binds #'([id init-expr] ...)))
+              data]))
 
+  (define (reducer wrapper binds body-wrapper break-whener final-whener finisher static-infos data)
+    #`(#,wrapper #,binds #,body-wrapper #,break-whener #,final-whener #,finisher #,static-infos #,data))
+
+  (define (reducer/no-break wrapper binds body-wrapper static-infos data)
+    #`(bounce-to-wrapper
+       #,binds
+       bounce-to-body-wrapper
+       #f
+       #f
+       bounce-finisher
+       #,static-infos
+       [#,wrapper #,body-wrapper finish #,data]))
+  
   (define (check-reducer-result form proc)
     (syntax-parse (if (syntax? form) form #'#f)
       [_::reducer-form form]
@@ -48,3 +65,24 @@
     [(_ id:identifier rhs)
      #`(define-syntax #,(in-reducer-space #'id)
          rhs)]))
+
+(define-syntax (define-wrapped stx)
+  (syntax-parse stx
+    [(_ finish body-wrapper data expr)
+     #`(define (finish)
+         (body-wrapper data expr))]))
+
+(define-syntax (bounce-to-wrapper stx)
+  (syntax-parse stx
+    [(_ [wrapper body-wrapper finish data] e)
+     #'(wrapper data e)]))
+
+(define-syntax (bounce-to-body-wrapper stx)
+  (syntax-parse stx
+    [(_ [wrapper body-wrapper finish data] e)
+     #'(define (finish) (body-wrapper data e))]))
+
+(define-syntax (bounce-finisher stx)
+  (syntax-parse stx
+    [(_ [wrapper body-wrapper finish data])
+     #'(finish)]))

--- a/rhombus/private/set.rkt
+++ b/rhombus/private/set.rkt
@@ -165,12 +165,14 @@
   (reducer-transformer
    (lambda (stx)
      (syntax-parse stx
-       [(_)
-        (reducer/no-break #'build-set-reduce
-                          #'([ht #hashalw()])
-                          #'build-set-add
-                          set-static-info
-                          #'ht)]))))
+       [(_ . tail)
+        (values
+         (reducer/no-break #'build-set-reduce
+                           #'([ht #hashalw()])
+                           #'build-set-add
+                           set-static-info
+                           #'ht)
+         #'tail)]))))
 
 (define-syntax (build-set-reduce stx)
   (syntax-parse stx

--- a/rhombus/private/set.rkt
+++ b/rhombus/private/set.rkt
@@ -166,11 +166,11 @@
    (lambda (stx)
      (syntax-parse stx
        [(_)
-        #`[build-set-reduce
-           ([ht #hashalw()])
-           build-set-add
-           #,set-static-info
-           ht]]))))
+        (reducer/no-break #'build-set-reduce
+                          #'([ht #hashalw()])
+                          #'build-set-add
+                          set-static-info
+                          #'ht)]))))
 
 (define-syntax (build-set-reduce stx)
   (syntax-parse stx

--- a/rhombus/private/static-info-macro.rkt
+++ b/rhombus/private/static-info-macro.rkt
@@ -24,7 +24,8 @@
          "append-key.rkt"
          "index-key.rkt"
          "index-result-key.rkt"
-         "dot-provider-key.rkt")
+         "dot-provider-key.rkt"
+         "values-key.rkt")
 
 (provide (for-syntax (for-space rhombus/namespace
                                 statinfo_meta)))
@@ -38,6 +39,8 @@
     #:fields
     (pack
      unpack
+     pack_group
+     unpack_group
      wrap
      lookup
      
@@ -48,7 +51,8 @@
      [map_ref_key index_get_key] ; temporary
      [map_set_key index_set_key] ; temporary
      append_key
-     dot_provider_key)))
+     dot_provider_key
+     values_key)))
 
 (define-for-syntax (make-static-info-macro-macro in-space)
   (definition-transformer
@@ -74,6 +78,15 @@
 (define-for-syntax (unpack v)
   (unpack-static-infos v))
 
+(define-for-syntax (pack_group v)
+  (datum->syntax
+   #f
+   (map (lambda (v) (pack-static-infos v 'statinfo_meta.pack_group))
+        (cdr (syntax->list (unpack-group v 'statinfo_meta.pack_group #f))))))
+
+(define-for-syntax (unpack_group v)
+  #`(group . #,(map unpack-static-infos (syntax->list v))))
+
 (define-for-syntax (wrap form info)
   (pack-term #`(parsed #,(wrap-static-info* (wrap-expression form)
                                             (pack info)))))
@@ -98,3 +111,4 @@
 (define-for-syntax index_set_key #'#%index-set)
 (define-for-syntax append_key #'#%append)
 (define-for-syntax dot_provider_key #'#%dot-provider)
+(define-for-syntax values_key #'#%values)

--- a/rhombus/private/syntax-object.rkt
+++ b/rhombus/private/syntax-object.rkt
@@ -271,7 +271,7 @@
   (pack-multi (for/list ([e (in-list v)])
                 (do-make 'Syntax.make_sequence e ctx-stx #t #t))))
 
-(define/arity (make_id str ctx)
+(define/arity (make_id str [ctx #f])
   #:static-infos ((#%call-result #,syntax-static-infos))
   (unless (string? str)
     (raise-argument-error* 'Syntax.make_id rhombus-realm "StringView" str))

--- a/rhombus/private/unquote-binding-primitive.rkt
+++ b/rhombus/private/unquote-binding-primitive.rkt
@@ -381,7 +381,7 @@
           (compat #'pack-block* #'unpack-multi-as-term*)]
          [else (incompat)])]
       [else
-       (error "unrecognized kind" kind)])))
+       (error "unrecognized kind"  (rhombus-syntax-class-kind rsc))])))
 
 (define-for-syntax (normalize-id form)
   (if (identifier? form)

--- a/rhombus/private/values.rkt
+++ b/rhombus/private/values.rkt
@@ -38,12 +38,14 @@
    (lambda (stx)
      (syntax-parse stx
        #:datum-literals (group op)
-       [(_ (parens (group id:identifier _::equal rhs ...) ...))
-        (reducer/no-break #'build-return
-                          #'([id (rhombus-expression (group rhs ...))] ...)
-                          #'build-return
-                          #'()
-                          #'#f)]))))
+       [(_ (parens (group id:identifier _::equal rhs ...) ...) . tail)
+        (values
+         (reducer/no-break #'build-return
+                           #'([id (rhombus-expression (group rhs ...))] ...)
+                           #'build-return
+                           #'()
+                           #'#f)
+         #'tail)]))))
 
 (define-syntax (build-return stx)
   (syntax-parse stx

--- a/rhombus/private/values.rkt
+++ b/rhombus/private/values.rkt
@@ -39,11 +39,11 @@
      (syntax-parse stx
        #:datum-literals (group op)
        [(_ (parens (group id:identifier _::equal rhs ...) ...))
-        #'[build-return
-           ([id (rhombus-expression (group rhs ...))] ...)
-           build-return
-           ()
-           #f]]))))
+        (reducer/no-break #'build-return
+                          #'([id (rhombus-expression (group rhs ...))] ...)
+                          #'build-return
+                          #'()
+                          #'#f)]))))
 
 (define-syntax (build-return stx)
   (syntax-parse stx

--- a/rhombus/private/values.rkt
+++ b/rhombus/private/values.rkt
@@ -14,7 +14,11 @@
                       rhombus/bind
                       rhombus/reducer
                       rhombus/statinfo)
-                     values))
+                     values)
+         (for-spaces (#f
+                      rhombus/statinfo)
+                     (rename-out
+                      [call-with-values call_with_values])))
 
 (define-binding-syntax values
   (binding-prefix-operator
@@ -47,3 +51,6 @@
 
 (define-static-info-syntax values
   (#%function-arity -1))
+
+(define-static-info-syntax call-with-values
+  (#%function-arity 4))

--- a/rhombus/scribblings/ref-bind-macro.scrbl
+++ b/rhombus/scribblings/ref-bind-macro.scrbl
@@ -228,6 +228,21 @@
 
 }
 
+
+@doc(
+  fun bind_meta.is_immediate(info :: Syntax) :: Boolean
+){
+
+ @provided_meta()
+
+ Takes the initialized binding-form expansion produced by
+ @rhombus(bind_meta.get_info) and restports whether the binding is
+ immediate in the same sense as just a variable: the binding always
+ matches, and no work is required to convert or unpack the matched value.
+
+}
+
+
 @doc(
   defn.macro '«bind.matcher '$id($id_pattern, $data_pattern,
                                  $IF_pattern, $success_pattern, $fail_pattern)':
@@ -317,6 +332,81 @@
  @provided_meta()
 
  Analogous to @rhombus(expr_meta.Parsed, ~stxclass), etc., but for bindings.
+
+}
+
+@doc(
+  ~nonterminal:
+    bind_maybe_kw_opt: fun
+
+  syntax_class bind_meta.Argument:
+    kind: ~group
+    field parsed
+    field maybe_keyword
+    field maybe_expr
+){
+
+ @provided_meta()
+
+ Matches forms that combine a binding with an optional kyword and
+ optional default-value expression, like @rhombus(bind_maybe_kw_opt) for
+ @rhombus(fun).
+
+@itemlist(
+
+  @item{The @rhombus(parsed) field holds a parsed binding form.}
+
+  @item{The @rhombus(maybe_keyword) field is @rhombus(#false) if no
+  keyword is present, otherwise it is a keyword syntax object.}
+
+  @item{The @rhombus(maybe_expr) field is @rhombus(#false) if no
+  default-value expression is provided, otherwise it is a group syntax
+  object for the expression.}
+
+)
+
+}
+
+@doc(
+  ~nonterminal:
+    maybe_res_annot: fun
+
+  syntax_class bind_meta.Result:
+    kind: ~sequence
+    field count
+    field maybe_converter
+    field static_info
+    field annotation_string
+){
+
+ @provided_meta()
+
+ Matches a sequence of terms (possibly empty) for a result annotation,
+ like @rhombus(maybe_res_annot) for @rhombus(fun).
+
+ @itemlist(
+
+  @item{The @rhombus(count) field holds an integer for the number of
+  expected results.}
+
+  @item{The @rhombus(maybe_converter) field is @rhombus(#false) if no
+  annotation is declared or if it is unchecked, otherwise it is a syntax
+  object for a function expression; the resulting function expects
+  @rhombus(count) plus two arguments: each original result followed by a
+  success procedure of @rhombus(count) arguments and a failure procedure
+  of zero arguments.}
+
+  @item{The @rhombus(static_info) field holds static information for the
+  result (in unpacked form; see @rhombus(static_info.pack)); when
+  @rhombus(count) is not @rhombus(1), then @rhombus(static_info) has a
+  single key @rhombus(statinfo_meta.values_key) whose value is (packed)
+  static information for each value (see
+  @rhombus(statinfo_meta.pack_group)).}
+
+  @item{The @rhombus(annotation_string) field describes the annotation,
+  which is useful for raising an exception when conversion fails.}
+
+)
 
 }
 

--- a/rhombus/scribblings/ref-boolean.scrbl
+++ b/rhombus/scribblings/ref-boolean.scrbl
@@ -73,6 +73,26 @@
 }
 
 @doc(
+  reducer.macro '||'
+){
+
+ A @tech{reducer} that stops an iteration as soon as a non-@rhombus(#false)
+ value is produced for an element and returns that value, otherwise
+ returns @rhombus(#false).
+
+@examples(
+  for ||:
+    each i: 0..10
+    (i == 5) && to_string(i)
+  for ||:
+    each i: 0..10
+    i == 10
+)
+
+}
+
+
+@doc(
   expr.macro '$expr && $expr'
 ){
 
@@ -139,6 +159,27 @@
 )
 
 }
+
+
+@doc(
+  reducer.macro '&&'
+){
+
+ A @tech{reducer} that stops an iteration as soon as a @rhombus(#false) value
+ is produced for an element and otherwise returns the result of the last
+ iteration.
+
+@examples(
+  for &&:
+    each i: 0..10
+    i == 5
+  for &&:
+    each i: 0..10
+    (i < 10) && to_string(i)
+)
+
+}
+
 
 
 @doc(

--- a/rhombus/scribblings/ref-recur.scrbl
+++ b/rhombus/scribblings/ref-recur.scrbl
@@ -1,0 +1,70 @@
+#lang scribble/rhombus/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@(def dots: @rhombus(..., ~bind))
+@(def dots_expr: @rhombus(...))
+
+@title(~tag: "ref-recur"){Recursion}
+
+Rhombus functions defined with @rhombus(fun) can be recursive, of
+course, but the @rhombus(recur) form offers a shorthand for the case
+that a recurive function would be used just once and is better written
+inline. Iteration with @rhombus(for) is also a kind of recursion, but
+@rhombus(recur) supports non-tail recursion, instead of only iterative
+loops.
+
+@doc(
+  ~nonterminal:
+    bind_maybe_kw_opt: fun
+    maybe_res_annot: fun
+
+  expr.macro 'recur $id($bind_maybe_kw_opt, ...) maybe_res_annot:
+                $body
+                ...'
+){
+
+ Similar to defining @rhombus(id) as a function and immediately calling
+ it, where @rhombus(id) is bound only within the @rhombus(body) block for
+ recursive calls. The intent is to implement a recursive calculation ``in
+ place,'' instead of defining a recurive function and then calling
+ it---including cases where the recursion is not in tail position or
+ where @rhombus(for) is not a good fit for some other reason.
+
+ @margin_note{Racket and Scheme programmers will recognize this form as
+  a kind of ``@as_index{named let}.''}
+
+ To enable the immediate call of @rhombus(id), each
+ @rhombus(bind_maybe_kw_opt) must include a ``default'' expression, and
+ the immediate call is like supplying zero arguments. Thus, each
+ ``default'' expression is really an initial-value expression. The
+ binding of @rhombus(id) within the @rhombus(body) block, however, is a
+ function where only keyword arguments are optional. The default value
+ for a keyword argument in a recursive call, meanwhile, is whatever was
+ supplied for the enclosing call, with the effect that keyword arguments
+ are automatically propogated in a recursive call.
+
+ Beware that when @rhombus(maybe_res_annot) specifies a result
+ annotation using @rhombus(::, ~bind), the annotation is checked on every
+ recursive call. In that case, no recursive calls are in tail position.
+
+@examples(
+  ~repl:
+    recur nest_to(n = 5):
+      match n
+      | 0: [0]
+      | ~else: [n, nest_to(n-1)]
+  ~repl:
+    recur sum_halves(l = [1, 2, 3, -4, 5, -6],
+                     ~pos_sum: pos_sum = 0,
+                     ~neg_sum: neg_sum = 0):
+      match l
+      | []: values(pos_sum, neg_sum)
+      | [n, & ns]:
+          if n > 0
+          | sum_halves(ns, ~pos_sum: pos_sum + n)
+          | sum_halves(ns, ~neg_sum: neg_sum + n)
+)
+
+}

--- a/rhombus/scribblings/ref-reducer-macro.scrbl
+++ b/rhombus/scribblings/ref-reducer-macro.scrbl
@@ -1,7 +1,8 @@
 #lang scribble/rhombus/manual
 @(import:
     "common.rhm" open
-    "nonterminal.rhm" open
+    "nonterminal.rhm" open:
+      except: bind expr defn
     "macro.rhm")
 
 @(def macro_eval: macro.make_macro_eval())
@@ -21,12 +22,12 @@
 
 @doc(
   ~nonterminal:
-    prefix_macro_patterns: defn.macro
+    macro_patterns: expr.macro
 
-  defn.macro 'reducer.macro $prefix_macro_patterns'
+  defn.macro 'reducer.macro $macro_patterns'
 ){
 
- Like @rhombus(defn.macro, ~expr), but defines an identifier
+ Like @rhombus(expr.macro, ~expr), but defines an identifier or operator
  as a reducer form in the @rhombus(reducer, ~space) @tech{space}.
  The result of the macro expansion can be a low-level
  reducer description created with @rhombus(reducer_meta.pack).
@@ -206,11 +207,19 @@
   syntax_class reducer_meta.Parsed:
     kind: ~group
     field group
+  syntax_class reducer_meta.AfterPrefixParsed(op_name):
+    kind: ~group
+    field group
+    field [tail, ...]
+  syntax_class reducer_meta.AfterInfixParsed(op_name):
+    kind: ~group
+    field group
+    field [tail, ...]
 ){
 
  @provided_meta()
 
- Analogous to @rhombus(expr_meta.Parsed, ~stxclass), but for reducers.
+ Analogous to @rhombus(expr_meta.Parsed, ~stxclass), etc., but for reducers.
 
 }
 

--- a/rhombus/scribblings/ref-reducer-macro.scrbl
+++ b/rhombus/scribblings/ref-reducer-macro.scrbl
@@ -42,21 +42,28 @@
       i
   ~defn:
     reducer.macro 'WithCount($(r :: reducer_meta.Parsed))':
-      def '($wrap, ($accum_id = $init, ...), $step, $static_info, $data)':
+      def '($wrap, ($bind, ...), $step, $break, $final, $finish, $static_info, $data)':
         reducer_meta.unpack(r)
       reducer_meta.pack('build_return',
-                        '($accum_id = $init, ..., count = 0)',
+                        '($bind, ..., count = 0)',
                         'build_inc',
+                        break.unwrap() && 'build_break',
+                        final.unwrap() && 'build_final',
+                        'build_finish',
                         '()',
-                        '[($accum_id, ...), count, $wrap, $step, $data]')
-    expr.macro 'build_return [($accum_id, ...), $count, $wrap, $step, $data] $e':
+                        '[count, $wrap, $step, $break, $final, $finish, $data]')
+    expr.macro 'build_return [$count, $wrap, $step, $break, $final, $finish, $data] $e':
       'block:
-         let values($accum_id, ..., c) = $e
-         values($wrap $data $accum_id ..., c)'
-    expr.macro 'build_inc [($accum_id, ...), $count, $wrap, $step, $data] $e':
-      'block:
-         let ($accum_id, ...) = $step $data $e
-         values($accum_id, ..., $count + 1)'
+         def values(r, c) = $e
+         values($wrap $data r, c)'
+    defn.macro 'build_inc [$count, $wrap, $step, $break, $final, $finish, $data] $e':
+      '$step $data $e'
+    expr.macro 'build_break [$count, $wrap, $step, $break, $final, $finish, $data]':
+      '$break $data'
+    expr.macro 'build_final [$count, $wrap, $step, $break, $final, $finish, $data]':
+      '$final $data'
+    expr.macro 'build_finish [$count, $wrap, $step, $break, $final, $finish, $data]':
+      'values($finish $data, $count + 1)'
   ~repl:
     for WithCount(List):
       each i: 0..3
@@ -69,29 +76,53 @@
 }
 
 @doc(
-  fun reducer_meta.pack(stx :: Syntax) :: Syntax
+  fun reducer_meta.pack(complete_id :: Identifier,
+                        binds :: Syntax,
+                        step_id :: Identifier,
+                        break_id :: maybe(Identifier),
+                        final_id :: maybe(Identifier),
+                        step_result_id :: Identifier,
+                        static_info :: Syntax,
+                        data :: Syntax) :: Syntax
 ){
 
  @provided_meta()
 
  Packs reducer information that is represented by a syntax object with
- five parts, which are combined in the form
+ eight parts. The parts are taken separately by
+ @rhombus(reducer_meta.pack), but they are combined in the form
 
  @rhombusblock(
-  '(#,(@rhombus(complete_id, ~var)),
+  '(#,(@rhombus(complete_id, ~var)),    // expression macro
     (#,(@rhombus(accum_id, ~var)) = #,(@rhombus(accum_expr, ~var)), ...),
-    #,(@rhombus(step_id, ~var)),
+    #,(@rhombus(step_id, ~var)),        // definition macro
+    #,(@rhombus(break_id, ~var)),       // optional expression macro
+    #,(@rhombus(final_id, ~var)),       // optional expression macro
+    #,(@rhombus(step_result_id, ~var)), // expression macro
     ((#,(@rhombus(var_static_key, ~var)), #,(@rhombus(var_static_value, ~var))), ...),
     #,(@rhombus(data, ~var)))')
+
+ These pieces give the reducer control over how elements of the
+ iteration are accumulated on each step and a single completion action
+ performed for the accumulated values. Configuration of the step is split
+ into four parts---@rhombus(step_id), @rhombus(break_id),
+ @rhombus(final_id), @rhombus(step_result_id)---to enable early
+ termination of the iteration depending on element values or an
+ accumulated value.
 
  As an example, for the @rhombus(List, ~reducer),
  @rhombus(complete_id, ~var) reverses an accumulated list, one
  @rhombus(accum_id, ~var) is initialized to @rhombus([]) and represents
  an accumulated (in reverse) list, @rhombus(step_id, ~var) adds a new
- value to the front of the list, the @rhombus(var_static_key, ~var)s with
- @rhombus(var_static_values, ~var)s provide static information for a
- list, and @rhombus(data, ~var) is @rhombus(accum_id, ~var) (so that
- @rhombus(step_id, ~var) is able to refer to it).
+ value to the front of the list and binds it to a fresh variable
+ @rhombus(next_accum_id, ~var), @rhombus(break_id) and @rhombus(final_id)
+ are false (because early termination is never needed by the reducer),
+ @rhombus(step_result_id) returns @rhombus(next_accum_id, ~var), the
+ @rhombus(var_static_key, ~var)s with @rhombus(var_static_values, ~var)s
+ provide static information for a list, and @rhombus(data, ~var) has
+ @rhombus(accum_id, ~var) and @rhombus(next_accum_id, ~var) (so that
+ @rhombus(step_id, ~var) and @rhombus(step_result_id, ~var) are able to
+ refer to them).
 
  In detail:
 
@@ -99,7 +130,7 @@
 
  @item{The @rhombus(complete_id, ~var) should refer to a macro that
   expects @rhombus(data, ~var) followed by an expression that produces a
-  final value for each @rhombus(accum_id, ~var), and the result of that
+  final value for each @rhombus(accum_id, ~var). The result of that
   macro use is the overall accumulated result (e.g., the result of the
   @rhombus(for) form using the packed reducer).}
 
@@ -110,6 +141,31 @@
   values, the @rhombus(step_id, ~var) determins how each is updated for an
   input. When no further inputs are available, @rhombus(complete_id, ~var)
   receives the final state to convert it in to the result value.}
+
+ @item{The @rhombus(step_id, ~var) should refer to a macro that expects
+  @rhombus(data, ~var) followed by an expression that produces a value (or
+  multiple values) to be accumulated. It should expand to definitions that
+  bind whatever is needed by @rhombus(break_id, ~var),
+  @rhombus(final_id, ~var), and especially @rhombus(step_result_id, ~var).}
+
+ @item{The optional @rhombus(break_id, ~var) identifier should refer to
+  a macro that expects @rhombus(data, ~var) and produces a boolean that
+  indicates whether to stop the iteration with the value(s) accumulated
+  through previous steps, not accumulating in this step. Supplying
+  @rhombus(#false) for @rhombus(break_id) is a hint that breaking is never
+  needed before the interation would otherwise complete, which might
+  enable a more efficient compilation.}
+
+ @item{The optional @rhombus(final_id, ~var) identifier should refer to
+  a macro that expects @rhombus(data, ~var) and produces a boolean that
+  indicates whether to stop the iteration after the accumulation of the
+  current step. Like @rhombus(break_id), Supplying @rhombus(#false) for
+  @rhombus(final_id) serves as a performance hint.}
+ 
+ @item{The @rhombus(step_result_id, ~var) should refer to a macro that
+  expects @rhombus(data, ~var) and produces a number of results
+  corresponding to the number of @rhombus(accum_id, ~var)s. Each result
+  becomes the new value of the corresponding @rhombus(accum_id, ~var).}
 
  @item{The @rhombus(step_id, ~var) should refer to a macro that expects
   @rhombus(data, ~var) followed by an expression that produces a value (or
@@ -137,9 +193,12 @@
 
  @provided_meta()
 
- The inverse of @rhombus(reducer_meta.pack), which can be useful for
- defining a new form that works with reducers or for defining a reducer
- in terms of another reducer.
+ Roughly the inverse of @rhombus(reducer_meta.pack), except that the
+ pieces are returned in a combined syntax object instead of as multiple
+ values. Unpacking can be useful for defining a new form that works with
+ reducers or for defining a reducer in terms of another reducer.
+
+  See @rhombus(reducer_meta.pack) for an example.
 
 }
 

--- a/rhombus/scribblings/ref-static-info.scrbl
+++ b/rhombus/scribblings/ref-static-info.scrbl
@@ -86,6 +86,25 @@
 }
 
 @doc(
+  fun statinfo_meta.pack_group(statinfo_stx :: Syntax) :: Syntax
+  fun statinfo_meta.unpack_group(statinfo_stx :: Syntax) :: Syntax
+){
+
+ @provided_meta()
+
+ Analogous to @rhombus(statinfo_meta.pack) and
+ @rhombus(statinfo_meta.unpack), but for a sequence of static information
+ sets, such as one set of static information per value produced by a
+ multiple-value expression (see @rhombus(statinfo_meta.values_key).
+
+ An unpacked sequence is represented as a group syntax object, where
+ each term in the group is unpacked static information in the sense of
+ @rhombus(statinfo_meta.pack).
+
+}
+
+
+@doc(
   fun statinfo_meta.lookup(expr_stx :: Syntax, key :: Identifier)
 ){
 
@@ -120,6 +139,7 @@
   def statinfo_meta.index_set_key
   def statinfo_meta.append_key
   def statinfo_meta.dot_provider_key
+  def statinfo_meta.values_key
 ){
 
  @provided_meta()
@@ -156,6 +176,10 @@
         bound to a @rhombus(dot.macro) or
         @rhombus(dot.macro_more_static) to implement the expression's
         behavior as a @tech{dot provider}}
+
+  @item{@rhombus(statinfo_meta.values_key) --- a packed group of
+        static infoformation (see @rhombus(statinfo_meta.pack_group)),
+        one for each value produced by a multiple-value expression}
 
 )
 

--- a/rhombus/scribblings/ref-values.scrbl
+++ b/rhombus/scribblings/ref-values.scrbl
@@ -40,3 +40,38 @@
  are the final values of the @rhombus(id)s.
 
 }
+
+
+@doc(
+  fun call_with_values(producer :: Function.of_arity(0),
+                       consumer :: Function)
+){
+
+ Calls @rhombus(producer) with no arguments, and then calls
+ @rhombus(consumer) with the result value(s) from @rhombus(producer).
+
+ Use @rhombus(call_with_values) to dispatch on the number of values that
+ are produced by an expression. The @rhombus(match) form cannot make that
+ distinction, because it always expects a single result value from its
+ initial subexpression.
+
+@examples(
+  ~defn:
+    fun get_fruit(n :: NonnegInt):
+      match n
+      | 0: values()
+      | 1: "apple"
+      | 2: values("apple", "banana")
+      | ~else values("apple", n +& " bananas")
+    fun
+    | show(): println("nothing")
+    | show(s): println(s)
+    | show(a, b): println(a +& " and " +& b)
+  ~repl:
+    call_with_values(fun (): get_fruit(0), show)
+    call_with_values(fun (): get_fruit(1), show)
+    call_with_values(fun (): get_fruit(2), show)
+    call_with_values(fun (): get_fruit(3), show)
+)
+
+}

--- a/rhombus/scribblings/reference.scrbl
+++ b/rhombus/scribblings/reference.scrbl
@@ -23,10 +23,11 @@
 
 @include_section("ref-repetition.scrbl")
 
+@include_section("ref-block.scrbl")
 @include_section("ref-cond.scrbl")
 @include_section("ref-match.scrbl")
 @include_section("ref-for.scrbl")
-@include_section("ref-block.scrbl")
+@include_section("ref-recur.scrbl")
 @include_section("ref-parameter.scrbl")
 @include_section("ref-exn.scrbl")
 @include_section("ref-control.scrbl")

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -171,3 +171,39 @@ check:
     each i: 3..7
     i
   ~raises "index is out of range"
+
+check:
+  def mutable accum = []
+  [for &&:
+     each i: 0..10
+     accum := List.cons(i, accum)
+     i > -1 && i,
+   accum]
+  ~is [9, [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]]
+  
+check:
+  def mutable accum = []
+  [for &&:
+     each i: 0..10
+     accum := List.cons(i, accum)
+     i < 6,
+   accum]
+  ~is [#false, [6, 5, 4, 3, 2, 1, 0]]
+
+check:
+  def mutable accum = []
+  [for ||:
+     each i: 0..10
+     accum := List.cons(i, accum)
+     i > 9,
+   accum]
+  ~is [#false, [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]]
+  
+check:
+  def mutable accum = []
+  [for ||:
+     each i: 0..10
+     accum := List.cons(i, accum)
+     i > 5 && i,
+   accum]
+  ~is [6, [6, 5, 4, 3, 2, 1, 0]]

--- a/rhombus/tests/recur.rhm
+++ b/rhombus/tests/recur.rhm
@@ -1,0 +1,96 @@
+#lang rhombus
+
+use_static
+
+check:
+  recur f(x = 1): x
+  ~is 1
+
+check:
+  (recur f(x = 1): x) ~is 1
+  (recur f(x = 1, y = [x]): y) ~is [1]
+  (recur f(x = 1, y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(x = 1, ~y: y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(~x: x = 1, ~y: y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(~x: x = 1, ~y: y = [x], ~z: z = [x, y]): z) ~is [1, [1]]
+
+// argument pattern triggers more general transformation
+check:
+  (recur f([x] = [1]): x) ~is 1
+  (recur f([x] = [1], y = [x]): y) ~is [1]
+  (recur f([x] = [1], y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f([x] = [1], ~y: y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(~x: [x] = [1], ~y: y = [x], z = [x, y]): z) ~is [1, [1]]
+  (recur f(~x: [x] = [1], ~y: y = [x], ~z: z = [x, y]): z) ~is [1, [1]]
+
+check:
+  recur f(x = 2, ~y: y = x):
+    if x == 0
+    | y
+    | f(0)
+  ~is 2
+
+check:
+  recur f(x = 2, ~y: y = x):
+    match x
+    | 0: y
+    | 1: f(0)
+    | ~else: f(x-1, ~y: y+1)
+  ~is 3
+
+check:
+  recur f([x] = [2], ~y: y = x):
+    if x == 0
+    | y
+    | f([0])
+  ~is 2
+
+check:
+  recur f([x] = [2], ~y: y = x):
+    match x
+    | 0: y
+    | 1: f([0])
+    | ~else: f([x-1], ~y: y+1)
+  ~is 3
+
+check:
+  ~eval
+  recur f(x): x
+  ~raises "missing initial-value expression"
+
+check:
+  ~eval
+  recur f(~x: x): x
+  ~raises "missing initial-value expression"
+
+check:
+  recur loop(x :: String = "a"):
+    x.length()
+  ~is 1
+
+check:
+  recur loop(x :: String = 10):
+    x.length()
+  ~raises "value does not match annotation"
+
+check:
+  (recur loop(x :: String = "abs") :: String:
+     x).length()
+  ~is 3
+
+check:
+  def (s, x):
+    recur loop(x :: String = "abs") :: (String, Int):
+      values(x, 0)
+  s.length()
+  ~is 3
+
+check:
+  recur loop(x :: String = "abs") :: String:
+    0
+  ~raises "result does not match annotation"
+
+check:
+  recur loop(x :: String = "abs") :: (String, Int):
+    0
+  ~raises "result does not match annotation"

--- a/rhombus/tests/reducer-macro.rhm
+++ b/rhombus/tests/reducer-macro.rhm
@@ -1,4 +1,4 @@
-#lang rhombus/and_meta
+#lang rhombus/static/and_meta
 
 check:
   reducer.macro 'A5': 'Array ~length 5'
@@ -12,12 +12,17 @@ check:
     reducer_meta.pack('build_reverse',
                       '(l = List.empty)',
                       'build_cons',
+                      #false,
+                      #false,
+                      'use_cons',
                       '()',
-                      'l')
-  expr.macro 'build_reverse $l_id $e':
+                      '(l, next_l)')
+  expr.macro 'build_reverse $_ $e':
     'List.reverse($e)'
-  expr.macro 'build_cons $l_id $e':
-    'List.cons([$e], $l_id)'
+  defn.macro 'build_cons ($l_id, $next_l_id) $e':
+    'def $next_l_id = List.cons([$e], $l_id)'
+  expr.macro 'use_cons ($l_id, $next_l_id)':
+    next_l_id
   for ListOfLists:
     each i: 1..3
     i
@@ -25,18 +30,27 @@ check:
 
 check:
   reducer.macro 'AndCount($(r :: reducer_meta.Parsed))':
-    def '($wrap, ($bind, ...), $step, $static_info, $data)' = reducer_meta.unpack(r)
+    def '($wrap, ($bind, ...), $step, $break, $final, $finish, $static_info, $data)' = reducer_meta.unpack(r)
     reducer_meta.pack('build_return',
                       '($bind, ..., count = 0)',
                       'build_inc',
+                      break.unwrap() && 'build_break',
+                      final.unwrap() && 'build_final',
+                      'build_finish',
                       '()',
-                      '[count, $wrap, $step, $data]')
-  expr.macro 'build_return [$count, $wrap, $step, $data] $e':
+                      '[count, $wrap, $step, $break, $final, $finish, $data]')
+  expr.macro 'build_return [$count, $wrap, $step, $break, $final, $finish, $data] $e':
     'block:
        def values(r, c) = $e
        values($wrap $data r, c)'
-  expr.macro 'build_inc [$count, $wrap, $step, $data] $e':
-    'values($step $data $e, $count + 1)'
+  defn.macro 'build_inc [$count, $wrap, $step, $break, $final, $finish, $data] $e':
+    '$step $data $e'
+  expr.macro 'build_break [$count, $wrap, $step, $break, $final, $finish, $data]':
+    '$break $data'
+  expr.macro 'build_final [$count, $wrap, $step, $break, $final, $finish, $data]':
+    '$final $data'
+  expr.macro 'build_finish [$count, $wrap, $step, $break, $final, $finish, $data]':
+    'values($finish $data, $count + 1)'
   for AndCount(List):
     each i: 0..3
     i

--- a/rhombus/tests/statinfo-macro.rhm
+++ b/rhombus/tests/statinfo-macro.rhm
@@ -24,3 +24,19 @@ check:
   use_static
   ((two list_of_zero)[0])[0]
   ~is 0
+
+block:
+  import:
+    meta -1: rhombus/meta open
+  check:
+    statinfo_meta.unpack(statinfo_meta.pack('((x, y))'))
+    ~prints_like '((x, y))'
+  check:
+    statinfo_meta.unpack(statinfo_meta.pack('((x, y), (z, w))'))
+    ~prints_like '((x, y), (z, w))'
+  check:
+    statinfo_meta.unpack_group(statinfo_meta.pack_group('((x, y))'))
+    ~prints_like '((x, y))'
+  check:
+    statinfo_meta.unpack_group(statinfo_meta.pack_group('((x, y)) ((z, w))'))
+    ~prints_like '((x, y)) ((z, w))'

--- a/scribble/private/rhombus-doc.rkt
+++ b/scribble/private/rhombus-doc.rkt
@@ -297,9 +297,9 @@
 (define-doc reducer.macro reducer
   "reducer"
   rhombus/reducer
-  identifier-macro-extract-name
-  identifier-macro-extract-metavariables
-  identifier-macro-extract-typeset)
+  operator-macro-extract-name
+  operator-macro-extract-metavariables
+  operator-macro-extract-typeset)
 
 (define-doc for_clause.macro for_clause
   "for clause"

--- a/scribble/rhombus.rkt
+++ b/scribble/rhombus.rkt
@@ -9,7 +9,8 @@
                     [verbatim base:verbatim]
                     [table-of-contents table_of_contents]
                     [local-table-of-contents local_table_of_contents]
-                    [margin-note margin_note])
+                    [margin-note margin_note]
+                    [as-index as_index])
          scribble/private/manual-defaults
          "private/rhombus.rhm"
          "private/rhombus_typeset.rhm"


### PR DESCRIPTION
[Edit: some of this isn't what I think, now, as reflected by the change in names by a force-pushed commit.]

Most of this PR is a straightforward generalization of the reducer macro API to support early termination of an iteration, which is needed for "and" and "or" reducer (analogous to `for/and` and `for/or`). The macro API is also extended to support operators, instead of allowing only prefix identifiers as reducers.

These changes allow `&&` and `||` as reducers. The new reducer don't accept any arguments in a reducer position, and I'm not sure that no-fix reducer operators are a good choice. I considered using `and` and `or` for the reducer names, instead, but `&&` and `||` match the name used for "and" and "or" everywhere else, so I went with those for a first draft.

There's also the `every`/`all` versus `any` convention, but because I'm more used to `andmap` and `ormap`, I usually have to work out which of `every` or `any` is "and" and which is "or". But maybe that's just a question of what I'm used to. Then again, `Any` has a stronger precedent for us as an annotation or contract.

Example:

```
fun lex_greater_or_equal(l1 :: List.of(Real),
                         l2 :: List.of(Real)):
  l1.length() >= l2.length()
    && (for &&:
          each:
            e1: l1
            e2: l2
          e1 >= e2)
```