### PR TITLE
implement more propagation of sequence element static infos

### DIFF
--- a/rhombus/private/map.rkt
+++ b/rhombus/private/map.rkt
@@ -461,6 +461,7 @@
                                              #'())
                                            #:static-infos map-static-info
                                            #:index-result-info? #t
+                                           #:sequence-element-info? #t
                                            #:rest-accessor
                                            (and maybe-rest
                                                 (if rest-repetition?

--- a/rhombus/private/set.rkt
+++ b/rhombus/private/set.rkt
@@ -23,6 +23,7 @@
          "call-result-key.rkt"
          "function-arity-key.rkt"
          "sequence-constructor-key.rkt"
+         "sequence-element-key.rkt"
          "parse.rkt"
          "literal.rkt"
          "realm.rkt"
@@ -318,6 +319,7 @@
                                            '()
                                            '()
                                            #:static-infos set-static-info
+                                           #:sequence-element-info? #t
                                            #:rest-accessor
                                            (and maybe-rest
                                                 (if rest-repetition?
@@ -432,7 +434,7 @@
     #`(for/and ([v (in-hash-keys (set-ht #,arg-id))])
         (#,(car predicate-stxs) v)))
   (lambda (static-infoss)
-    #`())
+    #`((#%sequence-element #,(car static-infoss))))
   #'set-build-convert #'())
 
 (define-syntax (set-build-convert arg-id build-convert-stxs kws data)

--- a/rhombus/tests/composite-statinfo.rhm
+++ b/rhombus/tests/composite-statinfo.rhm
@@ -33,6 +33,12 @@ block:
     ~completes
 
   check:
+    def [& xs] = (["a", "b", "cd"] :: List.of(String))
+    for List (x: xs):
+      x.length()
+    ~is [1, 1, 2]
+
+  check:
     def [x, ...] = (["a", "b", "cd"] :: List.of(String))
     [x.length(), ...]
     ~is [1, 1, 2]
@@ -55,18 +61,51 @@ block:
     ~is 1
 
   check:
-    def {_: val, ...} = ({1: "a", 2: "b", 3: "cd"} :: Map.of(Any, String))
-    {val.length(), ...}
-    ~is {1, 2}
+    def {& map}:
+      ({Box(1): "a", Box(2): "b", Box(3): "cd"} :: Map.of(Box, String))
+    for Set ((key, val): map):
+      key.value + val.length()
+    ~is {2, 3, 5}
 
   check:
-    def {& map :: Map.of(Any, String)} = {1: "a", 2: "b", 3: "cd"}
-    for Set ((_, val): map):
+    def {key: val, ...}:
+      ({Box(1): "a", Box(2): "b", Box(3): "cd"} :: Map.of(Box, String))
+    {key.value + val.length(), ...}
+    ~is {2, 3, 5}
+
+  check:
+    def {& map :: Map.of(Box, String)}:
+      {Box(1): "a", Box(2): "b", Box(3): "cd"}
+    for Set ((key, val): map):
+      key.value + val.length()
+    ~is {2, 3, 5}
+
+  check:
+    def {key :: Box: val :: String, ...} && map:
+      {Box(1): "a", Box(2): "b", Box(3): "cd"}
+    {key.value + val.length(), ...} == (for Set ((key, val): map):
+                                          key.value + val.length())
+    ~is #true
+
+  check:
+    def Set{& set} = ({"a", "b", "cd"} :: Set.of(String))
+    for Set (val: set):
       val.length()
     ~is {1, 2}
 
   check:
-    def {_: val :: String, ...} && map = {1: "a", 2: "b", 3: "cd"}
-    {val.length(), ...} == (for Set ((_, val): map):
+    def {val, ...} = ({"a", "b", "cd"} :: Set.of(String))
+    {val.length(), ...}
+    ~is {1, 2}
+
+  check:
+    def Set{& set :: Set.of(String)} = {"a", "b", "cd"}
+    for Set(val: set):
+      val.length()
+    ~is {1, 2}
+
+  check:
+    def {val :: String, ...} && set = {"a", "b", "cd"}
+    {val.length(), ...} == (for Set (val: set):
                               val.length())
     ~is #true

--- a/rhombus/tests/set.rhm
+++ b/rhombus/tests/set.rhm
@@ -226,3 +226,19 @@ block:
   check m == n ~is #false
   check m.snapshot() == n ~is #true
   check m.snapshot() === n ~is #false
+
+check:
+  use_static
+  class Posn(x, y)
+  def set :: Set.of(Posn) = {Posn(1, 2), Posn(3, 4), Posn(4, 5)}
+  for Set (val: set):
+    val.x + val.y
+  ~is {3, 7, 9}
+
+check:
+  ~eval
+  use_static
+  // make sure sequence element static info isn't confused for index
+  def set :: Set.of(String) = {"foo", "1", "Box(2)"}
+  set["foo"].length()
+  ~raises "no such field or method (based on static information)"


### PR DESCRIPTION
It makes sense to propagate sequence element static infos in composite bindings and set annotations.  Specifically, some care is taken to convert back and forth from two-value and pair static infos, which is needed for map bindings.