### PR TITLE
fix in-common-superinterface? gather condition

### DIFF
--- a/rhombus/private/class-method.rkt
+++ b/rhombus/private/class-method.rkt
@@ -450,7 +450,7 @@
         (gather (lookup int-id) ht saw-abstract?))))
   (define (gather i ht saw-abstract?)
     (cond
-      [i
+      [(and i (hash-has-key? (super-method-map i) key))
        (define idx (hash-ref (super-method-map i) key))
        (define impl (vector-ref (super-method-vtable i) idx))
        (cond

--- a/rhombus/tests/in-common-superinterface-gather-condition.rhm
+++ b/rhombus/tests/in-common-superinterface-gather-condition.rhm
@@ -1,0 +1,24 @@
+#lang rhombus
+
+interface S
+
+interface CV:
+  extends S
+  // read-only property
+  property size :: Int
+
+interface MC:
+  extends CV
+  method clear() :: Void
+
+class AVS():
+  nonfinal
+  implements CV
+  override property size: 0
+
+class AMS():
+  extends AVS
+  implements MC
+  override method clear(): #void
+
+check: AMS().size ~is 0


### PR DESCRIPTION
To avoid an error message like
```
.../rhombus/private/class-method.rkt:454:19: Map.get: no value found for key
  key: #'size
```
while it's looking for `size` in a super-interface that doesn't have `size`, like `S` in
```
interface S

interface CV:
  extends S
  // read-only property
  property size :: Int
```