### PR TITLE
add `where` for binding in the process of matching

### DIFF
--- a/rhombus/private/bind-macro.rkt
+++ b/rhombus/private/bind-macro.rkt
@@ -293,10 +293,10 @@
                       (let ([id id-ref] ... [arg-id #'arg-id])
                         (let-syntaxes ([(sid ...) sid-ref] ...)
                           (let ([IF-id #'if-bridge])
-                            (let ([success-id #'(parsed success)]
+                            (let ([success-id #'(parsed (maybe-definition success))]
                                   ;; putting `if-bridge` in `fail-id`
                                   ;; helps make sure it's used correctly
-                                  [fail-id #'(parsed (if-bridge IF fail))])
+                                  [fail-id #'(parsed (maybe-definition (if-bridge IF fail)))])
                               (unwrap-block
                                (rhombus-body-at block-tag body ...))))))])])))])])))
 
@@ -305,13 +305,13 @@
   ;; or definition context
   (let ([parse (lambda (stx)
                  (syntax-parse stx
-                   #:datum-literals (alts block parsed)
+                   #:datum-literals (alts block parsed maybe-definition)
                    [(form-id e ... (alts (block success ...)
                                          (block . fail-case)))
                     (syntax-parse #'fail-case
                       #:datum-literals (group parsed)
                       #:literals (if-bridge)
-                      [((group (parsed (if-bridge IF fail))))
+                      [((group (parsed (maybe-definition (if-bridge IF fail)))))
                        #`(IF (rhombus-expression (group e ...))
                              (rhombus-body-sequence success ...)
                              fail)]
@@ -328,7 +328,7 @@
   ;; depends on `IF` like `if-bridge` does
   (let ([parse (lambda (rhombus stx)
                  (syntax-parse stx
-                   #:datum-literals (parsed group parens)
+                   #:datum-literals (parsed group parens maybe-definition)
                    [(_ (parens (group arg-id:identifier)
                                (group (parsed (matcher-id committer-id binder-id data)))
                                (group if-id)
@@ -336,7 +336,7 @@
                                (group fail ...)))
                     (syntax-parse #'(fail ...)
                       #:literals (if-bridge)
-                      [((parsed (if-bridge IF fail)))
+                      [((parsed (maybe-definition (if-bridge IF fail))))
                        #:with rhombus rhombus
                        (syntax-parse #'(success ...)
                          [((_::block g ...))

--- a/rhombus/private/class-method-result.rkt
+++ b/rhombus/private/class-method-result.rkt
@@ -9,6 +9,7 @@
          (submod "annotation.rkt" for-class)
          "binding.rkt"
          "static-info.rkt"
+         "dot-provider-key.rkt"
          "call-result-key.rkt"
          "function-arity-key.rkt"
          "index-result-key.rkt"
@@ -89,14 +90,14 @@
               (syntax-e #'maybe-append-statinfo-id+id))
           (define (gen id)
             (if (syntax-e id)
-              #`((define-static-info-syntax #,id
-                   #,(if (eq? (syntax-e #'kind) 'property)
-                         #`(#%call-results-at-arities ((1 all-static-infos)))
-                         #`(#%call-result all-static-infos))
-                   #,@(if (syntax-e #'arity)
-                          #`((#%function-arity arity))
-                          #'())))
-              #'()))
+                #`((define-static-info-syntax #,id
+                     #,(if (eq? (syntax-e #'kind) 'property)
+                           #`(#%call-results-at-arities ((1 all-static-infos)))
+                           #`(#%call-result all-static-infos))
+                     #,@(if (syntax-e #'arity)
+                            #`((#%function-arity arity))
+                            #'())))
+                #'()))
           (define (gen-bounce ind-id+id key result-key)
             (if (syntax-e ind-id+id)
                 (syntax-parse ind-id+id

--- a/rhombus/private/composite.rkt
+++ b/rhombus/private/composite.rkt
@@ -286,7 +286,10 @@
 (define-syntax (maybe-repetition-as-list stx)
   (syntax-parse stx
     [(_ id (_ ... 0 _ ...)) #'(rhombus-expression (group id))]
-    [(_ id (_ ... depth:exact-integer _ ...)) (repetition-as-list (quote-syntax ...) #'(group id) (syntax-e #'depth))]))
+    [(_ id (_ ... depth:exact-integer _ ...))
+     ;; unchecked, because this may be an internal identifier where expansion
+     ;; hasn't bothered to bind the identifier as a repetition
+     (repetition-as-list/unchecked #'(group id) (syntax-e #'depth))]))
 
 (define-syntax-rule (if/blocked tst thn els)
   (if tst (let () thn) els))

--- a/rhombus/private/core-derived.rkt
+++ b/rhombus/private/core-derived.rkt
@@ -6,5 +6,6 @@
         "maybe.rhm"
         "string.rhm"
         "when_unless.rhm"
+        "where.rhm"
         "described_as.rhm"
         "sequence.rhm")

--- a/rhombus/private/core.rkt
+++ b/rhombus/private/core.rkt
@@ -151,6 +151,9 @@
   (define (get-info-proc key default make-default)
     (case key
       [(drracket:default-extension) "rhm"]
+      [(drracket:define-popup) '(("def" "def" "δ" [case-sensitive delimited])
+                                 ("fun" "fun" "δ" [case-sensitive delimited])
+                                 ("class" "class" "δ" [case-sensitive delimited]))]
       [else (shrubbery:get-info-proc key default make-default)])))
 
 (module configure-runtime racket/base

--- a/rhombus/private/pack.rkt
+++ b/rhombus/private/pack.rkt
@@ -47,6 +47,7 @@
          pack-group*
          unpack-group*
          unpack-maybe-group*
+         unpack-group-list*
          pack-multi*
          pack-tagged-multi*
          pack-block*
@@ -155,6 +156,16 @@
     [(list? r) (for/list ([e (in-list r)])
                  (unpack-term e who at-stx))]
     [else (list (datum->syntax at-stx r))]))
+
+;; Unpacks a multi-group sequence into a list of groups,
+;; but otherwise produces a list with one group. A list is
+;; treated as a list of elements instead of a list of groups
+(define (unpack-group-list r who at-stx)
+  (cond
+    [(and (syntax? r)
+          (multi-syntax? r))
+     (cdr (syntax->list r))]
+    [else (list (unpack-group r who at-stx))]))
 
 ;; `r` is a sequence of groups
 (define (pack-multi r)
@@ -279,6 +290,9 @@
   (unpack* qs r depth (lambda (form who at-stx)
                         (and form
                              (unpack-group form who at-stx)))))
+
+(define (unpack-group-list* qs r depth)
+  (unpack* qs r depth unpack-group-list))
 
 ;; Packs to a `multi` form
 (define (pack-multi* stxes depth)

--- a/rhombus/private/parse.rkt
+++ b/rhombus/private/parse.rkt
@@ -28,6 +28,8 @@
 
          rhombus-top-step
 
+         maybe-definition
+
          (for-syntax :declaration
                      :nestable-declaration
                      :definition
@@ -209,7 +211,10 @@
 (define-syntax (rhombus-body-sequence stx)
   (with-syntax-error-respan
     (syntax-parse (syntax-local-introduce stx)
+      #:datum-literals (group parsed)
       [(_) #'(begin)]
+      [(_ (group (parsed ((~literal maybe-definition) e))) . tail)
+       #`(begin e . tail)]
       [(_ e::definition-sequence . tail)
        (define-values (parsed new-tail)
          (apply-definition-sequence-transformer #'e.id #'e.tail #'tail))
@@ -227,6 +232,11 @@
         #`(begin
             (#%expression e.parsed)
             (rhombus-body-sequence . tail)))])))
+
+;; Wraps a `parsed` term that can be treated as a definition:
+(define-syntax (maybe-definition stx)
+  (syntax-parse stx
+    [(_ e) #'e]))
 
 ;; For an expression context:
 (define-syntax (rhombus-expression stx)

--- a/rhombus/private/quasiquote.rkt
+++ b/rhombus/private/quasiquote.rkt
@@ -128,6 +128,7 @@
                    #f))]
       [((~and tag (~or parens brackets braces quotes multi block alts group))
         g ...)
+       (define in-block? (eq? (syntax-e #'tag) 'block))
        ;; Note: this is where `depth` would be incremented, when `tag` is `quotes`, if we wanted that
        (let loop ([gs #'(g ...)] [pend-idrs #f] [pend-sidrs #f] [pend-vars #f]
                                  [idrs '()]  ; list of #`[#,id #,rhs] for definitions
@@ -501,7 +502,8 @@
                     (lambda ($-id e in-e)
                       (check-escape e)
                       (define id (car (generate-temporaries (list e))))
-                      (values id (list #`[#,id (pending-unpack #,e unpack-group* (quote-syntax #,$-id))]) null null))
+                      (values #`(#,(quote-syntax ~@) . #,id)
+                              (list #`[#,id (pending-unpack #,e unpack-group-list* (quote-syntax #,$-id))]) null null))
                     ;; handle-multi-escape:
                     (lambda ($-id e in-e splice?)
                       (check-escape e)

--- a/rhombus/private/syntax-object.rkt
+++ b/rhombus/private/syntax-object.rkt
@@ -117,6 +117,7 @@
    make_group
    make_sequence
    make_id
+   make_temp_id
    unwrap
    unwrap_op
    unwrap_group
@@ -282,6 +283,10 @@
     (raise-argument-error* 'Syntax.make_id rhombus-realm "StringView" str))
   (datum->syntax (extract-ctx 'Syntax.make_id ctx)
                  (string->symbol str)))
+
+(define/arity (make_temp_id [v #false])
+  #:static-infos ((#%call-result #,syntax-static-infos))
+  (car (generate-temporaries (list v))))
 
 (define/arity (unwrap v)
   (cond

--- a/rhombus/private/where.rhm
+++ b/rhombus/private/where.rhm
@@ -1,0 +1,109 @@
+#lang rhombus/private/core
+import:
+  "core-meta.rkt" open
+
+export:
+  where
+
+expr.macro
+| 'where':
+    ~op_stx self
+    syntax_meta.error("misuse as an expression", self)
+| '$left where':
+    ~op_stx self
+    syntax_meta.error("misuse in an expression", self)
+
+meta:
+  syntax_class Bind_Right_Expr:
+    kind: ~group
+  | '$bind ... = $expr'
+  | '$bind ...: $(body :: Block)':
+      field expr = 'block $body'
+
+bind.macro
+| '$bind_left where:«»':
+    bind_left
+| '$bind_left where:
+     $(bind_right_expr :: Bind_Right_Expr)
+     ...':
+    def ['$(bind_r :: bind_meta.Parsed)', ...] = ['$bind_right_expr.bind ...', ...]
+    bind_meta.pack('(where_infoer,
+                     ($bind_left, ($bind_r, $bind_right_expr.expr), ...))')
+| '$bind_left where $bind_right ... = $expr ...':
+    def '$(bind_r :: bind_meta.Parsed)' = '$bind_right ...'
+    bind_meta.pack('(where_infoer,
+                     ($bind_left, ($bind_r, $expr ...)))')
+
+bind.infoer 'where_infoer($static_info, ($bind_a, ($bind_b, $b_expr), ...))':
+  def a_info: bind_meta.get_info(bind_a, static_info)
+  def [b_info, ...]: [bind_meta.get_info(bind_b, '()'), ...]
+  def '($a_ann, $a_name, $a_static_info, $a_var_info, $_, $_, $_, $_)':
+    bind_meta.unpack_info(a_info)
+  def ['($b_ann, $b_name, $b_static_info, $b_var_info, $_, $_, $_, $_)', ...]:
+    [bind_meta.unpack_info(b_info), ...]
+  def [b_tmp_id, ...] = [Syntax.make_temp_id(b_name), ...]
+  def '(($a_var_id, [$a_var_use, ...], $a_statinfo), ...)': a_var_info
+  def ['(($b_var_id, [$b_var_use, ...], $b_statinfo), ...)', ...]: [b_var_info, ...]
+  def [[b_keep_statinfo, ...], ...]:
+    // keep only last b's statinfos, since others are bound early
+    def len = [[b_statinfo, ...], ...].length()
+    for List:
+      each:
+        statinfos: [[b_statinfo, ...], ...]
+        i: 0..
+      if i == len-1
+      | statinfos
+      | statinfos.map(fun (_): '()')
+  def ann: Syntax.unwrap(a_ann) +& " where ...."
+  '($ann,
+    $a_name,
+    $a_static_info,
+    (($a_var_id, [$a_var_use, ..., ~no_let], ()), ..., // drop static info, because we bind it manually
+     ($b_var_id, [$b_var_use, ..., ~no_let], $b_keep_statinfo), ..., ...),
+    where_matcher,
+    where_committer,
+    where_binder,
+    ($a_info, ($b_info, $b_tmp_id, $b_expr), ...))'
+
+bind.matcher 'where_matcher($in_id, ($a_info, ($b_info, $b_tmp_id, $b_expr), ...),
+                            $IF, $success, $failure)':
+  def '($_, $_, $_, $a_var_info, $a_matcher, $a_committer, $a_binder, $a_data)':
+    bind_meta.unpack_info(a_info)
+  def '(($a_var_id, $a_var_use, $a_statinfo), ...)': a_var_info
+  '«$a_matcher($in_id, $a_data, $IF,
+               : $a_committer($in_id, $a_data)
+                 $a_binder($in_id, $a_data)
+                 statinfo.macro '$a_var_id': '$a_statinfo'
+                 ...
+                 $(block:
+                     fun
+                     | loop([], [], []):
+                         '$success'
+                     | loop([b_info, & b_infos], [b_tmp_id, & b_tmp_ids], [b_expr, & b_exprs]):
+                         def '($_, $b_name, $_, $b_var_info, $b_matcher, $b_committer, $b_binder, $b_data)':
+                           bind_meta.unpack_info(b_info)
+                         def '(($b_var_id, $b_var_use, $b_statinfo), ...)': b_var_info
+                         'def $b_tmp_id:
+                            let $b_name = $b_expr
+                            $b_name
+                          $b_matcher($b_tmp_id, $b_data, $IF,
+                                     : $(if b_infos != []
+                                         | '«$b_committer($b_tmp_id, $b_data)
+                                             $b_binder($b_tmp_id, $b_data)
+                                             statinfo.macro '$b_var_id': '$b_statinfo'
+                                             ...»'
+                                         | '')
+                                       $(loop(b_infos, b_tmp_ids, b_exprs)),
+                                     $failure)'
+                     loop([b_info, ...], [b_tmp_id, ...], [b_expr, ...])),
+               $failure)»'
+
+bind.committer 'where_committer($in_id, ($a_info, $b, ..., ($b_info, $b_tmp_id, $b_expr)))':
+  def '($_, $_, $_, $_, $b_matcher, $b_committer, $b_binder, $b_data)':
+    bind_meta.unpack_info(b_info)
+  '$b_committer($b_tmp_id, $b_data)'
+
+bind.committer 'where_binder($in_id, ($a_info, $b, ..., ($b_info, $b_tmp_id, $b_expr)))':
+  def '($_, $_, $_, $_, $b_matcher, $b_committer, $b_binder, $b_data)':
+    bind_meta.unpack_info(b_info)
+  '$b_binder($b_tmp_id, $b_data)'

--- a/rhombus/scribblings/ref-boolean.scrbl
+++ b/rhombus/scribblings/ref-boolean.scrbl
@@ -114,6 +114,9 @@
  static information from @rhombus(left_bind) is propagated to
  @rhombus(right_bind) (but not the other way around).
 
+ See @rhombus(where, ~bind) for a different kind of ``and'' binding that
+ allows the right-hand side to refer to bindings from the left-hand side.
+
 @examples(
   class Posn(x, y)
   fun three_xs(v):

--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -16,6 +16,7 @@ normally bound to implement function calls.
   "function"
   @rhombus(Function)
   [f.map(args, ...), Function.map(f, args, ...)]
+  [f.for_each(args, ...), Function.for_each(f, args, ...)]
 )
 
 @doc(
@@ -375,17 +376,21 @@ Only one @rhombus(~& map_bind) can appear in a @rhombus(rest) sequence.
 
 @doc(
   fun Function.map(f :: Function, args :: List, ...) :: List,
+  fun Function.for_each(f :: Function, args :: List, ...) :: Void,
 ){
 
  Applies @rhombus(f) to each element of each @rhombus(args), iterating
  through the @rhombus(args) lists together, so @rhombus(f) must take as
- many arguments as the number of given @rhombus(args) lists. The result
- is a list constaining the result of each call to @rhombus(f) in
- order.
+ many arguments as the number of given @rhombus(args) lists. For
+ @rhombus(Function.map), the result is a list constaining the result of
+ each call to @rhombus(f) in order. For @rhombus(Function.for_each), the
+ result is @rhombus(#void), and the result of each call to @rhombus(f) is
+ ignored.
 
 @examples(
   Function.map(fun (x, y): x + y, [1, 2, 3], [4, 5, 6])
   (fun (x, y): x + y).map([1, 2, 3], [4, 5, 6])
+  println.for_each([1, 2, 3])
 )
 
 }

--- a/rhombus/scribblings/ref-list.scrbl
+++ b/rhombus/scribblings/ref-list.scrbl
@@ -31,6 +31,7 @@ it supplies its elements in order.
   [list.drop_left(lst, n), List.drop_left(lst, n)]
   [list.drop_right(lst, n), List.drop_right(lst, n)]
   [lst.map(func), List.map(lst, func)]
+  [lst.for_each(func), List.for_each(lst, func)]
   [lst.sort(arg, ...), List.sort(lst, arg, ...)]
 )
 
@@ -283,15 +284,17 @@ it supplies its elements in order.
 }
 
 @doc(
-  fun List.map(args :: List, f :: Function) :: List,
+  fun List.map(args :: List, f :: Function.of_arity(1)) :: List,
+  fun List.for_each(args :: List, f :: Function.of_arity(1)) :: List,
 ){
 
- Like @rhombus(Function.map), but with a single list of arguments first,
- with the function supplied second.
+ Like @rhombus(Function.map) and @rhombus(Function.for_each), but with a
+ single list of arguments first, with the function supplied second.
 
 @examples(
   List.map([1, 2, 3], fun (x): x + 1)
   [1, 2, 3].map(fun (x): x + 1)
+  [1, 2, 3].for_each(println)
 )
 
 }

--- a/rhombus/scribblings/ref-match.scrbl
+++ b/rhombus/scribblings/ref-match.scrbl
@@ -87,3 +87,73 @@
 )
 
 }
+
+
+@doc(
+  ~nonterminal:
+    left_bind: def bind
+    right_bind: def bind
+
+  bind.macro '$left_bind where $right_bind = $expr'
+  bind.macro '$left_bind where:
+                $right_bind_and_expr
+                ...'
+
+  grammar right_bind_and_expr:
+    $right_bind = $expr
+    $right_bind:
+      $body
+      ...
+){
+
+ Creates a binding that matches only when both @rhombus(left_bind)
+ matches and when each @rhombus(right_bind) matches the value of the
+ corresponding @rhombus(expr) or @rhombus(body) sequence. Names bound by
+ @rhombus(left_bind) and each @rhombus(right_bind) are visible in
+ @rhombus(expr)s and @rhombus(body) sequences for subsequent
+ @rhombus(right_bind)s.
+
+ The @rhombus(where) form should generally be used with parentheses
+ around it, since parsing is otherwise likely to interact badly with the
+ enclosing context, such as conflicting interpretations of a @rhombus(=)
+ by @rhombus(where) and @rhombus(def).
+
+@examples(
+  ~repl:
+    def ([x, y, z] where sum = x+y+z) = [1, 2, 3]
+    '$x $y $z'
+    sum
+  ~defn:
+    fun | f(([x, y, z] where sum = x+y+z) when sum == 6):
+            '$x $y $z = $sum'
+        | f(_):
+            "something else"
+  ~repl:
+    f([1, 2, 3])
+    f([0, 2, 3])
+  ~repl:
+    def ([x, y, z] where:
+           partial_sum = x+y
+           sum = partial_sum+z):
+      [1, 2, 3]
+    sum
+  ~repl:
+    def ([xs] where [x, ...] = xs): [[1, 2, 3]]
+    '$x ...'
+  ~repl:
+    ~error:
+      def ([xs] where [x, ...] = xs): ["oops"]
+)
+
+}
+
+
+@doc(
+  expr.macro 'where'
+  expr.macro '$left_bind where'
+){
+
+ As an expression operator, @rhombus(where) always reports a syntax
+ error.
+
+}

--- a/rhombus/scribblings/ref-stxobj.scrbl
+++ b/rhombus/scribblings/ref-stxobj.scrbl
@@ -99,7 +99,7 @@ Metadata for a syntax object can include a source location and the raw
 )
 
  The result of the expression after @rhombus($) can be a list, in which
- case and the elements of the list are spliced in place of the
+ case and the elements of the list are spliced as terms in place of the
  @rhombus($) term and expression witin the enclosing group. If the result
  is a syntax object, it can be a single-term syntax object or a group
  syntax object; in the latter case, the group terms are spliced in place
@@ -108,6 +108,14 @@ Metadata for a syntax object can include a source location and the raw
 @examples(
   'x $[1, 2, 3] z'
   'x $('1 2 3') z'
+)
+
+ Similarly, when an @rhombus($) escape is alone within its enclosing group, then the
+ result of the expression after @rhombus($) can be a multi-group syntax object,
+ in which case the group sequence is spliced in place of the escape.
+
+@examples(
+  'x; $('1; 2 3; 4'); z'
 )
 
  A @dots as a @rhombus(term,~var) must follow a
@@ -604,7 +612,7 @@ Metadata for a syntax object can include a source location and the raw
 
 @doc(
   fun Syntax.make_op(name :: Symbol,
-                     ctx_stx :: maybe(Term) = #false) :: Syntax
+                     ctx_stx :: maybe(Term) = #false) :: Operator
 ){
 
  Convenience to convert a plain symbol to a syntax object for an
@@ -619,13 +627,30 @@ Metadata for a syntax object can include a source location and the raw
 }
 
 @doc(
-  fun Syntax.make_id(str :: String, ctx_stx :: maybe(Term) = #false) :: Syntax
+  fun Syntax.make_id(str :: String, ctx_stx :: maybe(Term) = #false) :: Identifier
 ){
 
  Composes @rhombus(Syntax.make) and @rhombus(Symbol.from_string).
 
 @examples(
   Syntax.make_id("hello" +& 7, 'here')
+)
+
+}
+
+
+@doc(
+  fun Syntax.make_temp_id(name = #false) :: Identifier
+){
+
+ Creates an identifier with a fresh scope, which is useful for creating
+ a temporary binding. The @rhombus(name) argument can be any value, and
+ the name of the generated identifier may be derived from @rhombus(name)
+ for debugging purposes (especially if it is a string, symbol, or
+ identifier).
+
+@examples(
+  Syntax.make_temp_id("hello")
 )
 
 }

--- a/rhombus/scribblings/syntax.scrbl
+++ b/rhombus/scribblings/syntax.scrbl
@@ -213,8 +213,9 @@ term escape, even if it is not at the end of the group.
     '0 + $x + 4'
 )
 
-A multi-group syntax object will not splice multiple
-groups in place of a group escape, because that turns out to create
+A multi-group syntax object splices multiple groups in place of a group
+escape only when the escape is alone in its group. A list of group syntax
+objects does not splice into group contexts, because that would create
 ambiguities among group and term contexts. Meanwhile, a single-term
 syntax object can be used as a group syntax object, a single-group
 syntax object can be used as a multi-group syntax object, and a

--- a/rhombus/tests/fun.rhm
+++ b/rhombus/tests/fun.rhm
@@ -177,3 +177,13 @@ check:
   fun f(x = "hello" :: String):
     "ok"
   ~raises "immediate annotation operator not allowed in default-value expression"
+
+check:
+  use_static
+  (fun (x): x + 1).map([1, 2, 3]).length()
+  ~is 3
+
+check:
+  use_static
+  (fun (x): x + 1).for_each([1, 2, 3])
+  ~is #void

--- a/rhombus/tests/list.rhm
+++ b/rhombus/tests/list.rhm
@@ -6,6 +6,8 @@ block:
     List(l, ...)
     List.length(lst)
     List.cons(a, d)
+    List.map(lst, proc)
+    List.for_each(lst, proc)
 
 check:
   List.length([1, 2, 3])
@@ -110,9 +112,12 @@ check:
   [1, 2].reverse().reverse()
   ~is [1, 2]
 
-check:
-  [1, 2].map(fun (x): x + 1).reverse()
-  ~is [3, 2]
+block:
+  check [1, 2].map(fun (x): x + 1).reverse() ~is [3, 2]
+  block:
+    def mutable sum = 0
+    check [1, 2].for_each(fun (x): sum := sum + x) ~is #void
+    check sum ~is 3
 
 check:
   List.append(&[[1, 2], [3], [4, 5]]) ~is [1, 2, 3, 4, 5]

--- a/rhombus/tests/quasiquote.rhm
+++ b/rhombus/tests/quasiquote.rhm
@@ -134,3 +134,8 @@ check:
   def g = ''
   '3 + (1, $g $g)'
   ~raises "generated an empty group"
+
+check:
+  def ['(($b_var_id), ...)', ...]: ['((1), (2 2), (3))', '((4))']
+  [b_var_id, ..., ...]
+  ~prints_like ['1', '2 2', '3', '4']

--- a/rhombus/tests/syntax-kind-interchange.rhm
+++ b/rhombus/tests/syntax-kind-interchange.rhm
@@ -68,12 +68,27 @@ check:
 check:
   def none = '1; 2'
   'x; $none; y'
-  ~raises "multi-group syntax not allowed in group context"
+  ~prints_like 'x; 1; 2; y'
+
+check:
+  def none = ['1', '2']
+  'x; $none; y'
+  ~prints_like 'x; 1 2; y'
+
+check:
+  def none = ['1', '2 3']
+  'x; $none; y'
+  ~raises "multi-term syntax not allowed in term context"
+
+check:
+  def none = []
+  'x; $none; y'
+  ~raises "cannot coerce empty list to group syntax"
 
 check:
   def none = ''
   'x; $none; y'
-  ~raises "multi-group syntax not allowed in group context"
+  ~prints_like 'x; y'
 
 check:
   def '$tail ...' = ''

--- a/rhombus/tests/where.rhm
+++ b/rhombus/tests/where.rhm
@@ -1,0 +1,69 @@
+#lang rhombus/static
+
+check:
+  match 1
+  | x where y = x+1:
+      y
+  ~is 2
+
+check:
+  match 1
+  | (x where:
+      y = x+1):
+      y
+  ~is 2
+
+check:
+  match 1
+  | (x where:
+      y: x+1):
+      y
+  ~is 2
+
+check:
+  def y = 0
+  block:
+    match 1
+    | (x where:
+         y = x+1
+         z = y+1):
+        [y, z]
+  ~is [2, 3]
+
+check:
+  def y = 0
+  block:
+    match 1
+    | ((x where:
+          y = x+1) where:
+         z = y+1):
+        [y, z]
+  ~is [2, 3]
+
+check:
+  def y = 0
+  block:
+    match 1
+    | (x where:
+         y = x+1
+         z: y+1):
+        [y, z]
+  ~is [2, 3]
+
+check:
+  match 1
+  | x where [y] = [x+1]:
+      y
+  ~is 2
+
+check:
+  match 1
+  | x where y :~ List = [0, 0, 0, x+1]:
+      y.length()
+  ~is 4
+
+check:
+  match 1:
+  | (x where:«»):
+      x
+  ~is 1


### PR DESCRIPTION
Like `when`, the `where` operator creates a side condition on a binding pattern match. Unlike `when`, `where` binds names that are visible in the same scope as the names bound by the left-hand pattern. A match successed only if both the main pattern and its `where` bindings all match.

Examples from the documentation:

```
    def ([x, y, z] where sum = x+y+z) = [1, 2, 3]
    '$x $y $z' // prints '1 2 3'
    sum // prints 6

    fun | f(([x, y, z] where sum = x+y+z) when sum == 6):
            '$x $y $z = $sum'
        | f(_):
            "something else"
    f([1, 2, 3]) // prints '1 2 3 = 6'
    f([0, 2, 3]) // prints "something else"

    def ([x, y, z] where:
           partial_sum = x+y
           sum = partial_sum+z):
      [1, 2, 3]
    partial_sum // prints 3
    sum // prints 6

    def ([xs] where [x, ...] = xs): [[1, 2, 3]]
    '$x ...' // prints '1 2 3'

    def ([xs] where [x, ...] = xs): ["oops"]
    // fails with a match error
```

Taken together, `when` and `where` allow many binding macros to implemented by rewriting, instead of resorting to the low-level binding protocol.

It's not clear that `where` is the best name. I worry that `where` and `when` are easy to confuse, but maybe that's just me. This `where` operator is unlike Haskell's `where`, but maybe those are far enough apart that it doesn't matter.