### PR TITLE
don’t propagate wrong number of static information in `for`

### DIFF
--- a/rhombus/scribblings/ref-static-info.scrbl
+++ b/rhombus/scribblings/ref-static-info.scrbl
@@ -189,7 +189,9 @@
         @rhombus(each, ~for_clause); for a sequence with
         multiple values in each element, the static information can
         map @rhombus(statinfo_meta.values_key) to a group of per-value
-        static information; when @rhombus(statinfo_meta.sequence_element_key)
+        static information; the number of static information must be
+        consistent with the bindings, otherwise no static information
+        will be propageted at all; when @rhombus(statinfo_meta.sequence_element_key)
         is not specified, @rhombus(each, ~for_clause) uses
         @rhombus(statinfo_meta.index_result_key)}
 

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -319,3 +319,45 @@ check:
   for Set (val: dynamic({1, 2, 3})):
     val
   ~is {1, 2, 3}
+
+check:
+  ~eval
+  use_static
+  for ((key, val): ([Box(1), Box(2), Box(3)] :: List.of(Box))):
+    key.value
+  ~raises "no such field or method (based on static information)"
+
+check:
+  ~eval
+  use_static
+  for ((key, val): ([Box(1), Box(2), Box(3)] :: List.of(Box))):
+    val.value
+  ~raises "no such field or method (based on static information)"
+
+check:
+  ~eval
+  use_static
+  for ((key, val): ({Box(1), Box(2), Box(3)} :: Set.of(Box))):
+    key.value
+  ~raises "no such field or method (based on static information)"
+
+check:
+  ~eval
+  use_static
+  for ((key, val): ({Box(1), Box(2), Box(3)} :: Set.of(Box))):
+    val.value
+  ~raises "no such field or method (based on static information)"
+
+check:
+  ~eval
+  use_static
+  for (val: ({Box(1): "1", Box(2): "2", Box(3): "3"} :: Map.of(Box, String))):
+    val.value
+  ~raises "no such field or method (based on static information)"
+
+check:
+  ~eval
+  use_static
+  for (val: ({Box(1): "1", Box(2): "2", Box(3): "3"} :: Map.of(Box, String))):
+    val.length()
+  ~raises "no such field or method (based on static information)"


### PR DESCRIPTION
I think this behavior results in better error reporting in general.  Moreover, the *whole* multiple-value static information shouldn’t be propagated to each value anyway.