### PR TITLE
implement a slightly more general strategy for literals in `match`

### DIFF
--- a/rhombus/scribblings/ref-match.scrbl
+++ b/rhombus/scribblings/ref-match.scrbl
@@ -56,10 +56,11 @@
  generated exception's message may be specialized to report the expected
  pattern, instead of just reporting that no cases matched.
 
- If all @rhombus(bind) patterns are literals or combinations of literals
+ If an initial segment of @rhombus(bind) patterns are literals or combinations of literals
  with @rhombus(||, ~bind), then the match is implemented as a case
  dispatch, and a match is found with logarithmic rather than linear
- time complexity in the number of literals.
+ time complexity in the number of literals. The remaining patterns are
+ handled as usual.
 
 @examples(
   match 1+2

--- a/rhombus/tests/match.rhm
+++ b/rhombus/tests/match.rhm
@@ -16,10 +16,14 @@ check:
   | '($a + y, {[$n, ...]})': List.cons(a, [n, ...])
   ~prints_like ['z', '10', '11', '12']
 
-check:
+block:
+  let mutable cnt = 0
   fun f(x):
-    // literals for all patterns should be converted to `case` internally
-    match x
+    // literals for initial patterns should be converted to `case` internally
+    match (block:
+             // check whether expression is repeatedly evaluated
+             cnt := cnt + 1
+             x)
     | 0: 1
     | 1: 1
     | 2: 3
@@ -33,8 +37,9 @@ check:
     | 14: 5
     | 15: 5
     | #'apple: "other"
-  [f(0), f(5), f(10), f(#'apple)]
-  ~is [1, 5, 1, "other"]
+    | [_, ...]: "list"
+  check [f(0), f(5), f(10), f(#'apple), f([])] ~is [1, 5, 1, "other", "list"]
+  check cnt ~is 5
 
 check (match 1 | 1 || 2: "yes") ~is "yes"
 check (match 2 | 1 || 2: "yes") ~is "yes"


### PR DESCRIPTION
Similar to racket/racket#4522, an initial segment of literal patterns is expanded to `case`, and the remaining patterns are handled by the fallback.