### PR TITLE
Minor cleanup: remove trailing whitespace

### DIFF
--- a/enforest/main.rkt
+++ b/enforest/main.rkt
@@ -156,7 +156,7 @@
 
          (define enforest-step (make-enforest-step form-kind-str operator-kind-str
                                                    in-space prefix-operator-ref infix-operator-ref
-                                                   name-path-op in-name-root-space name-root-ref 
+                                                   name-path-op in-name-root-space name-root-ref
                                                    check-result track-origin 'parsed-tag
                                                    make-identifier-form
                                                    make-operator-form
@@ -200,7 +200,7 @@
                         #f
                         null
                         (information-about-bindings op-stx lookup-space-description)))
-  
+
   ;; Takes 3 or 4 arguments, depending on whether a preceding expression is available
   (define enforest-step
     (case-lambda
@@ -299,7 +299,7 @@
            (define-values (implicit-name ctx) (select-infix-implicit #'head))
            (dispatch-infix-implicit implicit-name ctx #'head)])
 
-        . where . 
+        . where .
 
         (define (dispatch-infix-operator op tail stxes op-stx)
           (define rel-prec (if (not current-op)
@@ -345,7 +345,7 @@
                [(eq? rel-prec 'same-on-left)
                 (raise-syntax-error #f
                                     (format
-                                     (string-append 
+                                     (string-append
                                       "combination of ~as at same precedence, but only in the other order;\n"
                                       " needs explicit parenthesization\n"
                                       "  earlier operator: ~a")
@@ -357,7 +357,7 @@
                [else
                 (raise-syntax-error #f
                                     (format
-                                     (string-append 
+                                     (string-append
                                       "combination of ~as without declared relative precedence;\n"
                                       " needs explicit parenthesization\n"
                                       "  other operator: ~a")

--- a/rhombus/private/function-parse.rkt
+++ b/rhombus/private/function-parse.rkt
@@ -84,7 +84,7 @@
     (pattern form::non-...
              #:with arg::binding #'form
              #:with parsed #'arg.parsed))
-  
+
   (define (keyword->binding kw)
     #`(group #,(datum->syntax kw (string->symbol (keyword->string (syntax-e kw))) kw)))
 
@@ -119,7 +119,7 @@
     (pattern (group kw:keyword))
     (pattern arg::non-...
              #:attr kw #'#f))
-  
+
   (define-syntax-class :kw-opt-binding
     #:attributes [kw parsed default]
     #:datum-literals (block group)
@@ -350,7 +350,7 @@
               (~alt (~optional ::pos-rest #:defaults ([arg #'#f] [parsed #'#f]))
                     (~optional ::kwp-rest #:defaults ([kwarg #'#f] [kwparsed #'#f])))
               ...)))
-  
+
   ;; used when just extracting an arity:
   (define-splicing-syntax-class :pos-arity-rest
     #:attributes [rest?]
@@ -446,7 +446,7 @@
                             (list (list arg+default) default)]
                            [else
                             (list (list kw arg+default) default)]))])
-          (define arity (summarize-arity kws defaults (syntax-e rest-arg) (syntax-e kwrest-arg)))               
+          (define arity (summarize-arity kws defaults (syntax-e rest-arg) (syntax-e kwrest-arg)))
           (define body
             (wrap-expression
              ((entry_point_meta.Adjustment-wrap-body adjustments)

--- a/rhombus/private/static-info-macro.rkt
+++ b/rhombus/private/static-info-macro.rkt
@@ -45,7 +45,7 @@
      unpack_group
      wrap
      lookup
-     
+
      call_result_key
      index_result_key
      index_get_key
@@ -68,7 +68,7 @@
 
 (define-defn-syntax macro
   (make-static-info-macro-macro in-static-info-space))
-   
+
 (define-for-syntax (convert-static-info who stx)
   (unless (syntax? stx)
     (raise-bad-macro-result who "static info" stx))

--- a/rhombus/tests/annot-macro.rhm
+++ b/rhombus/tests/annot-macro.rhm
@@ -59,7 +59,7 @@ check:
   import: rhombus/meta open
   annot.delayed_declare Forward
   class Posn(x, y)
-  annot.delayed_complete Forward: Posn  
+  annot.delayed_complete Forward: Posn
   fun (): (10 :: Forward).x
   ~completes
 

--- a/rhombus/tests/dot-macro.rhm
+++ b/rhombus/tests/dot-macro.rhm
@@ -54,7 +54,7 @@ check:
   ~is 4
 
 // checking some static-info propagation cases
-  
+
 dot.macro 'myint_dot_provider $left $dot $right $tail ...':
   match right
   | 'is_zero': '$left .= 0'

--- a/rhombus/tests/repet-macro.rhm
+++ b/rhombus/tests/repet-macro.rhm
@@ -20,7 +20,7 @@ repet.macro 'enum($from, $(sub :: repet_meta.Parsed))':
   def '($orig, $name, $expr, $depth, $use_depth, $statinfos, $is_immed)':
     repet_meta.unpack_list(sub)
   def (pred, si):
-    annot_meta.unpack_predicate(match 'List' | '$(p :: annot_meta.Parsed)': p)                                       
+    annot_meta.unpack_predicate(match 'List' | '$(p :: annot_meta.Parsed)': p)
   repet_meta.pack_list('($self(),
                          $name,
                          for List:


### PR DESCRIPTION
As I've been exploring Rhombus I've come across a few files with some extra whtiespace at the end of lines. I've just been running `M-x delete-trailing-whitespace` as I go along.