### PR TITLE
Improvements to Shrubbery and Enforestation references

### DIFF
--- a/enforest/operator.rkt
+++ b/enforest/operator.rkt
@@ -17,7 +17,8 @@
 ;; precedence than the one referenced by the identifier. An operator
 ;; is implicitly the 'same as itself (i.e., not covered by 'default).
 
-(provide operator?
+(provide operator
+         operator?
          operator-name
          operator-precedences
          operator-protocol

--- a/enforest/scribblings/api.scrbl
+++ b/enforest/scribblings/api.scrbl
@@ -25,7 +25,7 @@ types and one macro:
    property value must be a function that takes a structure
    implementing the property and returns a @racket[name-root] instance. The
    @racket[name-root] structure implements @racket[prop:name-root] with a function that
-   results the structure instance itself.}
+   results in the structure instance itself.}
 
  @item{An @racket[operator] structure type with @racket[infix-operator]
   and @racket[prefix-operator] structure subtypes. An @racket[operator]

--- a/enforest/scribblings/api.scrbl
+++ b/enforest/scribblings/api.scrbl
@@ -1,240 +1,334 @@
 #lang scribble/manual
+@(require (for-label enforest
+                     enforest/name-root
+                     enforest/operator
+                     enforest/transformer
+                     racket/base
+                     racket/contract/base
+                     syntax/parse))
 
 @title{Enforestation API}
 
-The Rhombus expander's primary API consists of three Racket structure
-types and one macro:
+@section{Name Roots}
 
-@itemlist[
+@defmodule[enforest/name-root]
 
- @item{A @racket[name-root] structure with one field:
+@defproc[(name-root [proc procedure?])
+         name-root?]{
 
-  @itemlist[
+ Returns an implementation of @racket[prop:name-root] with a function
+ that results in the structure instance itself.
 
-        @item{@racket[proc]: a transformer procedure, which takes an introducer
-        funciton and a syntactic list of tokens and returns two values: a new
-        head identifier or operator token, and a new tail syntactic list of
-        tokens. The introducer function corresponds to the space that is
-        otherwise used to lookup identifiers, which the transformer procedure
-        might take into account.}
+ The transformer procedure @racket[proc] takes an introducer funciton
+ and a syntax list of terms and returns two values: a new head
+ identifier or operator, and a syntax list of remaining terms. The
+ introducer function corresponds to the space that is otherwise used
+ to lookup identifiers, which the transformer procedure might take
+ into account.
 
-      ]
+}
 
-   A @racket[prop:name-root] structure type property is also provided, and
-   @racket[name-root?] refers to implementations of @racket[prop:name-root]. The
-   property value must be a function that takes a structure
-   implementing the property and returns a @racket[name-root] instance. The
-   @racket[name-root] structure implements @racket[prop:name-root] with a function that
-   results in the structure instance itself.}
+@defproc[(name-root-proc [v any/c])
+         procedure?]{
 
- @item{An @racket[operator] structure type with @racket[infix-operator]
-  and @racket[prefix-operator] structure subtypes. An @racket[operator]
-  structure has
+ Extracts the transformer procedure from @racket[v], which must be an
+ instance of @racket[name-root].
 
-  @itemlist[
-            
-      @item{@racket[name]: an identifier syntax object}
+}
 
-      @item{@racket[precs]: an association list from identifiers
-        to @racket['stronger], @racket['weaker], @racket['same], @racket['same-on-left], or
-        @racket['same-on-right], indicating that the
-        @racket[operator] instance's precedence is stronger than, weaker
-        than, or the same as (when on the indicated side of) the
-        associated identifier; @racket['default] can
-        be used instead of an identifier to specify a default
-        relationship}
+@defthing[prop:name-root struct-type-property?]{
 
-      @item{@racket[protocol]: @racket['macro] or @racket['automatic]}
+ A structure type property whose value must be a function that takes a
+ structure implementing the property and returns an instance of
+ @racket[name-root].
 
-      @item{@racket[proc]: a transformer procedure, where the arguments and
-        results depend on whether the operator is prefix or infix,
-        macro or automatic}
+}
 
-   ]
+@defproc[(name-root? [v any/c])
+         boolean?]{
 
-   A @racket[prefix-operator] has no additional fields.
+ Returns @racket[#t] if @racket[v] implements @racket[prop:name-root],
+ @racket[#f] otherwise.
 
-   An @racket[infix-operator] has one additional field:
+}
 
-   @itemlist[
+@defproc[(name-root-ref [v any/c])
+         any/c]{
 
-      @item{@racket[assoc]: @racket['left], @racket['right], or @racket['none]}
+ Returns an instance of @racket[name-root] if @racket[v] implements
+ @racket[prop:name-root], @racket[#f] otherwise.
 
-   ]
-   
-   These structure types are provided by the @racket[enforest/operator]
-   library.}
+}
 
- @item{A @racket[define-enforest] macro that parameterizes the enforestation
-   algorithm over the following, which are all optional:
+@section{Operators}
 
-   @itemlist[
+@defmodule[enforest/operator]
 
-   @item{@racket[#:enforest]: the name to bind as an enforest function
-      (defaults to a fresh name), which is used to start enforestation
-      of a group. It takes a list of S-expressions for parsed
-      shrubberies that were in a group, and it returns a parsed form.
-      The enforest function drives a loop that calls the
-      enforest-step function.}
+@defstruct*[operator ([name identifier?]
+                      [precs (listof (cons/c (or/c identifier? 'default)
+                                             (or/c 'stronger 'weaker
+                                                   'same 'same-on-left 'same-on-right)))]
+                      [protocol (or/c 'macro 'automatic)]
+                      [proc procedure?])
+            #:omit-constructor]{
 
-   @item{@racket[#:enforest-step]: the name to bind as an enforest-step function
-      (defaults to a fresh name), which continues an enforestation. It
-      takes two arguments, which is the list of renaming terms in a
-      group and the current operator. The result is two values: a
-      parsed form and the remaining sequence of terms (starting with
-      an infix operator that has lower precedence than the input
-      operator).}
+ The @racket[name] identifier is the name of the operator.
 
-   @item{@racket[#:syntax-class]: the name of a syntax class (see
-      @racket[syntax-parse]) to bind (defaults to a fresh name), which
-      matches a @racket[group] shrubbery representation and enforests it. A
-      match has an @racket[parsed] attribute representing the enforestation
-      result.}
+ The @racket[precs] list is an association list from identifiers to
+ @racket['stronger], @racket['weaker], @racket['same],
+ @racket['same-on-left], or @racket['same-on-right], indicating that
+ the operator's precedence is stronger than, weaker than, or the same
+ as (when on the indicated side of) the associated identifier;
+ @racket['default] can be used instead of an identifier to specify a
+ default relationship.
 
-  @item{@racket[#:relative-precedence]: an optional name to bind as a
-      function that compares the precedence of two operators. The
-      function takes four arguments: @racket['infix] or
-      @racket['prefix] for the left operator's mode, the left
-      operator's identifier, @racket['infix] or @racket['prefix] for
-      the right operator's mode, and the right operator's identifier.
-      The result is either @racket['stronger] (left takes precedence),
-      @racket['weaker] (right takes precedence), or an error results:
-      @racket[#f] (no relation), @racket['inconsistent-prec],
-      @racket['inconsistent-assoc], @racket['same] (error because no
-      associativity), @racket['same-on-left] (error because on right),
-      @racket['unbound] (one of the operators is not bound).}
+ The @racket[protocol] is either @racket['macro] for
+ @tech{macro protocol} or @racket['auto] for
+ @tech{automatic protocol}.
 
-   @item{@racket[#:prefix-more-syntax-class] and @racket[#:infix-more-syntax-class]:
-      names of syntax classes (defaulting to fresh names) that take
-      an operator-name argument and match a group that's intended to represent
-      the tail of a group. The syntax class continues
-      enforestation based on the precedence and associatvity of the given operator.
-      A match has a @racket[parsed] attribute for the parsed
-      result and a @racket[tail] attribute for the remaining terms in
-      a group.}
+ The @racket[proc] transformer procedure depends on the mode (prefix
+ or infix) as well as the @racket[protocol] for its arguments and
+ results.
 
-    @item{@racket[#:desc] and @racket[#:operator-desc]: strings used in error reporting
-      to refer to a form or an operator for a form. The defaults are
-      @racket["form"] and @racket["operator"].}
+ This structure type should not be used directly. Instead, use its
+ subtypes @racket[prefix-operator] and @racket[infix-operator].
 
-    @item{@racket[#:in-space]: a function that takes an identifier syntax object
-      and adds a space scope if the enforesting context uses a space.
-      The default is @racket[values].}
+}
 
-    @item{@racket[#:prefix-operator-ref] and @racket[#:infix-operator-ref]: functions
-      that take a compile-time value and extract an instance of
-      @racket[prefix-operator] or @racket[infix-operator], respectively, if the
-      value has one suitable for the context, returning @racket[#f]
-      otherwise. Normally, these functions use structure-property
-      accessors. The defaults are @racket[prefix-operator-ref] and
-      @racket[infix-operator-ref].}
+@defstruct*[(prefix-operator operator) ()]{
 
-    @item{@racket[#:name-path-op]: an operator name that is recognized after a
-      name-root identifier for hierarhical name references. The
-      default is @racket['|.|].}
+ If the @racket[protocol] is @racket['macro], @racket[proc] takes a
+ syntax list of terms consisting of all remaining terms (including the
+ operator term) in the enclosing group and returns two values: a
+ parsed form, and a syntax list of remaining terms.
 
-    @item{@racket[#:name-root-ref]: a function that takes a
-      compile-time value and extracts an instance of
-      @racket[name-root], used only on the compile-time value of an
-      identifier that is followed by the @racket[#:name-path-op]
-      operator.}
+ If the @racket[protocol] is @racket['auto], @racket[proc] takes two
+ arguments: a parsed right-hand form and the operator name, and
+ returns a further parsed form.
 
-    @item{@racket[#:check-result]: a function that takes the result of an
-      operator and checks whether the result is suitable for the
-      context, used for earlier detection of errors; the
-      @racket[check-result] function should either raise an exception or
-      return its argument (possibly adjusted). A second argument to
-      the function is the procedure that produced the result, which
-      can be used for error checking. The default function checks that
-      its first argument is a syntax object and returns it.}
+}
 
-    @item{@racket[#:make-identifier-form]: a function that takes an identifier an
-      produces a suitable parsed form. If a context does not have a
-      meaning for unbound identifiers, @racket[make-identifier-form] can
-      report a syntax error. The default is @racket[values].}
+@defproc[(prefix-operator-ref [v any/c])
+         any/c]{
 
-    @item{@racket[#:make-operator-form]: a function that takes an operator an
-      produces a suitable parsed form, or @racket[#f] to have an error
-      tiggered for an unbound operator in an expression position.}
+ Returns @racket[v] if it is an instance of @racket[prefix-operator],
+ @racket[#f] otherwise.
 
-    @item{@racket[#:juxtapose-implicit-name]: a symbol for the implicit infix
-      form used on an identifier after a parsed term with no infix
-      operator in between. The default is @racket['#%juxtapose].}
+}
 
-    @item{@racket[#:select-implicit-prefix]: a function that takes a term within
-      a group that is not an operator and does not follow an infix
-      operator. The result should be two values: a symbol for an
-      implicit prefix form name and a syntax object whose lexical
-      context is added to the symbol to look up the implement binding.
-      The default is described in @secref["implicit-ops"].}
+@defstruct*[(infix-operator operator) ([assoc (or/c 'left 'right 'none)])]{
 
-    @item{@racket[#:select-implicit-infix]: a function that takes a term within a
-      group that is not an operator and follows a parsed term. The
-      result should be two values: a symbol for an implicit infix form
-      name and a syntax object whose lexical context is added to the
-      symbol to look up the implement binding. The default is
-      described in @secref["implicit-ops"].}
+ The @racket[assoc] is either @racket['left] for left-associativity,
+ @racket['right] for right-associativity, or @racket['none] for
+ non-associativity.
 
-    ]
+ If the @racket[protocol] is @racket['macro], @racket[proc] takes two
+ arguments: a parsed left-hand form and a syntax list of terms
+ consisting of all remaining terms (including the operator term) in
+ the enclosing group, and returns two values: a parsed form, and a
+ syntax list of remaining terms.
 
-   The @racket[define-enforest] macro is provided by the @racket[enforest] library.}
+ If the @racket[protocol] is @racket['auto], @racket[proc] takes three
+ arguments: a parsed left-hand form, a parsed right-hand form, and the
+ operator name, and returns a further parsed form.
 
- ]
+}
 
-To support simple contexts that have only prefix transformers and name
-roots, the Rhombus expander API provides an additional structure type
-and macro:
+@defproc[(infix-operator-ref [v any/c])
+         any/c]{
 
-@itemlist[
+ Returns @racket[v] if it is an instance of @racket[infix-operator],
+ @racket[#f] otherwise.
 
- @item{A @racket[transformer] structure type with one field:
+}
 
-    @itemlist[
-              
-    @item{@racket[proc]: a procedure that takes a list of terms and returns a
-      parsed term}
-   ]
-    
-   The @racket[transformer] structure type is provided by the
-   @racket[enforest/transform] library.}
+@section{Parameterized Enforestation}
 
- @item{A @racket[define-transform] macro that defines a syntax class to
-   trigger parsing given the following, which are all optional:
+@defmodule[enforest]
 
-   @itemlist[
+@(define prefix-operator-ref/default @racket[prefix-operator-ref])
+@(define infix-operator-ref/default @racket[infix-operator-ref])
+@(define name-root-ref/default @racket[name-root-ref])
+@defform[(define-enforest option ...)
+         #:grammar ([option
+                     (code:line #:enforest enforest)
+                     (code:line #:enforest-step enforest-step)
+                     (code:line #:syntax-class syntax-class)
+                     (code:line #:relative-precedence relative-precedence)
+                     (code:line #:prefix-more-syntax-class prefix-more-syntax-class)
+                     (code:line #:infix-more-syntax-class infix-more-syntax-class)
+                     (code:line #:desc desc)
+                     (code:line #:operator-desc operator-desc)
+                     (code:line #:in-space in-space)
+                     (code:line #:prefix-operator-ref prefix-operator-ref)
+                     (code:line #:infix-operator-ref infix-operator-ref)
+                     (code:line #:name-path-op name-path-op)
+                     (code:line #:name-root-ref name-root-ref)
+                     (code:line #:check-result check-result)
+                     (code:line #:make-identifier-form make-identifier-form)
+                     (code:line #:make-operator-form make-operator-form)
+                     (code:line #:juxtapose-implicit-name juxtapose-implicit-name)
+                     (code:line #:select-implicit-prefix select-implicit-prefix)
+                     (code:line #:select-implicit-infix select-implicit-infix)
+                     ])]{
 
-    @item{@racket[#:syntax-class]: the name of the syntax class to define
-      (defaults to a fresh name), which matches a @racket[group] shrubbery
-      representation and parses it. A match has an @racket[parsed] attribute
-      representing the parsed result.}
+ The @racket[enforest] name (defaulting to a fresh name) is bound to
+ an enforest function, which is used to start enforestation of a
+ group. It takes a syntax list of S-expressions for parsed shrubberies
+ in a group and returns a parsed form. The enforest function drives a
+ loop that calls the enforest-step function.
 
-    @item{@racket[#:desc]: string used in error reporting to refer to a form. The
-      default is @racket["form"].}
+ The @racket[enforest-step] name (defaulting to a fresh name) is bound
+ to an enforest-step function that continues an enforestation. It
+ takes two arguments: a syntax list of all remaining terms in a group
+ and the current operator, and returns two values: a parsed form and a
+ syntax list of remaining terms (starting with an infix operator that
+ has lower precedence than the input operator).
 
-    @item{@racket[#:transformer-ref]: function that takes a compile-time value
-      and extract an instance of @racket[transformer], if the value has one
-      suitable for the context, returning @racket[#f] otherwise. Normally,
-      these functions use structure-property accessors. The default is
-      @racket[transformer-ref].}
+ The @racket[syntax-class] name (defaulting to a fresh name) is bound
+ to a syntax class (see @racket[define-syntax-class]) that matches and
+ enforests a @racket[group] shrubbery representation. A match has a
+ @racket[parsed] attribute for the enforestation result.
 
-    @item{@racket[#:name-path-op]: an operator name that is recognized after a
-      name-root identifier for hierarhical name references. The
-      default is @racket['|.|].}
+ The @racket[relative-precedence] name, if present, is bound to a
+ function that compares the precedence of two operators. The function
+ takes four arguments: @racket['infix] or @racket['prefix] for the
+ left operator's mode, the left operator's identifier, @racket['infix]
+ or @racket['prefix] for the right operator's mode, and the right
+ operator's identifier. The result is either @racket['stronger] (left
+ takes precedence), @racket['weaker] (right takes precedence), or an
+ error result: @racket[#f] (no precedence relation),
+ @racket['inconsistent-prec] (inconsistent precedence),
+ @racket['inconsistent-assoc] (inconsistent associativity),
+ @racket['same] (same precedence but non-associativity),
+ @racket['same-on-left] (same precedence but on the wrong side),
+ @racket['unbound] (one of the operators is unbound).
 
-    @item{@racket[#:name-root-ref]: analogous to @racket[define-enforest].}
+ The @racket[prefix-more-syntax-class] and
+ @racket[infix-more-syntax-class] names (defaulting to fresh names)
+ are bound to syntax classes that take an operator-name argument, and
+ match and enforest a group that's intended to represent the tail of a
+ group. The enforestation is based on the precedence and associatvity
+ of the given operator. A match has a @racket[parsed] attribute for
+ the enforestation result and a @racket[tail] attribute for the
+ remaining terms in a group.
 
-    @item{@racket[#:check-result]: a function that takes the result of an
-      transformer and checks whether the result is suitable for the
-      context, used for earlier detection of errors; the
-      @racket[check-result] function should either raise an exception or
-      return its argument (possibly adjusted). A second argument to
-      the function is the procedure that produced the result, which
-      can be used for error checking. The default function checks that
-      its first argument is a syntax object and returns it.}
+ The @racket[desc] (defaulting to @racket["form"]) and
+ @racket[operator-desc] (defaulting to @racket["operator"]) strings
+ are used in error reporting to refer to a form or an operator for a
+ form.
 
-    ]
+ The @racket[in-space] function (defaulting to the identity function)
+ takes an identifier syntax object and adds a space scope if the
+ enforesting context uses a space.
 
-   The @racket[define-transform] function is provided by the
-   @racket[enforest/transformer] library.}
+ The @racket[prefix-operator-ref] (defaulting to
+ @prefix-operator-ref/default) and @racket[infix-operator-ref]
+ (defaulting to @infix-operator-ref/default) functions take a
+ compile-time value and extract an instance of
+ @racket[prefix-operator] or @racket[infix-operator], respectively, if
+ the value has one suitable for the context, returning @racket[#f]
+ otherwise. Normally, these functions use structure-property
+ accessors.
 
- ]
+ The @racket[name-path-op] symbol (defaulting to @racket['|.|]) is an
+ operator name that is (symbolically) recognized after a name-root
+ identifier for hierarhical name references.
+
+ The @racket[name-root-ref] function (defaulting to
+ @name-root-ref/default) takes a compile-time value and extracts an
+ instance of @racket[name-root]. The compile-time value is resolved
+ from an identifier that is followed by an operator recognized by
+ @racket[name-path-op].
+
+ The @racket[check-result] function (defaulting to a function that
+ checks whether its first argument is a syntax object, returning it
+ as-is if so, raising an exception otherwise) takes an enforestation
+ result and checks whether the result is suitable for the context. It
+ should either raise an exception for earlier detection of errors or
+ return its first argument (possibly adjusted). A second argument to
+ the function is the procedure that produced the result, which can be
+ used for error reporting (e.g., through @racket[object-name]).
+
+ The @racket[make-identifier-form] function (defaulting to the
+ identity function) takes an identifier an produces a suitable parsed
+ form. If a context does not have a meaning for unbound identifiers, a
+ syntax error can be reported.
+
+ The @racket[make-operator-form] function, if non-@racket[#f], takes
+ an operator and produces a suitable parsed form. Absence or
+ @racket[#f] means that an error is reported for an unbound operator
+ in an expression position.
+
+ The @racket[juxtapose-implicit-name] symbol (defaulting to
+ @racket['#%juxtapose] as described in @secref["implicit-ops"]) is the
+ name for the implicit infix operator between two immediately adjacent
+ expressions.
+
+ The @racket[select-implicit-prefix] function (defaulting to a
+ function that selects implicit prefix operators as described in
+ @secref["implicit-ops"]) takes a term within a group that is not an
+ operator and does not follow an infix operator. The result should be
+ two values: a symbol as the name for the implicit prefix operator and
+ a syntax object whose lexical context is added to the symbol to look
+ up the operator binding.
+
+ The @racket[select-implicit-infix] function (defaulting to a
+ function that selects implicit infix operators as described in
+ @secref["implicit-ops"]) takes a term within a group that is not an
+ operator and follows a parsed term. The result should be two values:
+ a symbol as the name for the implicit infix operator and a syntax
+ object whose lexical context is added to the symbol to look up the
+ operator binding.
+
+}
+
+@section{Prefix Transformers}
+
+@defmodule[enforest/transformer]
+
+@defstruct*[transformer ([proc procedure?])]{
+
+ The @racket[proc] transformer procedure takes a syntax list of all
+ terms (including the resolved name) in a group and returns a parsed
+ term.
+
+}
+
+@defproc[(transformer-ref [v any/c])
+         any/c]{
+
+ Returns @racket[v] if it is an instance of @racket[transformer],
+ @racket[#f] otherwise.
+
+}
+
+@(define transformer-ref/default @racket[transformer-ref])
+@defform[(define-transform option ...)
+         #:grammar ([option
+                     (code:line #:syntax-class syntax-class)
+                     (code:line #:desc desc)
+                     (code:line #:transformer-ref transformer-ref)
+                     (code:line #:name-path-op name-path-op)
+                     (code:line #:name-root-ref name-root-ref)
+                     (code:line #:check-result check-result)])]{
+
+ The @racket[syntax-class] name (defaulting to a fresh name) is bound
+ to a syntax class that matches and parses a @racket[group] shrubbery
+ representation. A match has a @racket[parsed] attribute for the
+ parsed result.
+
+ The @racket[desc] string (defaulting to @racket["form"]) is used in
+ error reporting to refer to a form.
+
+ The @racket[transformer-ref] function (defaulting to
+ @transformer-ref/default) takes a compile-time value and extracts an
+ instance of @racket[transformer], if the value has one suitable for
+ the context, returning @racket[#f] otherwise. Normally, this function
+ uses a structure-property accessor.
+
+ See @racket[define-enforest] for the meanings of @racket[desc],
+ @racket[name-path-op], @racket[name-root-ref], and
+ @racket[check-result].
+
+}

--- a/enforest/scribblings/common.rhm
+++ b/enforest/scribblings/common.rhm
@@ -3,12 +3,18 @@
 import:
   scribble/rhombus/manual open
   "racket.rkt" open
+  meta_label:
+    rhombus open
+    rhombus/meta open
 
 export:
   all_from("racket.rkt")
   shrubbery_doc
   rhombus_doc
   Rhombus
+  meta_label:
+    all_from(rhombus)
+    all_from(rhombus/meta)
 
 def shrubbery_doc: [#'lib, "shrubbery/scribblings/shrubbery.scrbl"]
 def rhombus_doc: [#'lib, "rhombus/scribblings/rhombus.scrbl"]

--- a/enforest/scribblings/enforest-algorithm.scrbl
+++ b/enforest/scribblings/enforest-algorithm.scrbl
@@ -1,13 +1,14 @@
-#lang scribble/manual
+#lang scribble/rhombus/manual
+@(import: "common.rhm" open)
 
 @title{Enforestation Algorithm}
 
 The Rhombus parsing algorithm is similar to figure 1 of
-@hyperlink["http://www.cs.utah.edu/plt/publications/gpce12-rf.pdf"]{the
+@hyperlink("http://www.cs.utah.edu/plt/publications/gpce12-rf.pdf"){the
  Honu paper}, but with some key differences:
 
-@itemlist[
-          
+@itemlist(
+
  @item{When the inital term is an identifier followed by a name-path
   operator and @tt{lookup} produces a name root for the identifier, the
   name-root transformer is applied. Its result, a new term and tail, are
@@ -17,25 +18,25 @@ The Rhombus parsing algorithm is similar to figure 1 of
   procedure to produce a Racket form, instead of always making a @tt{bin}
   or @tt{un} AST node. Whether the Racket form is an expression or some
   other form (such as pieces of a binding) depends on the context.}
-  
- @item{Operators using the _automatic_ protocol are dispatched as in the
-  figure. If a prefix operator's protocol is @emph{macro}, it behaves
+
+ @item{Operators using the @tech{automatic protocol} are dispatched as in the
+  figure. If a prefix operator's protocol is @tech(~key: "macro protocol"){macro}, it behaves
   the same as the figure's case of an identifier that is mapped to a
-  transformer. A macro infix operator's treatment is analogous.}
+  transformer. A @tech(~key: "macro protocol"){macro} infix operator's treatment is analogous.}
 
  @item{Function calls, array references, and list construction are not
    built-in in the same way as Honu. Instead, those positions
-   correspond to the use of implicit operators, such as @racket[#%call].}
-   
+   correspond to the use of implicit operators, such as @rhombus(#%call).}
+
  @item{The figure's prefix-operator case seems wrong; the old operator and
    combiner should be pushed onto the stack.}
 
- @item{Already-parsed forms that are encoded with @racket['parsed]
+ @item{Already-parsed forms that are encoded with @racket_q_parsed
   (which are ``term''s in the figure's terminology) are immediately
   converted to parsed form (i.e., ``tree term''s in the figure) by
-  removing the @racket['parsed] wrapper.}
+  removing the @racket_q_parsed wrapper.}
 
- ]
+)
 
 The implementation represents pending operators during enforestation
 through the Racket continuation, instead of using an explicit stack;
@@ -49,12 +50,12 @@ precedence, the enforestation function returns both the parsed form and
 the remaining terms.
 
 An identifier/operator is connected to a transformer using Racket's
-mapping machinery (@racket[define-syntax], etc.). The enforestation
+mapping machinery (@racket_define_syntax, etc.). The enforestation
 algorithm is parameterized over the space (in the sense of
-@racket[for-space]) it should consult and accessor–predicate functions
+@racket_provide_for_space) it should consult and accessor–predicate functions
 that extract infix and prefix transformers from compile-time bindings.
 
-When a context includes only prefix macro operators that are
+When a context includes only prefix @tech(~key: "macro protocol"){macro} operators that are
 constrained to consume all available terms, then enforestation is not
 really relevant. In that case, the context just needs a way to find
 and invoke operator transformers. The Rhombus expander provides a

--- a/enforest/scribblings/enforest.scrbl
+++ b/enforest/scribblings/enforest.scrbl
@@ -16,7 +16,7 @@ For brevity, we call this parsing layer @deftech{Rhombus expansion},
 even though it does not define a full candidate Rhombus language, and
 although it's in many ways independent of a specific language. That's
 similar to referring to @emph{Racket expansion}, by which we do not
-necessarily mean something involving @litchar{#lang racket}.
+necessarily mean something involving @rhombus(#,(hash_lang()) #,(@rhombuslangname(racket))).
 
 @table_of_contents()
 
@@ -26,6 +26,7 @@ necessarily mean something involving @litchar{#lang racket}.
 @include_section("transformer.scrbl")
 @include_section("precedence.scrbl")
 @include_section("implicit-operator.scrbl")
+@include_section("macro-protocol.scrbl")
 @include_section("enforest-algorithm.scrbl")
 @include_section("api.scrbl")
 @include_section("example.scrbl")

--- a/enforest/scribblings/example.scrbl
+++ b/enforest/scribblings/example.scrbl
@@ -2,6 +2,8 @@
 @(require (only-in "common.rhm" Rhombus)
           "rhm_id.rhm"
           (for-label compatibility/package
+                     enforest
+                     enforest/transformer
                      racket/base
                      syntax/parse))
 

--- a/enforest/scribblings/example.scrbl
+++ b/enforest/scribblings/example.scrbl
@@ -1,5 +1,9 @@
 #lang scribble/manual
-@(require (only-in "common.rhm" Rhombus))
+@(require (only-in "common.rhm" Rhombus)
+          "rhm_id.rhm"
+          (for-label compatibility/package
+                     racket/base
+                     syntax/parse))
 
 @title{Implementation Examples}
 
@@ -10,7 +14,8 @@ The prototype @Rhombus implementation starts with a
 
 @racketblock[
 (define-syntax (rhombus-module-begin stx)
-  (syntax-case stx ()
+  (syntax-parse stx
+    #:datum-literals (top)
     [(_ (top . content))
      #`(#%module-begin
         (rhombus-top . content))]))
@@ -60,16 +65,16 @@ makes sure that the low-level transformer returns at least a
 list-shaped syntax object, but that's just for earlier error
 detection.
 
-A simple implementation of the @racket[val] definition form could be like
+A simple implementation of the @racket[def] definition form could be like
 this:
 
 @racketblock[
-(define-syntax val
+(define-syntax def
   (definition-transformer
     (lambda (stx)
       (syntax-parse stx
         #:datum-literals (block)
-        (code:comment "match `val <binding>: <form> ...`, where")
+        (code:comment "match `def <binding>: <form> ...`, where")
         (code:comment "`:` grouping is represented by `block`")
         [(_ b::binding (block rhs ...))
          (build-values-definitions #'b.parsed
@@ -141,10 +146,9 @@ An infix expression operator like @racket[+] is defined roughly like this:
 ]
 
 The actual implementation has more layers of abstraction, deals with
-macro scope introductions, supports a @racket[define*]-like @racket[forward]
+macro scope introductions, supports a @racket[define*]-like forward
 definition form, implements more complicated syntax, and so on. Some
 part of the language would be built in this low-level way, including
-operator- and macro-defining forms like @racket[operator] and
-@racket[expr.macro], and then more of the Rhombus prototype language
-could be built using the Rhombus prototype language.
+operator- and macro-defining forms like @rhm-operator and
+@rhm-expr-macro, and then more of @Rhombus could be built using @|Rhombus|.
 

--- a/enforest/scribblings/hierarchical-naming.scrbl
+++ b/enforest/scribblings/hierarchical-naming.scrbl
@@ -1,5 +1,7 @@
 #lang scribble/rhombus/manual
-@(import: "common.rhm" open)
+@(import:
+    meta_label:
+      rhombus/meta open)
 
 @title{Hierarchical Naming}
 

--- a/enforest/scribblings/implicit-operator.scrbl
+++ b/enforest/scribblings/implicit-operator.scrbl
@@ -1,59 +1,62 @@
-#lang scribble/manual
+#lang scribble/rhombus/manual
 
-@title[#:tag "implicit-ops"]{Implicit Operators}
+@title(~tag: "implicit-ops"){Implicit Operators}
 
-In much the same way that @racket[#%app] and @racket[#%datum] are
+In much the same way that @rhombus(#%app) and @rhombus(#%datum) are
 implicitly used in many Racket expressions, Rhombus enforestation needs
 at least two implicit forms: an implicit prefix operator for a
-non-identifier form by itself (somewhat like @racket[#%datum]), and an
+non-identifier form by itself (somewhat like @rhombus(#%datum)), and an
 implicit infix operator for the juxtaposition of a parsed form and
 another form without a binary operator in between (somewhat like
-@racket[#%app]). To help enforestation applications avoid a level of
+@rhombus(#%app)). To help enforestation applications avoid a level of
 indirection between those minimal implicit forms, however, enforestation
 is parameterized over functions that select implicit prefix and infix
 forms. The default selection function generates references to the
 following forms:
 
-@itemlist[
-          
- @item{@racket[#%parens]: implicit prefix for a parenthesized term that is not
+@itemlist(
+
+ @item{@rhombus(#%parens): implicit prefix for a parenthesized term that is not
    immediately after a parsed form}
 
- @item{@racket[#%call]: implicit infix for a parsed form followed by a
+ @item{@rhombus(#%call): implicit infix for a parsed form followed by a
    parenthesized term}
 
- @item{@racket[#%array]: implicit prefix for a square-bracketed term that is not
+ @item{@rhombus(#%brackets): implicit prefix for a square-bracketed term that is not
    immediately after a parsed form}
 
- @item{@racket[#%ref]: implicit infix for a parsed form followed by a
+ @item{@rhombus(#%index): implicit infix for a parsed form followed by a
    square-bracketed term}
 
- @item{@racket[#%set]: implicit prefix for a curly-braced term that is not
+ @item{@rhombus(#%braces): implicit prefix for a curly-braced term that is not
    immediately after a parsed form}
 
- @item{@racket[#%comp]: implicit infix for a parsed form followed by a
+ @item{@rhombus(#%comp): implicit infix for a parsed form followed by a
    curly-braced term}
 
- @item{@racket[#%juxtapose]: implicit infix for adjacent expressions with no
-   operator between them when @racket[#%call], @racket[#%ref], and @racket[#%comp] do not
+ @item{@rhombus(#%juxtapose): implicit infix for adjacent expressions with no
+   operator between them when @rhombus(#%call), @rhombus(#%index), and @rhombus(#%comp) do not
    apply}
 
- @item{@racket[#%block]: implicit prefix for a block (written with @racket[:]) not
+ @item{@rhombus(#%quotes): implicit prefix for a single-quoted term that is not
    immediately after a parsed form}
 
- @item{@racket[#%alts]: implicit prefix for a block of alternatives
+ @item{@rhombus(#%block): implicit prefix for a block (written with @litchar{:}) not
+   immediately after a parsed form}
+
+ @item{@rhombus(#%alts): implicit prefix for a sequence of alternatives
    (written with @litchar{|} notation) not immediately after a parsed form}
 
- @item{@racket[#%literal]: implicit prefix for a literal, such as a number or
+ @item{@rhombus(#%literal): implicit prefix for a literal, such as a number or
    boolean, not immediately after a parsed form}
 
- ]
+)
 
-In an expression context, a Rhombus language's @racket[#%call] implementation
-most likely creates a function call, @racket[#%parens] most likely does
+In an expression context, a Rhombus language's @rhombus(#%call) implementation
+most likely creates a function call, @rhombus(#%parens) most likely does
 nothing for a single expression in parentheses (so parentheses can be
 used for grouping) and might otherwise create a tuple value or return
-multiple values, @racket[#%juxtapose] probably reports an error. Implicit
+multiple values, @rhombus(#%juxtapose) probably reports an error. Implicit
 operators are likely to have the highest possible precedence and be
 left-associative, but they are not constrained to those conventions by
 the Rhombus expander. Implicit operators are likely to be implemented

--- a/enforest/scribblings/macro-protocol.scrbl
+++ b/enforest/scribblings/macro-protocol.scrbl
@@ -1,9 +1,9 @@
 #lang scribble/rhombus/manual
-@(import: "common.rhm": open)
+@(import: "common.rhm" open)
 
-@title{Macro protocol}
+@title{Macro Protocols}
 
-When an operator's mapping indicates a macro protocol, then the
+When an operator's mapping indicates a @tech{macro protocol}, then the
 operator's transformer procedure is called with a parsed left-hand
 argument (in the case of an infix operator) and all of the remaining
 terms in the operator's group starting with the operator. The
@@ -24,27 +24,27 @@ as an already-parsed term and need not conform to the shrubbery
 grammar's representation. Since the list starting @racket_q_parsed
 itself has no shrubbery representation, it's conveniently opaque to a
 shrubbery layer of patterning matching. For example, in the earlier
-example implementing the @rhombus(->) macro infix operator,
+example implementing the @rhombus(->) @tech(~key: "macro protocol"){macro} infix operator,
 
 @rhombusblock(
-  expr.macro '($x -> $y $tail ...)':
-    values('($x . $y)', tail)
+  expr.macro '$x -> $y $tail ...':
+    values('$x . $y', '$tail ...')
 )
 
-the macro transformer receives an syntax-object representing the
+the macro transformer receives a syntax object representing the
 already-parsed left-hand argument @rhombus(x) as a @racket_q_parsed
 list. The macro therefore has no way to pull the expression apart,
 inspect it, or rearrange it. Of course, such facilities could be made
 available to the macro transformer in lower-level form. Meanwhile,
-@rhombus(y) and @rhombus(tail) are likely unparsed terms, that can be
+@rhombus(y) and @rhombus(tail) are likely unparsed terms, which can be
 inspected—although it's possible that some other macro constructs a
 @rhombus(->) expression using already-parsed terms, in which case they
 are similarly opaque to the @rhombus(->) transformer.
 
-For binding-operator macros, @Rhombus includes @rhombus(bind.unpack) to
+For binding-operator macros, @Rhombus includes @rhombus(bind_meta.unpack) to
 expose certain pieces of a binding's implementation, which allows the
 macro to compose or adjust other binding expansions. New binding pieces
-can be put back together into a parsed form using @rhombus(bind.pack).
+can be put back together into a parsed form using @rhombus(bind_meta.pack).
 
 Some contexts may oblige a macro transformer to consume all of the
 remaining terms in a group. For example, a definition or declaration

--- a/enforest/scribblings/motivation.scrbl
+++ b/enforest/scribblings/motivation.scrbl
@@ -54,7 +54,7 @@ operator's right-hand side is not an expression; it must always be an
 identifier. The @rhombus(weather.currently_raining) form looks like a
 use of the @rhombus(.) operator, but it's meant here to be a use of the
 namer @rhombus(weather) that is bound by @rhombus(import) and recognizes
-@rhombus(.) to access the imported @rhombus(currently_raining) binding,
+@litchar{.} to access the imported @rhombus(currently_raining) binding,
 which might be a macro instead of a variable that is bound to a
 function.
 
@@ -82,9 +82,9 @@ macro as
   home->x + 1 // same as home.x + 1
 )
 
-The intent here is that @rhombus(expr.macro) (the @rhombus(.) there is
-like using an import, accessing the @rhombus(macro) form within an
-@rhombus(expr) group of bindings) allows a macro to consume as many
+The intent here is that @rhombus(expr.macro) (the @litchar{.} there is
+like using an import, accessing the @rhombus(macro, ~datum) form within an
+@rhombus(expr, ~datum) group of bindings) allows a macro to consume as many
 terms after the operator as it wants, and the macro must return two
 values: a quoted expression for the expansion plus leftover terms for
 further expression parsing (i.e., @rhombus(tail) in the example use will
@@ -115,11 +115,11 @@ principle, the variant could be minimal, corresponding to the core forms
 that all Racket modules expand into, but some larger variant (including
 keyword arguments, for example) is likely a better choice of
 interoperability with Racket modules. The enforestation and expansion
-process here are defined in terms of the S-expression form of parsed
+processes here are defined in terms of the S-expression form of parsed
 shrubbery notation (really, syntax-object form, so it can include scopes
 to determine a mapping for identifiers and operators). The @rhombus(<>)
 and @rhombus(->) examples above use operator- and macro-definition forms
-in terms of shrubbery notation, but this proposal focused on the
+in terms of shrubbery notation, but this proposal focuses on the
 lower-level mechanisms that allow such shrubbery-native forms to be
 implemented.
 

--- a/enforest/scribblings/rhm_id.rhm
+++ b/enforest/scribblings/rhm_id.rhm
@@ -1,0 +1,14 @@
+#lang rhombus/static
+import:
+  scribble/rhombus as scribble
+  meta_label:
+    rhombus open
+    rhombus/meta open
+
+export:
+  #{rhm-operator}
+  #{rhm-expr-macro}
+
+def #{rhm-operator} = scribble.rhombus(operator)
+
+def #{rhm-expr-macro} = scribble.rhombus(expr.macro)

--- a/enforest/scribblings/syntactic-categories.scrbl
+++ b/enforest/scribblings/syntactic-categories.scrbl
@@ -12,7 +12,7 @@ possible contexts:
   @item{declarations (in a module's immediate body or at the top level)},
   @item{definitions},
   @item{expressions},
-  @item{bindings (like @rhombus(match) patterns, but everywhere)}
+  @item{bindings (like @racket_match patterns, but everywhere)}
 )
 
 In Racket's expander, a few core contexts are reflected by
@@ -27,8 +27,8 @@ The Rhombus expander is parameterized over the way that different
 kinds of compile-time values for different contexts are recognized,
 but they are expected to be implemented through structure-type
 properties. A compile-time value can then implement multiple kinds of
-transformers to create a mapping that is works in multiple contexts.
-For example, the example @rhombus(<>) operator is useful in both expression
+transformers to create a mapping that works in multiple contexts.
+For example, the previous @rhombus(<>) operator is useful in both expression
 and binding contexts, with a suitable meaning in each context.
 
 Different contexts may also consult different mapping spaces in the
@@ -43,7 +43,7 @@ the way that mapping spaces are used.
 
 The relevant syntactic category for a shrubbery is determined by its
 surrounding forms, and not inherent to the shrubbery. For example,
-@rhombus(Posn(x, y)) or @rhombus(x <> y) in the example mean one thing
+@rhombus(Posn(x, y)) or @rhombus(x <> y) in the example means one thing
 as an expression and another as a binding. Exactly where the contexts
 reside in a module depends on a specific Rhombus language that is built
 on the Rhombus expander. Meanwhile, a full Rhombus language can have

--- a/enforest/scribblings/transformer.scrbl
+++ b/enforest/scribblings/transformer.scrbl
@@ -5,7 +5,7 @@
 
 Some contexts in a Rhombus language (likely including expression
 contexts) will support infix, prefix, and postfix operators. The Rhombus
-expander provides an _enforestation_ framework for parsing forms that
+expander provides an @emph{enforestation} framework for parsing forms that
 involve multiple operators, each with a declared precedence and
 associativity. The enforestation process also allows an operator
 transformer to completely take over parsing of terms that follow the
@@ -68,7 +68,7 @@ resume enforestation, all operators could be implemented with the
 Some contexts might constrain the allowed forms of operators to prefix
 or infix, constrain the names used for operators, and/or eschew one of
 the operator protocols. For example, declaration and definition contexts
-might allow only macro prefix operators with identifier names. The
+might allow only @tech(~key: "macro protocol"){macro} prefix operators with identifier names. The
 @Rhombus implementation makes that choice, and it also allows
 expression forms with operators to appear in the same places as
 declaration and definition forms.

--- a/info.rkt
+++ b/info.rkt
@@ -21,6 +21,7 @@
     "rackunit-lib"
     "scribble-doc"
     "draw-doc"
-    "gui-easy"))
+    "gui-easy"
+    "compatibility"))
 
 (define version "0.18")

--- a/shrubbery/scribblings/at-notation.scrbl
+++ b/shrubbery/scribblings/at-notation.scrbl
@@ -1,5 +1,6 @@
 #lang scribble/rhombus/manual
 @(import:
+    "grammar.rhm" open
     "quote.rhm" open
     "at-exp.rkt" open)
 
@@ -64,13 +65,15 @@ Overall, @litchar("@") notation has three key properties:
 Each input of the form
 
 @verbatim(~indent: 2){
- @litchar("@")@italic{command}@litchar{(} @italic{arg} @litchar{,} ... @litchar{)}@litchar("{") @italic{text} @litchar("}")...
+ @bseq(@litchar("@"), @italic{command},
+       @litchar{(}, @italic{arg}, @litchar{,}, @elem{...}, @litchar{)},
+       @litchar("{"), @italic{text}, @litchar("}"), @elem{...})
 }
 
 is parsed into the same representation as
 
 @verbatim(~indent: 2){
- @italic{command}@litchar{(}@italic{arg}@litchar{,} ...@litchar{,} @litchar{[}@italic{converted_text}, ...@litchar{]}, ...@litchar{)}
+ @italic{command}@litchar{(}@italic{arg}@litchar{,} @elem{...}@litchar{,} @litchar{[}@italic{converted_text}, @elem{...}@litchar{]}, @elem{...}@litchar{)}
 }
 
 Each component of the original form---@italic{command}, parenthesized
@@ -78,12 +81,12 @@ Each component of the original form---@italic{command}, parenthesized
 component is present, and as long as @italic{command} is present
 before parenthesized @italic{arg}s. The @italic{command} and
 @italic{arg} components are in shrubbery notation, while @italic{text}
-is in text mode and converted to @italic{converted_text}. The
+is in text mode and converted to @italic{converted_text} lists. The
 @italic{converted_text} translation includes elements that are not
 string literals in places where @italic{text} has escapes. An
 @litchar("@") form can have multiple @braces @italic{text}
 blocks, in which case the translation has multiple
-@italic{converted_list} list arguments.
+@italic{converted_text} list arguments.
 
 More examples:
 
@@ -113,21 +116,21 @@ Some additional @litchar("@") rules:
 
  @item{While the @italic{command} component itself can be parenthesized, it
        can also have the form
-       @rhombus(#,(@litchar("«")) #,(@italic{command}) ... #,(@litchar{»})),
+       @bseq(@litchar{«}, @italic{command}, @elem{...}, @litchar{»})
        for a multi-part command component that is spliced into the translation
        without surrounding parentheses.},
 
  @item{A multi-part @italic{command} that is a sequence of
        identifiers separated by operators (usually @litchar{.}) can be
-       written without grouping @litchar{«»}, as long as no space
+       written without grouping @guillemets, as long as no space
        appears between the identifiers and operators.},
 
- @item{When @litchar{(} @italic{arg} @litchar{,} ... @litchar{)} is
+ @item{When @bseq(@litchar{(}, @italic{arg}, @litchar{,}, @elem{...}, @litchar{)}) is
        present, the separating commas are optional. That is, arguments
        can be provided as different newline-separated groups without a
        @litchar{,} in between.}
 
- @item{The form @rhombus(#,(@litchar("@(«")) #,(@italic{command}) ... #,(@litchar{»)}))
+ @item{The form @bseq(@litchar("@(«"), @italic{command}, @elem{...}, @litchar{»})
        splices as-is with no arguments, even if the subsequent text has
        the shape of parenthesed @italic{arg}s or braced @italic{text}.},
 

--- a/shrubbery/scribblings/at-parsing.scrbl
+++ b/shrubbery/scribblings/at-parsing.scrbl
@@ -1,5 +1,7 @@
 #lang scribble/rhombus/manual
-@(import: "grammar.rhm" open)
+@(import:
+    "grammar.rhm" open
+    "quote.rhm" open)
 
 @title(~tag: "at-parsing"){At-Notation Parsing}
 
@@ -18,7 +20,7 @@ one of these forms:
       }
 
       where @italic{command_splice} is the same as @italic{command}, except
-      that an immediately wrapping @litchar("«»") (if any) is removed, and the
+      that an immediately wrapping @guillemets (if any) is removed, and the
       conversion of @italic{braced_text} is described below.
 
       The allowed form of @italic{command} is described in
@@ -36,7 +38,7 @@ one of these forms:
       are allowed.
 
       Although a character other than @litchar{(} after
-      @italic{command} would normally, mean that one of the other @litchar("@")
+      @italic{command} would normally mean that one of the other @litchar("@")
       forms is being used, a @litchar("[") in that position is treated
       as a parse error. (This prohibition is intended to support
       better error reporting when S-expression @litchar("@") syntax is
@@ -59,7 +61,7 @@ one of these forms:
 
       Converts to 
       @verbatim(~indent: 2){
-        @litchar{(}@litchar{[}@italic{converted_text}, ...@litchar{]}, ...@litchar{)}
+        @litchar{(}@litchar{[}@italic{converted_text}, @elem{...}@litchar{]}, @elem{...}@litchar{)}
       }
 
       The allowed forms of @italic{braced_text} and the spacing rules
@@ -198,7 +200,7 @@ and @italic{closer}:
        literal element, if it is not a separate element already.
 
        Note that a line that originally contained only whitespace will
-       have just a newline at this point (not not even that, if it's
+       have just a newline at this point (not even that, if it's
        the last line), since trailing whitespace was previously
        discarded.},
 

--- a/shrubbery/scribblings/example.scrbl
+++ b/shrubbery/scribblings/example.scrbl
@@ -1,4 +1,8 @@
 #lang scribble/rhombus/manual
+@(import:
+    "rkt-id.rkt" as rkt
+    meta_label:
+      rhombus open)
 
 @title(~tag: "example"){Examples}
 
@@ -12,34 +16,34 @@ that's roughly a shorthand for starting a new indented line after the
 terminology, but that's enough to get a sense of the examples.
 
 @rhombusblock(
-  def identity(x): x
+  fun identity(x): x
 
-  def fib(n):
-    cond
-    | n == 0: 0
-    | n == 1: 1
-    | ~else: fib(n-1) + fib(n-2)
+  fun fib(n):
+    match n
+    | 0: 0
+    | 1: 1
+    | n: fib(n-1) + fib(n-2)
 
-  def print_sexp(v):
+  fun print_sexp(v):
     match v
-    | empty: display("()")
-    | cons(a, d):
-        if is_list(d)
-        | display("(")
-          print_sexp(a)
-          for (v = in_list(d)):
-            display(" ")
-            print_sexp(v)
-          display(")")
-        | display("(")
-          print_sexp(a)
-          display(". ")
-          print_sexp(d)
-          display(")")
+    | []: print("()")
+    | [fst, & rst]:
+        print("(")
+        print_sexp(fst)
+        for (v: rst):
+          print(" ")
+          print_sexp(v)
+        print(")")
+    | Pair(fst, snd):
+        print("(")
+        print_sexp(fst)
+        print(" . ")
+        print_sexp(snd)
+        print(")")
     | v: print_atom(v)
 )
 
-Forms like @litchar{def}, @litchar{cond}, and @litchar{match} are not
+Forms like @rhombus(fun), @rhombus(match), and @rhombus(for) are not
 specified by shrubbery notation, since specifying those forms is up to a
 language that is built on top of shrubbery notation. Still, shrubbery
 notation is meant to accommodate a particular kind of syntax for nested
@@ -48,7 +52,7 @@ blocks (via @litchar{:} and indentation) and conditional blocks (via
 
 Identifiers are C-style with alphanumerics and underscores. Operators
 are sequences of symbolic characters in the sense of
-@litchar{char-symbolic?}, roughly. No spaces are needed between
+@(rkt.char_is_symbolic), roughly. No spaces are needed between
 operators and non-operators, so @litchar{1+2} and @litchar{1 + 2} mean
 the same thing. Comments are C-style. See @secref("token-parsing")
 for more information.

--- a/shrubbery/scribblings/grammar-s-exp.rkt
+++ b/shrubbery/scribblings/grammar-s-exp.rkt
@@ -14,6 +14,7 @@
              @racket[(group @#,nonterm{item} ... @#,nonterm{block} @#,nonterm{alts})])
        (list @nonterm{item}
              @nonterm{atom}
+             @racket[(op @#,nonterm{symbol})]
              @racket[(parens @#,nonterm{group} ...)]
              @racket[(brackets @#,nonterm{group} ...)]
              @racket[(braces @#,nonterm{group} ...)]

--- a/shrubbery/scribblings/group-and-block.scrbl
+++ b/shrubbery/scribblings/group-and-block.scrbl
@@ -81,7 +81,7 @@ same indentation create separate @tech{groups}, one for each line.
 )
 
 Comments and lines with only whitespace are ignored. They don't count
-when this document says “the previous line” or “the next line.”
+when this document says ``the previous line'' or ``the next line.''
 
 @section{Grouping by Opener--Closer Pairs}
 
@@ -319,7 +319,7 @@ immediately within @quotes, @brackets, or @braces, or if is
 the first group of the sequence immediately within @quotes. Like
 @litchar{:}, the group-sequence content after @litchar{|} cannot be
 empty (unless explicit-grouping @guillemets are used
-immediately after @litchar{|}, as desctibed in @secref("guillemet")).
+immediately after @litchar{|}, as described in @secref("guillemet")).
 
 If a @litchar{|} appears on the same line as an earlier @litchar{|} and
 is not more nested inside @parens, @brackets, or @braces,
@@ -495,7 +495,7 @@ The following five groups are the same:
     »
 )
 
-Using @guillemets can “armor” a shrubbery for transport from one
+Using @guillemets can ``armor'' a shrubbery for transport from one
 context to another where its line breaks or indentation might get
 mangled. For example, an editor might offer an operation to armor a
 range of text in perparation for moving or copying the text, and then
@@ -594,12 +594,12 @@ inside:« fruit » more
 As a last resort, @litchar{\} can be used at the end of a line (optionally
 followed by whitespace and coments on the line) to continue the next
 line as it if were one line continuing with the next line. The itself
-@litchar{\} does not appear in the parsed form. A that is not at the end of a
+@litchar{\} does not appear in the parsed form. A @litchar{\} that is not at the end of a
 line (followed by whitespace and coments) is treated the same as
 whitespace.
 
 Lines containing only whitespace and (non-term) comments do not count
-as “the next line” even for @litchar{\} continuations, so any number of
+as ``the next line'' even for @litchar{\} continuations, so any number of
 whitespace and comment lines can appear between @litchar{\} and the line that
 it continues.
 

--- a/shrubbery/scribblings/parsed-representation.scrbl
+++ b/shrubbery/scribblings/parsed-representation.scrbl
@@ -13,7 +13,7 @@ The parse of a shrubbery can be represented by an S-expression:
  @item{Each group is represented as a list that starts @litchar{'group}, and
    the rest of the list are the elements of the group.}
 
- @item{Atom elements are represented as “themselves” within a group,
+ @item{Atom elements are represented as ``themselves'' within a group,
    including identifers a symbols, except that an operator is
    represented as a 2-element list that is @litchar{'op} followed by the operator name
    as a symbol.}
@@ -79,55 +79,46 @@ Here are some example shrubberies with their S-expression parsed
 representations:
 
 @verbatim(~indent: 2){
-def pi: 3.14
+def pi = 3.14
 
-(group de pi (block (group 3.14)))
+(group def pi (op =) 3.14)
 
-def fourth(n: integer):
-  def m: n*n
-  def v: m*m
-  printf("~a^4 = ~a\n", n, v)
+fun fourth(n :: Int):
+  let m = n*n
+  let v = m*m
+  println(n +& "^4 = " +& v)
   v
 
-(group def
-       fourth
-       (parens (group n (block (group integer))))
+(group fun fourth (parens (group n (op ::) Int))
        (block
-        (group def m (block (group n (op *) n)))
-        (group def v (block (group m (op *) m)))
-        (group printf
-               (parens (group "\"~a^4 = ~a\\n\"") (group n) (group v)))
+        (group let m (op =) n (op *) n)
+        (group let v (op =) m (op *) m)
+        (group println (parens (group n (op +&) "^4 = " (op +&) v)))
         (group v)))
 
-if x = y
-| same
-| different
+if x == y
+| #'same
+| #'different
 
-(group if x (op =) y (alts (block (group same))
-                           (block (group different))))
+(group if x (op ==) y
+       (alts (block (group (op |#'|) same))
+             (block (group (op |#'|) different))))
 
-define fib(n):
+fun fib(n):
   match n
   | 0: 0
   | 1: 1
   | n: fib(n-1) + fib(n-2)
 
-(group define
-       fib
-       (parens (group n))
+(group fun fib (parens (group n))
        (block
-        (group match
-               n
+        (group match n
                (alts
                 (block (group 0 (block (group 0))))
                 (block (group 1 (block (group 1))))
-                (block
-                 (group n
-                        (block
-                         (group fib
-                                (parens (group n (op -) 1))
-                                (op +)
-                                fib
-                                (parens (group n (op -) 2))))))))))))
+                (block (group n (block
+                                 (group fib (parens (group n (op -) 1))
+                                        (op +)
+                                        fib (parens (group n (op -) 2))))))))))))
 }
 

--- a/shrubbery/scribblings/prior-art.scrbl
+++ b/shrubbery/scribblings/prior-art.scrbl
@@ -7,9 +7,9 @@
 Indentation-sensitive parsing and the use of @litchar{:} is obviously
 informed by Python.
 
-Sampling notation's rules relating indentation, lines, @litchar{;}, and
+Shrubbery notation's rules relating indentation, lines, @litchar{;}, and
 @litchar{:} are originally based on the
-@hyperlink("https://github.com/tonyg/racket-something"){#lang something}
+@hyperlink("https://github.com/tonyg/racket-something"){@tt{#lang something}}
 reader, which also targets an underlying expander that
 further groups tokens. Shrubbery notation evolved away from using
 @braces for blocks, however, because @litchar{:} was nearly always
@@ -38,7 +38,7 @@ needed in sapling notation.
 
 More generally, shrubbery notation takes inspiration from
 S-expressions and alternative S-expression notations. The idea that,
-even in an S-expression-like setting, some parsing can be deferred a
+even in an S-expression-like setting, some parsing can be deferred to a
 later parser has many precedents, including Clojure's choice of where
 to put parentheses and notations that use something like @litchar{$} to escape
 to infix mode.

--- a/shrubbery/scribblings/rationale.scrbl
+++ b/shrubbery/scribblings/rationale.scrbl
@@ -1,4 +1,5 @@
 #lang scribble/rhombus/manual
+@(import: "quote.rhm" open)
 
 @title{Rationale}
 
@@ -76,7 +77,7 @@ width. Counting the @litchar{\} itself is consistent with ignoring
 @litchar{\} when it appears within a line, so grouping stays the same
 whether there's a newline or the continue line immediately after
 @litchar{\}. The whitespace role of @litchar{\} also means that spaces
-can be turned into @litchar{\} to “harden” code for transfer via media
+can be turned into @litchar{\} to ``harden'' code for transfer via media
 (such as email) that might mangle consecutive spaces.
 
 Using @litchar{~} for keywords has a precedent in OCaml. Reserving
@@ -88,7 +89,7 @@ been liberating for Racket syntax (particularly since keywords can be
 kept disintinct from expressions more generally), and we expect
 similar benefits for having keywords in shrubbery notation.
 
-The @litchar{#{....}} escape to S-expressions provides a bridge between
+The @s_exp_braces escape to S-expressions provides a bridge between
 shrubbery notation and Racket identifiers. For example,
 @litchar{#{exact-integer?}} is an identifier with @litchar{-} and
 @litchar{?} as part of the identifier. Shrubbery notation could be

--- a/shrubbery/scribblings/rhm_id.rhm
+++ b/shrubbery/scribblings/rhm_id.rhm
@@ -1,0 +1,9 @@
+#lang rhombus/static
+import:
+  scribble/rhombus as scribble
+  meta_label:
+    rhombus.import
+
+export: #{rhm-import}
+
+def #{rhm-import} = scribble.rhombus(import)

--- a/shrubbery/scribblings/rkt-id.rkt
+++ b/shrubbery/scribblings/rkt-id.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+(require scribble/manual
+         (for-label racket/base))
+
+(provide char_is_symbolic)
+
+(define char_is_symbolic (racket char-symbolic?))

--- a/shrubbery/scribblings/token-parsing.scrbl
+++ b/shrubbery/scribblings/token-parsing.scrbl
@@ -1,5 +1,7 @@
 #lang scribble/rhombus/manual
-@(import: "grammar.rhm" open)
+@(import:
+    "grammar.rhm" open
+    "quote.rhm" open)
 
 @(def notecol = italic)
 
@@ -15,9 +17,9 @@ Other tokens are described by the grammar below, where a
 star (★) in the left column indicates the productions that correspond to
 @tech{terms} or comments.
 
-@deftech{Numbers} are supported directly in in simple forms---decimal integers,
+@deftech{Numbers} are supported directly in simple forms---decimal integers,
 decimal floating point, and hexadecimal/octal/binary integers---in all cases allowing
-@litchar{_}s between digits. A @litchar("#{")...@litchar("}") escape
+@litchar{_}s between digits. A @s_exp_braces escape
 provides access to the full Racket S-expression number grammar. Special
 floating-point values use a @litchar{#} notation: @litchar{#inf},
 @litchar{#neginf}, and @litchar{#nan}.
@@ -71,10 +73,10 @@ with no whitespace in between. For example, @litchar{1+2} is
 @litchar{1} plus @litchar{2}, but @litchar{1 +2} is @litchar{1}
 followed by the number @litchar{+2}.
 
-When a @litchar("#{")...@litchar("}") escape describes an identifier
+When a @s_exp_braces escape describes an identifier
 S-expression, it is an identifier in the same sense as a
 shrubbery-notation identifier. The same holds for numbers, booleans,
-strings, byte strings, and keywords. A @litchar("#{")...@litchar("}")
+strings, byte strings, and keywords. A @s_exp_braces
 escape must @emph{not} describe a pair, because pairs are used to represent a
 parsed shrubbery, and allowing pairs would create ambiguous or
 ill-formed representations.
@@ -219,7 +221,7 @@ but the table below describes the shape of @litchar("@") forms.
     [is_lex, @nonterm{comment}, bis, bseq(@litchar{//}, kleenestar(@nonterm{nonnlchar})), ""],
     ["", "", bor, bseq(@litchar{/*}, kleenestar(@nonterm{anychar}), @litchar{*/}), @notecol{nesting allowed}],
     ["", "", bor, bseq(@litchar("@//"), kleenestar(@nonterm{nonnlchar})), @elem{@notecol{only within} @nonterm{text}}],
-    ["", "", bor, bseq(@litchar("@//"), @nonterm{atopen}, kleenestar(@nonterm{anychar}), @nonterm{atopen}), @elem{only within @nonterm{text}}],
+    ["", "", bor, bseq(@litchar("@//"), @nonterm{atopen}, kleenestar(@nonterm{anychar}), @nonterm{atopen}), @elem{@notecol{only within} @nonterm{text}}],
     ["", "", bor, bseq(@litchar{#! }, kleenestar(@nonterm{nonnlchar}), kleenestar(@nonterm{continue})), ""],
     empty_line,
     [no_lex, @nonterm{nonnlchar}, bis, @italic{any character other than newline}, ""],


### PR DESCRIPTION
This PR is split into three commits:

- A commit that improves Shrubbery reference;
- A commit that improves Enforestation reference (except the API section);
- A commit that converts the Enforestation API section to proper Scribble docs (I’m aware that this section is incomplete, but hopefully it can serve as a useful starting point).