### PR TITLE
add `with` for functional update of objects

### DIFF
--- a/rhombus/private/class-clause-parse.rkt
+++ b/rhombus/private/class-clause-parse.rkt
@@ -114,6 +114,10 @@
               [(#:dot name block)
                (hash-set options 'dots (cons (cons #'name (extract-rhs #'block))
                                              (hash-ref options 'dots null)))]
+              [(#:update name block)
+               (when (hash-has-key? options 'update-rhs)
+                 (raise-syntax-error #f "multiple update clauses" orig-stx clause))
+               (hash-set options 'update-rhs (extract-rhs #'block))]
               [(#:nonfinal)
                (when (hash-has-key? options 'final?)
                  (raise-syntax-error #f "multiple finality clauses" orig-stx clause))

--- a/rhombus/private/class-parse.rkt
+++ b/rhombus/private/class-parse.rkt
@@ -247,12 +247,13 @@
                            "constructor name conflicts with expression macro"
                            stxes)])))
 
-(define (check-consistent-unimmplemented stxes final? abstract-name)
+(define (check-consistent-unimmplemented stxes final? abstract-name name)
   (when (and final? abstract-name)
     (raise-syntax-error #f
                         "final class cannot have abstract methods"
                         stxes
-                        abstract-name)))
+                        abstract-name
+                        (list name))))
 
 (define (check-field-defaults stxes super-has-defaults? constructor-fields defaults keywords)
   (for/fold ([need-default? #f]) ([f (in-list constructor-fields)]

--- a/rhombus/private/core.rkt
+++ b/rhombus/private/core.rkt
@@ -101,6 +101,7 @@
         "function.rkt"
         "class.rkt"
         "class-clause-primitive.rkt"
+        "with.rkt"
         "interface.rkt"
         "class-together.rkt"
         "block.rkt"

--- a/rhombus/private/dot.rkt
+++ b/rhombus/private/dot.rkt
@@ -60,7 +60,6 @@
              #,expr)))
 
   (define-syntax-class :dot-provider
-    #:literals (begin quote-syntax #%dot-provider)
     (pattern id:identifier
              #:when (syntax-local-value* (in-dot-provider-space #'id) dot-provider-ref))
     (pattern (~var ref-id (:static-info #'#%dot-provider))

--- a/rhombus/private/with.rkt
+++ b/rhombus/private/with.rkt
@@ -1,0 +1,56 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     enforest/syntax-local
+                     "statically-str.rkt")
+         "expression.rkt"
+         "static-info.rkt"
+         "parse.rkt"
+         "dot-provider-key.rkt")
+
+(provide with)
+
+(module+ for-update
+  (provide define-update-syntax
+           (for-syntax update-transformer)))
+
+
+(begin-for-syntax
+  (define in-update-space (make-interned-syntax-introducer 'rhombus/update))
+
+  (struct update-transformer (proc))
+  (define (update-transformer-ref v)
+    (and (update-transformer? v) v))
+  
+  (define-syntax-class :update-provider
+    (pattern (~var ref-id (:static-info #'#%dot-provider))
+             #:attr id #'ref-id.val)))
+
+(define-syntax with
+  (expression-infix-operator
+   (quote-syntax with)
+   '((default . weaker))
+   'macro
+   (lambda (orig-form1 tail)
+     (syntax-parse tail
+       [(with-id . tail)
+        (let ([form1 (rhombus-local-expand orig-form1)])
+          (define update-id
+            (syntax-parse form1
+              [dp::update-provider #'dp.id]
+              [_ #f]))
+          (define updater
+            (and update-id
+                 (syntax-local-value* (in-update-space update-id) update-transformer-ref)))
+          (unless updater
+            (raise-syntax-error #f
+                                (string-append "no update implementation available" statically-str)
+                                #'with-id
+                                (unwrap-static-infos orig-form1)))
+          ((update-transformer-proc updater) form1 #'with-id #'tail))]))
+   'left))
+  
+(define-syntax (define-update-syntax stx)
+  (syntax-parse stx
+    [(_ id rhs)
+     #`(define-syntax #,(in-update-space #'id) rhs)]))

--- a/rhombus/scribblings/ref-dot-provider.scrbl
+++ b/rhombus/scribblings/ref-dot-provider.scrbl
@@ -88,7 +88,7 @@
     ~tail: '$pattern'
 ){
 
- Forms for @rhombus(class) or @rhombus(interface) to bind a macro that
+ A form for @rhombus(class) or @rhombus(interface) to bind a macro that
  is normally triggered by using the @rhombus(defined_id) after @rhombus(.) on an
  expression that has the class's or interface's annotation. The macro can also be
  triggered by @rhombus(#,(@rhombus(name, ~var)).defined_id(obj_expr)) for a class

--- a/rhombus/static/meta.rhm
+++ b/rhombus/static/meta.rhm
@@ -1,0 +1,3 @@
+#lang rhombus
+import: "meta.rkt"
+export: all_from(.meta)

--- a/rhombus/tests/class.rhm
+++ b/rhombus/tests/class.rhm
@@ -5,11 +5,17 @@ import:
 
 use_static
   
-check:
+block:
   class Posn(x, y)
   def p = Posn(1, 2)
-  [p is_a Posn, p.x, p.y]
-  ~is [#true, 1, 2]
+  check [p is_a Posn, p.x, p.y] ~is [#true, 1, 2]
+  check p with (x = 10) ~is Posn(10, 2)
+  check p with (y = 20) ~is Posn(1, 20)
+  check p with (x = 10).x ~is 10
+  check p with (x = 10).y ~is 2
+  def mutable c = 10
+  check p with (y = c, x = block: c := c + 1; c) ~is Posn(11, 10)
+  check p with (x = block: c := c + 1; c, y = block: c := c + 2; c) ~is Posn(12, 14)
 
 check:
   ~eval
@@ -37,42 +43,50 @@ check:
     extends Posn
   ~raises "field name already exists in superclass"
 
-check:
+block:
   class Posn(~x, y)
   def p = Posn(~x: 1, 2)
   def p2 = Posn(2, ~x: 1)
-  [p.x, p.y, p2.x, p2.y]
-  ~is [1, 2, 1, 2]
+  check [p.x, p.y, p2.x, p2.y] ~is [1, 2, 1, 2]
+  check p with (x = 10) ~is Posn(~x: 10, 2)
+  check p with (y = 20) ~is Posn(~x: 1, 20)
 
-check:
+block:
   class Posn(~x, y):
     nonfinal
   class Posn3D(z):
     extends Posn
   def p = Posn3D(~x: 1, 2, 3)
   def p2 = Posn3D(2, 3, ~x: 1)
-  [p.x, p.y, p.z, p2.x, p2.y, p2.z]
-  ~is [1, 2, 3, 1, 2, 3]
+  check [p.x, p.y, p.z, p2.x, p2.y, p2.z] ~is [1, 2, 3, 1, 2, 3]
+  check p with (x = 10) ~is Posn3D(~x: 10, 2, 3)
+  check p with (y = 20) ~is Posn3D(~x: 1, 20, 3)
+  check p with (z = 30) ~is Posn3D(~x: 1, 2, 30)
+  check (p :: Posn) with (x = 10) ~is Posn(~x: 10, 2)
 
-check:
+block:
   class Posn(x, y):
     nonfinal
   class Posn3D(~z):
     extends Posn
   def p = Posn3D(1, 2, ~z: 3)
   def p2 = Posn3D(~z: 3, 1, 2)
-  [p.x, p.y, p.z, p2.x, p2.y, p2.z]
-  ~is [1, 2, 3, 1, 2, 3]
+  check [p.x, p.y, p.z, p2.x, p2.y, p2.z] ~is [1, 2, 3, 1, 2, 3]
+  check p with (x = 10) ~is Posn3D(10, 2, ~z: 3)
+  check p with (y = 20) ~is Posn3D(1, 20, ~z: 3)
+  check p with (z = 30) ~is Posn3D(1, 2, ~z: 30)
 
-check:
+block:
   class Posn(~x, y):
     nonfinal
   class Posn3D(~z: zz):
     extends Posn
   def p = Posn3D(~x: 1, 2, ~z: 3)
   def p2 = Posn3D(~z: 3, 2, ~x: 1)
-  [p.x, p.y, p.zz, p2.x, p2.y, p2.zz]
-  ~is [1, 2, 3, 1, 2, 3]
+  check [p.x, p.y, p.zz, p2.x, p2.y, p2.zz] ~is [1, 2, 3, 1, 2, 3]
+  check p with (x = 10) ~is Posn3D(~x: 10, 2, ~z: 3)
+  check p with (y = 20) ~is Posn3D(~x: 1, 20, ~z: 3)
+  check p with (zz = 30) ~is Posn3D(~x: 1, 2, ~z: 30)
 
 check:
   class Posn(x, y):
@@ -92,6 +106,14 @@ check:
   def p = Posn(1)
   [p.x, p.y]
   ~is [2, 0]
+
+check:
+  ~eval
+  class Posn(x, y):
+    constructor (z):
+      super(z+1, z-1)
+  Posn(0) with (x = 1)
+  ~raises "no update implementation available"
 
 check:
   class Posn(x, y):
@@ -189,7 +211,7 @@ check:
   [p.x, p.y, p.z]
   ~is [1, 2, 3]
 
-check:
+block:
   import rhombus/meta open
   class Posn(x, y):
     nonfinal
@@ -211,12 +233,13 @@ check:
   def p = Posn(0, 2)
   def Posn(yy, xx) = p
   def Posn(a) = p    
-  [p.y, p.x, yy, xx, a,
-   p is_a Posn,
-   Posn(1, "2") is_a Posn.of(Int, String)]
-  ~is [0, 2, 0, 2, 2,
-       #true,
-       #true]
+  check:
+    [p.y, p.x, yy, xx, a,
+     p is_a Posn,
+     Posn(1, "2") is_a Posn.of(Int, String)]
+    ~is [0, 2, 0, 2, 2,
+         #true,
+         #true]
 
 check:
   class Posn(x, y):
@@ -832,3 +855,71 @@ check:
     extends B
   [B(#true).b, C(#true).b]
   ~is [#true, #true]
+
+block:
+  class Posn(x, y):
+    field size = 0
+  def p = Posn (1, 2)
+  p.size := 100
+  check p with (x = 10) ~is_now Posn(10, 2)
+  check p with (x = 10).size ~is 0
+
+block:
+  def mutable c = 0
+  class Posn(x, y, private z = c):
+    method get_z(): z
+  def p = Posn (1, 2)
+  c := 1
+  check p with (x = 10) ~is_now Posn(10, 2)
+  check p with (x = 10).get_z() ~is 1
+
+block:
+  import rhombus/meta open
+  class Posn(x, y):
+    internal _Posn
+    expression 'Posn < $x $y >':
+      '_Posn($x, $y) :~ Posn'
+    update '$obj with (x = $v) $rest_tail ...':
+      values('_Posn($v, $(obj).y) :~ Posn',
+             '$rest_tail ...')
+  def p = Posn< 1 2 >
+  check p.x ~is 1
+  check p.y ~is 2
+  check p with (x = 10) ~is Posn< 10 2 >
+
+block:
+  import rhombus/meta open
+  class Posn(x, y):
+    internal _Posn
+    constructor Posn(x, y):
+      _Posn(x, y)
+    update '$obj with $tail ...':
+      match '$tail ...'
+      | '(EX = $rhs) $tail ...':
+          values('_Posn($rhs, $(obj).y) :~ Posn',
+                 '$tail ...')
+      | '(WY = $rhs) $tail ...':
+          values('_Posn($(obj).x, $rhs) :~ Posn',
+                 '$tail ...')
+  def p = Posn(1, 2)
+  check p.x ~is 1
+  check p.y ~is 2
+  check p with (EX = 10) ~is Posn(10, 2)
+  check p with (EX = 10).x ~is 10
+  check p with (WY = 20).x ~is 1
+  check p with (WY = 20).y ~is 20
+
+block:
+  import rhombus/meta open
+  class Posn(x, y):
+    update '$obj with $arg':
+      'block: $obj; ('$arg')'
+  check Posn(1, 2) with 99 +& "more" ~prints_like '99 +& "more"'
+
+block:
+  import rhombus/meta open
+  class Posn(x, y):
+    update '$obj with $arg $tail ...':
+      values('block: $obj; ('$arg')',
+             '$tail ...')
+  check Posn(1, 2) with 99 +& "more" ~is "99more"


### PR DESCRIPTION
Example:

```
 class Posn(x, y)
 Posn(1, 2) with (x = 10)
 // prints `Posn(10, 2)`
```

The general syntax is `obj_expr with (field_id = expr, ...)`. For an `obj_expr` with static information for class C, the result is obtained by calling the constructor for C with arguments from `obj_expr`'s field values, except that for each mentioned `field_id`, the result of the corresponding `expr` is used, instead.

A `class` declaration can replace `with` or fill it in for a custom constructor by using the new `udpdate` class-clause form, which is similar to `expression` or `annotation`.

The `with` form requires static information from `obj_expr` to identify a class. Otherwise, a syntax error is reported.

When a class is abstract or has a custom constructor, then there's no default implementation for `with`, but `update` can supply one.

The `with` syntax here is based on OCaml, but using parentheses instead of curly braces. I first tried `.with` and specialization via the existing `dot` clause in a class, but using `with` as a kind of magic name turned out to be clumsy (unsurprising in retrospect).

As of the initial PR, `update` is not allowed within `interface`, but probably it should be. A sensible implementation for an interface might call a method, instead of using a constructor.