### PR TITLE
scribble/rhombus: fix braces case in spacer

### DIFF
--- a/scribble/private/spacer.rhm
+++ b/scribble/private/spacer.rhm
@@ -43,7 +43,7 @@ meta:
     | '[$(g :: Group), ...]':
         '[$(adjust_group(g, context, esc)), ...]'.relocate(t)
     | '{$(g :: Group), ...}':
-        '[$(adjust_group(g, context, esc)), ...]'.relocate(t)
+        '{$(adjust_group(g, context, esc)), ...}'.relocate(t)
     | '«'$(g:: Group); ...'»':
         '«'$(adjust_group(g, context, esc)); ...'»'.relocate(t)
     | ': $_':


### PR DESCRIPTION
This fixes the incorrect rendering of braces expression with brackets.