### PR TITLE
add initial-`each` shorthand for `for`

### DIFF
--- a/rhombus/private/function-parse.rkt
+++ b/rhombus/private/function-parse.rkt
@@ -38,6 +38,7 @@
          (submod "equal.rkt" for-parse)
          (only-in "equal.rkt"
                   [= rhombus=])
+         "not-block.rkt"
          "dotted-sequence-parse.rkt"
          "lambda-kwrest.rkt"
          "error.rkt"
@@ -205,15 +206,6 @@
                            #f
                            (list #'eq2))]
       [_ (void)]))
-  
-  (define-syntax-class :not-block
-    #:datum-literals (op parens braces brackets quotes)
-    (pattern _:identifier)
-    (pattern (op . _))
-    (pattern (parens . _))
-    (pattern (braces . _))
-    (pattern (brackets . _))
-    (pattern (quotes . _)))
 
   (define-splicing-syntax-class :ret-annotation
     #:attributes (static-infos ; can be `((#%values (static-infos ...)))` for multiple results

--- a/rhombus/private/not-block.rkt
+++ b/rhombus/private/not-block.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse))
+
+(provide (for-syntax :not-block))
+
+(begin-for-syntax
+  (define-syntax-class :not-block
+    #:datum-literals (op parens braces brackets quotes)
+    (pattern _:identifier)
+    (pattern _:keyword)
+    (pattern (op . _))
+    (pattern (parens . _))
+    (pattern (braces . _))
+    (pattern (brackets . _))
+    (pattern (quotes . _))))

--- a/rhombus/private/reducer.rkt
+++ b/rhombus/private/reducer.rkt
@@ -5,6 +5,7 @@
                      enforest/property
                      enforest/proc-name
                      "introducer.rkt"
+                     (for-syntax racket/base)
                      "macro-result.rkt")
          "enforest.rkt")
 
@@ -19,8 +20,10 @@
            reducer-transformer
            :reducer
            :reducer-form
+           :infix-op+reducer+tail
            reducer
-           reducer/no-break)
+           reducer/no-break
+           reducer-quote)
 
   (property reducer-prefix-operator prefix-operator)
   (property reducer-infix-operator infix-operator)
