### PR TITLE
make `List.cons` treat list binding as rest binding

### DIFF
--- a/rhombus/private/composite.rkt
+++ b/rhombus/private/composite.rkt
@@ -375,7 +375,6 @@
                                 (or (not (pair? c-str))
                                     (null? (cdr c-str))))
                            "" ", ")
-                       (if rest-repetition? "" "& ")
                        (annotation-string-to-pattern
                         (if (eq? rest-repetition? 'pair)
                             (annotation-string-convert-pair (syntax-e rest-annotation-str))

--- a/rhombus/private/function-parse.rkt
+++ b/rhombus/private/function-parse.rkt
@@ -325,6 +325,7 @@
     #:datum-literals (group)
     (pattern (~seq (group _::&-bind a ...))
              #:with arg::non-...-binding #`(#,group-tag rest-bind #,list-static-infos
+                                            #:annot-prefix? #f
                                             (#,group-tag a ...))
              #:with parsed #'arg.parsed)
     (pattern (~seq e::non-...-binding (~and ooo (group _::...-bind)))
@@ -336,6 +337,7 @@
     #:datum-literals (group)
     (pattern (~seq (group _::~&-bind a ...))
              #:with kwarg::non-...-binding #`(#,group-tag rest-bind #,map-static-info
+                                              #:annot-prefix? #f
                                               (#,group-tag a ...))
              #:with kwparsed #'kwarg.parsed
              #:attr arg #'#f

--- a/rhombus/private/list.rkt
+++ b/rhombus/private/list.rkt
@@ -66,7 +66,19 @@
 
 (define-binding-syntax List.cons
   (binding-transformer
-   (make-composite-binding-transformer "cons" #'nonempty-list? (list #'car #'cdr) (list #'() list-static-infos))))
+   (let ([composite (make-composite-binding-transformer
+                     "List.cons" #'nonempty-list? (list #'car) (list #'())
+                     #:index-result-info? #t
+                     #:rest-accessor #'cdr
+                     #:rest-repetition? #f)])
+     (lambda (tail)
+       (syntax-parse tail
+         #:datum-literals (parens)
+         [(form-id ((~and tag parens) elem list) . new-tail)
+          (composite #'(form-id (tag elem) . new-tail)
+                     #`(#,group-tag rest-bind #,list-static-infos
+                        #:annot-prefix? #f
+                        list))])))))
 
 (define/arity (List.cons a d)
   #:static-infos ((#%call-result #,list-static-infos))

--- a/rhombus/private/rest-bind.rkt
+++ b/rhombus/private/rest-bind.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require (for-syntax racket/base
-                     syntax/parse/pre)
+                     syntax/parse/pre
+                     "annotation-string.rkt")
          "provide.rkt"
          "binding.rkt"
          "parse.rkt"
@@ -16,17 +17,38 @@
    'macro
    (lambda (tail)
      (syntax-parse tail
-       [(_ static-infos rest-arg::binding)
+       [(_ static-infos
+           (~optional (~seq #:annot-prefix? annot-prefix?)
+                      #:defaults ([annot-prefix? #'#t]))
+           rest-arg::binding)
         #:with rest::binding-form #'rest-arg.parsed
         (values
          (binding-form
           #'rest-bind-infoer
-          #'[static-infos rest.infoer-id rest.data])
+          #'[static-infos annot-prefix? rest.infoer-id rest.data])
          #'())]))))
 
 (define-syntax (rest-bind-infoer stx)
   (syntax-parse stx
-    [(_ up-static-infos [static-infos rest-infoer-id rest-data])
+    [(_ up-static-infos [static-infos annot-prefix? rest-infoer-id rest-data])
      #:with all-static-infos (static-infos-union #'static-infos #'up-static-infos)
      #:with rest-impl::binding-impl #'(rest-infoer-id all-static-infos rest-data)
-     #'rest-impl.info]))
+     (if (syntax-e #'annot-prefix?)
+         (annotation-str-update #'rest-impl.info
+                                (lambda (str) (string-append "& " str)))
+         #'rest-impl.info)]))
+
+(define-for-syntax (annotation-str-update info-stx updater)
+  (syntax-parse info-stx
+    [info::binding-info
+     (binding-info (annotation-string-from-pattern
+                    (updater
+                     (annotation-string-to-pattern
+                      (syntax-e #'info.annotation-str))))
+                   #'info.name-id
+                   #'info.static-infos
+                   #'info.bind-infos
+                   #'info.matcher-id
+                   #'info.committer-id
+                   #'info.binder-id
+                   #'info.data)]))

--- a/rhombus/scribblings/ref-list.scrbl
+++ b/rhombus/scribblings/ref-list.scrbl
@@ -184,7 +184,8 @@ it supplies its elements in order.
 
  Matches a non-empty list where @rhombus(elem_bind) matches the
  first element of the list and @rhombus(list_bind) matches the
- rest of the list.
+ rest of the list. Static information associated by @rhombus(List) is
+ propagated to @rhombus(list_bind).
 
 @examples(
   def List.cons(x, y): [1, 2, 3]


### PR DESCRIPTION
That is, `List.cons(elem, list)` should work exactly the same as `[elem, & list]`.  This way, more static information can be propagated.