### PR TITLE
scribble/rhombus: fix spacers of `extends`/`implements`

### DIFF
--- a/scribble/private/rhombus-spacer.rhm
+++ b/scribble/private/rhombus-spacer.rhm
@@ -9,6 +9,8 @@ export:
     fun
     class
     interface
+    extends
+    implements
     match
     ::
     :~
@@ -115,7 +117,7 @@ meta:
         spacer.adjust_sequence(tail, context, esc)
 
 spacer.bridge extends(self, tail, context, esc):
-  ~in: ~class_clause
+  ~in: ~class_clause ~interface_clause
   adjust_extends(self, tail, context, esc)
 
 spacer.bridge implements(self, tail, context, esc):
@@ -126,7 +128,7 @@ meta:
   fun adjust_extends(self, tail, context, esc):
     match tail
     | ': $(b :: Block)':
-        '$self $(': $(spacer.adjust_term(b, #'~class, esc))'.relocate(b))'
+        '$self $(spacer.adjust_term(b, #'~class, esc).relocate(b))'
     | '$tail ...':
         '$self $(spacer.adjust_sequence('$tail ...', #'~class, esc))'
 

--- a/scribble/private/spacer.rhm
+++ b/scribble/private/spacer.rhm
@@ -24,12 +24,15 @@ meta:
     | '$(t :: Term) ...':
         '$(Syntax.property(t, #'#{typeset-space-name}, context, #true)) ...'.relocate(stx)
 
-  fun is_relevant_context(context, in_contexts :~ List):
+  fun find_relevant_context(context, in_contexts :~ List):
     let nows :~ List = #{full-space-names}(context)
-    for any:
+    // `relevant_context` can be `#false` (the default space)
+    for values(found = #false, relevant_context = #false):
       each now: nows
       each in: in_contexts
-      now == in
+      skip_when now != in
+      final_when #true
+      values(#true, now)
 
   fun head_context(stxs):
     match stxs
@@ -92,28 +95,20 @@ meta:
     | '$(id :: Name) $tail ...':
         def mv = syntax_meta.value(id, typeset_meta.space, #false)
         match mv
-        | typeset_meta.Spacer(in_contexts, proc) when is_relevant_context(context, in_contexts):
-            let res:
-              try:
-                let id:
-                  cond
-                  | in_contexts.length() == 1:
-                      set_space(id, in_contexts[0])
-                  | ~else:
-                      let contexts :~ List = #{full-space-names}(context)    
-                      cond
-                      | contexts.length() == 1:
-                          set_space(id, contexts[0])
-                      | ~else:
-                          id
-                proc(id, '$tail ...', context, esc)
-                ~catch x :: Exn.Fail:
-                  error("error from " +& to_string(id, ~mode: #'expr) +& " spacer\n"
-                          +& "  message: " +& Exn.message(x))
-            match res
-            | '$_ ...': res
-            | ~else:
-                error(#false, "spacer " +& proc +& " returned wrong value " +& to_string(res, ~mode: #'value))
+        | typeset_meta.Spacer(in_contexts, proc):
+            let (found, relevant_context) = find_relevant_context(context, in_contexts)
+            if found
+            | let res:
+                try:
+                  proc(set_space(id, relevant_context), '$tail ...', context, esc)
+                  ~catch x :: Exn.Fail:
+                    error("error from " +& to_string(id, ~mode: #'expr) +& " spacer\n"
+                            +& "  message: " +& Exn.message(x))
+              match res
+              | '$_ ...': res
+              | ~else:
+                  error(#false, "spacer " +& proc +& " returned wrong value " +& to_string(res, ~mode: #'expr))
+            | default()
         | ~else:
             // `id` might be a dotted name, so don't treat it as a term
             default()


### PR DESCRIPTION
Also use the found relevant context for the “self” id, which is necessary for the correct linking of `extends` itself.