@@ -58,6 +61,9 @@
       [_ (raise-bad-macro-result (proc-name proc) "reducer" form)]))
 
   (define in-reducer-space (make-interned-syntax-introducer/add 'rhombus/reducer))
+  (define-syntax (reducer-quote stx)
+    (syntax-case stx ()
+      [(_ id) #`(quote-syntax #,((make-interned-syntax-introducer 'rhombus/reducer) #'id))]))
   
   (define-rhombus-enforest
     #:syntax-class :reducer

--- a/rhombus/private/values.rkt
+++ b/rhombus/private/values.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require (for-syntax racket/base
-                     syntax/parse/pre)
+                     syntax/parse/pre
+                     "srcloc.rkt")
          "provide.rkt"
          "expression.rkt"
          "binding.rkt"
@@ -36,7 +37,7 @@
 (define-reducer-syntax values
   (reducer-transformer
    (lambda (stx)
-     (syntax-parse stx
+     (syntax-parse (respan stx)
        #:datum-literals (group op)
        [(_ (parens (group id:identifier _::equal rhs ...) ...) . tail)
         #:with (e::expression ...) #'((group rhs ...) ...)

--- a/rhombus/scribblings/for.scrbl
+++ b/rhombus/scribblings/for.scrbl
@@ -26,6 +26,14 @@ from a starting integer (inclusive) to an ending integer (exclusive):
     println(i)
 )
 
+As a shorthand, an initial @rhombus(each, ~for_clause) form can be written
+using parentheses before the @rhombus(for) body block:
+
+@demo(
+  for (i: 1..4):
+    println(i)
+)
+
 If a @rhombus(for) body includes multiple @rhombus(each, ~for_clause) clauses, they
 are nested. That is, for each element of the first @rhombus(each, ~for_clause) clause,
 all elements are used for the second @rhombus(each, ~for_clause) clause, and so on.
@@ -61,6 +69,16 @@ immediately after @rhombus(each, ~for_clause).
     println(index +& ". " +& friend)
 )
 
+Note that the shorthand form using parentheses for an initial
+@rhombus(each, ~for_clause) clause corresponds to this parallel mode,
+since the short is for a single @rhombus(each, ~for_clause) clause:
+
+@demo(
+  for (friend: ["Alice", "Bob", "Carol"],
+       index: 1..4):
+    println(index +& ". " +& friend)
+)
+
 In this latest example, the sequence for @rhombus(index) could be
 @rhombus(1..) to avoid needing the length of the list for
 @rhombus(friend). When @rhombus(..) has no second argument, it creates
@@ -74,8 +92,7 @@ accumulating the values produced by each iteration of the @rhombus(for)
 body.
 
 @demo(
-  for List:
-    each i: 1..4
+  for List (i: 1..4):
     "number " +& i
   for List:
     each i: [1, 2]
@@ -87,8 +104,7 @@ If you prefer, you can put the reducer at the end of a @rhombus(for)
 body with @rhombus(~into).
 
 @demo(
-  for:
-    each i: 1..4
+  for (i: 1..4):
     "number " +& i
     ~into List
 )
@@ -98,10 +114,8 @@ body with @rhombus(~into).
 a value.
 
 @demo(
-  for Map:
-    each:
-      friend: ["alice", "bob", "carol"]
-      index: 1..
+  for Map (friend: ["alice", "bob", "carol"],
+           index: 1..):
     values(index, friend)
 )
 

--- a/rhombus/scribblings/ref-for.scrbl
+++ b/rhombus/scribblings/ref-for.scrbl
@@ -6,19 +6,25 @@
 @title{Iteration}
 
 @doc(
-  expr.macro 'for:
+  expr.macro 'for $maybe_each:
                 $clause_or_body
                 ...
                 $body'
-  expr.macro 'for $reducer:
+  expr.macro 'for $reducer $maybe_each:
                 $clause_or_body
                 ...
                 $body'
-  expr.macro 'for:
+  expr.macro 'for $maybe_each:
                 $clause_or_body
                 ...
                 $body
                 ~into $reducer'
+  grammar maybe_each:
+    ($bind:
+       $body
+       ...,
+     ...)
+    #,(epsilon)
   grammar clause_or_body:
     #,(@rhombus(each, ~for_clause)) $bind:
       $body
@@ -40,8 +46,10 @@
     : : $body; ...      
 ){
 
- Iterates as determined by @rhombus(each, ~for_clause) clauses among the
- @rhombus(clause_or_body)s. An @rhombus(each, ~for_clause) clause forms one layer
+ Iterates as determined by @rhombus(maybe_each) and @rhombus(each, ~for_clause) clauses among the
+ @rhombus(clause_or_body)s, where a non-empty @rhombus(maybe_each) is converted to
+ an initial @rhombus(each, ~for_clause) before all @rhombus(clause_or_body)s.
+ An @rhombus(each, ~for_clause) clause forms one layer
  of iteration; each subsequent part of the body is evaluated once per
  iteration, and additional @rhombus(each, ~for_clause) groups form nested
  iterations.
@@ -91,6 +99,8 @@
 
 @examples(
   ~repl:
+    for (v: ["a", "b", "c"]):
+      println(v)
     for:
       each v: ["a", "b", "c"]
       println(v)
@@ -110,6 +120,9 @@
       each v: ["a", "b", "c"]
       final_when v == "b"
       println(v)
+    for (v: ["a", "b", "c"],
+         i: 0..):
+      println(i +& ". " +& v)
     for:
       each:
         v: ["a", "b", "c"]

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -8,6 +8,11 @@ block:
       accum := List.cons(i, accum)
     accum
     ~is [1, 0]
+  check:
+    for (i: 0..2):
+      accum := List.cons(i + 10, accum)
+    accum
+    ~is [11, 10, 1, 0]
 
 check:
   for List:
@@ -16,8 +21,18 @@ check:
   ~is [0, 1]
 
 check:
+  for List (i: 0..2):
+    i
+  ~is [0, 1]
+
+check:
   for Map:
     each i: 0..2
+    values(i, "" +& i)
+  ~is {0: "0", 1: "1"}
+
+check:
+  for Map (i: 0..2):
     values(i, "" +& i)
   ~is {0: "0", 1: "1"}
 
@@ -29,8 +44,7 @@ check:
   ~is [0, 1]
 
 check:
-  for:
-    each i: 0..2
+  for (i: 0..2):
     i
     ~into List
   ~is [0, 1]
@@ -47,6 +61,12 @@ check:
     each:
       i: 0..2
       j: 0..2
+    [i, -j-1]
+  ~is [[0, -1], [1, -2]]
+
+check:
+  for List (i: 0..2,
+            j: 0..2):
     [i, -j-1]
   ~is [[0, -1], [1, -2]]
 
@@ -68,6 +88,13 @@ check:
   ~is [[1, -1], [1, -2], [2, -1], [2, -2]]
 
 check:
+  for List (i: 0..2):
+    def i_plus = i+1
+    each j: 0..2
+    [i_plus, -j-1]
+  ~is [[1, -1], [1, -2], [2, -1], [2, -2]]
+
+check:
   for List:
     each i: 0..2
     def i_len = i+1
@@ -78,6 +105,11 @@ check:
 check:
   for values(sum = 0):
     each i: 0..4
+    sum + i
+  ~is 6
+
+check:
+  for values(sum = 0) (i: 0..4):
     sum + i
   ~is 6
 
@@ -149,6 +181,11 @@ check:
   ~is {"3 -> c", "4 -> d"}
 
 check:
+  for Set ((key, val): {3: "c", 4: "d"}):
+    key +& " -> " +& val
+  ~is {"3 -> c", "4 -> d"}
+
+check:
   for Map:
     each key: {3, 4}
     values(key, key+1)
@@ -163,6 +200,17 @@ check:
 check:
   for Array ~length 6:
     each i: 3..7
+    i
+  ~prints_like Array(3, 4, 5, 6, 0, 0)
+
+check:
+  for Array ~length (1 + 5):
+    each i: 3..7
+    i
+  ~prints_like Array(3, 4, 5, 6, 0, 0)
+
+check:
+  for Array ~length 6 (i: 3..7):
     i
   ~prints_like Array(3, 4, 5, 6, 0, 0)
 
@@ -223,3 +271,31 @@ check:
                                "y": [4, 5] }
     [x, ...].reverse()
   ~is {[3, 2, 1], [5, 4]}
+
+check:
+  for values() ():
+    each i: 1..2
+    values()
+  ~is values()
+
+check:
+  for values():
+    each i: 1..2
+    values()
+  ~is values()
+
+check:
+  for values() ():
+    values()
+  ~is values()
+
+check:
+  for values():
+    values()
+  ~is values()
+
+check:
+  for values() ():
+    each:«»
+    values()
+  ~is values()


### PR DESCRIPTION
This commit changes `for` so that an initial `each` clause can be written with parentheses just before the `for` block. So, this change is sortof a step back toward Racket's `for`, but without a `for*` variant.

Examples

```
  for:
    each i: 1..4
    println(i)
  //  =>
  for (i: 1..4):
    println(i)

  for List:
    each i: 1..4
    i+1
  //  =>
  for List (i: 1..4):
    i+1

  for values(sum = 0):
    each i: 1..4
    sum+i
  //  =>
  for values(sum = 0) (i: 1..4):
    sum+i

  for:
    each:
      friend: ["Alice", "Bob", "Carol"]
      index: 1..4
    println(index +& ". " +& friend)
  //  =>
  for (friend: ["Alice", "Bob", "Carol"],
       index: 1..4):
    println(index +& ". " +& friend)
```

For all the current reducer forms, there turns out to be just one case of ambiguity. Only a `values` reducer can end in parentheses, and it requires `=` for each binding, while an `each` shorthand must use `:`. But in `for values(): ....`, the empty parentheses are parsed as an empty `each` shorthand, instead of an empty sequence of `values` bindings. This is a concern, and it's potentially a long-term concern as new reducers are written. So far, though, it seems like an ok compromise to me, since `values()` would be very rare as a reducer. It could be an issue for a macro that expands to `for values(....): ....`, though, where the macro writer would have to be careful to expand to `for values(....) (): ....`.

```
  for values(): // syntax error `values` expects more terms
    values()

  for values() (): // ok
    values()
```
