### PR TITLE
revise `pattern` shorthand

### DIFF
--- a/rhombus/private/check.rhm
+++ b/rhombus/private/check.rhm
@@ -13,27 +13,25 @@ export:
 meta:
   syntax_class ResultMode:
     kind: ~term
-    pattern
-    | '~is'
-    | '~is_now'
-    | '~is_a'
-    | '~prints_like'
-    | '~prints'
-    | '~raises'
-    | '~matches'
+  | '~is'
+  | '~is_now'
+  | '~is_a'
+  | '~prints_like'
+  | '~prints'
+  | '~raises'
+  | '~matches'
       
   syntax_class Result:
     kind: ~sequence
-    pattern
-    | '$(mode :: ResultMode): $body':
-        field [suffix, ...]: []
-    | '$(mode :: ResultMode) $g ...':
-        field body: '$g ...'
-        field [suffix, ...]: []
-    | '~completes':
-        field mode: '~completes'
-        field body: '#void'
-        field [suffix, ...]: ['#void']
+  | '$(mode :: ResultMode): $body':
+      field [suffix, ...]: []
+  | '$(mode :: ResultMode) $g ...':
+      field body: '$g ...'
+      field [suffix, ...]: []
+  | '~completes':
+      field mode: '~completes'
+      field body: '#void'
+      field [suffix, ...]: ['#void']
 
   syntax_class EvalClause:
     fields: make_eval

--- a/rhombus/private/pattern.rkt
+++ b/rhombus/private/pattern.rkt
@@ -1,6 +1,10 @@
 #lang racket/base
 (require (for-syntax racket/base
-                     syntax/parse/pre)
+                     syntax/parse/pre
+                     (only-in shrubbery/print
+                              shrubbery-syntax->string)
+                     "annotation-string.rkt"
+                     "srcloc.rkt")
          "binding.rkt"
          (only-in "unquote-binding-primitive.rkt"
                   pattern
@@ -16,29 +20,42 @@
                     pattern))
 
 ;; the `pattern` form for a binding context is here;
-;; the `pattern` form for `syntax_class` is in "syntax-class-clause-primitive.rkt";
 ;; the `pattern` form for `$` is in "unquote-binding-primitive.rkt"
 
 (define-binding-syntax pattern
   (binding-transformer
    (lambda (stx)
-     (define (expand s tail)
+     (define (expand s)
        (syntax-parse #`(group #%quotes
                               (quotes (group (op $)
                                              (parens ;; needs `#%parens` binding
                                               (group . #,s)))))
          [b::binding
-          (values #'b.parsed tail)]))
+          #:with b-form::binding-form #'b.parsed
+          (binding-form
+           #'pattern-infoer
+           #`[#,(annotation-string-from-pattern (shrubbery-syntax->string stx))
+              b-form.infoer-id b-form.data])]))
      (with-syntax ([pattern (syntax-parse stx
                               [(head . _)
                                (datum->syntax #'here 'pattern #'head #'head)])])
        (syntax-parse stx
-         [(_ (~and a (_::alts alt ...)) . tail)
-          (expand #'(pattern a)
-                   #'tail)]
-         [(_ (~and pat (_::quotes . _)) (~and b (_::block . _)))
-          (expand #'(pattern pat b)
-                  #'())]
-         [(_ (~and pat (_::quotes . _)) . tail)
-          (expand #'(pattern pat)
-                  #'tail)])))))
+         [(_ . tail)
+          (values (expand (relocate+reraw
+                           (respan stx)
+                           #'(pattern . tail)))
+                  #'())])))))
+
+(define-syntax (pattern-infoer stx)
+  (syntax-parse stx
+    [(_ up-static-infos [annot-str infoer-id data])
+     #:with impl::binding-impl #'(infoer-id up-static-infos data)
+     #:with info::binding-info #'impl.info
+     (binding-info #'annot-str
+                   #'info.name-id
+                   #'info.static-infos
+                   #'info.bind-infos
+                   #'info.matcher-id
+                   #'info.committer-id
+                   #'info.binder-id
+                   #'info.data)]))

--- a/rhombus/scribblings/ref-pattern-clause-macro.scrbl
+++ b/rhombus/scribblings/ref-pattern-clause-macro.scrbl
@@ -11,28 +11,32 @@
 @title{Syntax Pattern Clause Macros}
 
 @doc(
+  ~nonterminal:
+    pattern_body: syntax_class ~defn
+
   space.transform pattern_clause
 ){
 
  The @tech{space} for bindings of identifiers that implement
- @rhombus(pattern, ~bind) clauses.
+ @rhombus(pattern_body) clauses.
 
 }
 
 @doc(
   ~nonterminal:
     prefix_macro_patterns: defn.macro ~defn
+    pattern_body: syntax_class ~defn
 
   defn.macro 'pattern_clause.macro $prefix_macro_patterns'
 ){
 
  Similar to @rhombus(defn.macro), but defines a name in the
  @rhombus(pattern_clause, ~space) @tech{space} as a clause form
- for use within a @rhombus(pattern, ~bind) body.
+ for use within a @rhombus(pattern_body).
 
  The compile-time @rhombus(body, ~var) block returns the expansion result. The
  result must be a sequence of groups to be spliced in place of the macro
- use within a @rhombus(pattern) body.
+ use within a @rhombus(pattern_body).
 
 }
 

--- a/rhombus/scribblings/ref-syntax-class-clause-macro.scrbl
+++ b/rhombus/scribblings/ref-syntax-class-clause-macro.scrbl
@@ -31,15 +31,15 @@
  for use within a @rhombus(syntax_class) body.
 
  The compile-time @rhombus(body, ~var) block returns the expansion result. The
- result must be a sequence of groups to be spliced in place of the macro
- use within a @rhombus(syntax_class) body.
+ result must be a block of groups optionally followed by syntax patterns
+ to be spliced in place of the macro use within a @rhombus(syntax_class) body.
+ The spliced syntax patterns can be supplied at most once.
 
 @examples(
   ~eval: macro_eval
   ~defn:
     syntax_class_clause.macro 'maybe_block $id $rhs_id':
-      '«fields: [$rhs_id, $('...')]
-        pattern
+      '«: fields: [$rhs_id, $('...')]
         | '$id: $('$')$rhs_id; $('...')'
         | '$id $('$')rhs0 $('...')':
             field [$rhs_id, $('...')] = ['$('$')rhs0 $('...')']»'

--- a/rhombus/scribblings/ref-syntax-class.scrbl
+++ b/rhombus/scribblings/ref-syntax-class.scrbl
@@ -28,17 +28,11 @@
     #,(epsilon)
 
   grammar class_clause:
-    #,(@rhombus(pattern, ~syntax_class_clause)) $pattern_cases
     #,(@rhombus(description, ~syntax_class_clause)) $desc_rhs
     #,(@rhombus(error_mode, ~syntax_class_clause)) $error_mode_rhs
     #,(@rhombus(kind, ~syntax_class_clause)) $kind_rhs
     #,(@rhombus(fields, ~syntax_class_clause)): $field_decl
     #,(@rhombus(root_swap, ~syntax_class_clause)): $id $id
-
-  grammar pattern_cases:
-    $pattern_case
-    Z| $pattern_case
-     | ...
 
   grammar pattern_case:
     $syntax_pattern
@@ -63,14 +57,8 @@
  syntax classes.
 
  Syntax forms matched by the syntax class are described by
- @rhombus(pattern_case) alternatives. The
- @rhombus(pattern, ~syntax_class_clause) clause is optional in the sense
- that pattern alternatives can be inlined directly in the
- @rhombus(syntax_class) form, in which case @rhombus(pattern, ~syntax_class_clause)
- must not appear as a clause. Each kind of
- @rhombus(class_clause) alternative can be supplied at most once, and
- @rhombus(pattern, ~syntax_class_clause) is required if no @rhombus(pattern_case)
- alternatives are supplied inline.
+ @rhombus(pattern_case) alternatives. Each kind of
+ @rhombus(class_clause) alternative can be supplied at most once.
 
  An optional @rhombus(description,  ~syntax_class_clause) clause
  provides a description of the syntax class, which is used to produce
@@ -211,65 +199,14 @@
     syntax_class.together:
       syntax_class ModPath:
         fields: [elem, ...]
-        pattern
-        | '$head':
-            field [elem, ...]: [head]
-        | '$head / $(mp :: ModPath)':
-            field [elem, ...] = [head, mp.elem, ...]
+      | '$head':
+          field [elem, ...]: [head]
+      | '$head / $(mp :: ModPath)':
+          field [elem, ...] = [head, mp.elem, ...]
   ~repl:
     match 'a / b / c'
     | '$(mp :: ModPath)':
         [mp.elem, ...]
-)
-
-}
-
-
-@doc(
-  ~nonterminal:
-    pattern_cases: syntax_class pattern_cases ~defn
-    pattern_case: syntax_class pattern_case ~defn
-                   
-  syntax_class_clause.macro 'pattern $pattern_cases'
-  bind.macro 'pattern $pattern_cases'
-){
-
- The @rhombus(pattern, ~syntax_class_clause) clause form in
- @rhombus(syntax_class) describes the patterns that the class matches;
- see @rhombus(syntax_class) for more information. A
- @rhombus(pattern, ~syntax_class_clause) class with only a
- @rhombus(pattern_case) is a shorthand for writing the
- @rhombus(pattern_case) in a single @litchar{|} alternative.
-
- The binding variant of @rhombus(pattern , ~syntax_class_clause) (for
- direct use in a binding context) has the same syntax and matching rules
- as a @rhombus(pattern, ~syntax_class_clause) form in
- @rhombus(syntax_class), but with all fields exposed. In particular, a
- @rhombus(pattern_case) can have a block with
- @rhombus(match_def, ~pattern_clause),
- @rhombus(match_when, ~pattern_clause), and
- @rhombus(match_unless, ~pattern_clause) clauses that refine the match.
-
-@examples(
-  ~defn:
-    fun simplify(e):
-      match e
-      | '($e)': simplify(e)
-      | '0 + $e': simplify(e)
-      | '$e + 0': simplify(e)
-      | (pattern '$a + $b - $c':
-           match_when same(simplify(b), simplify(c))):
-          simplify(a)
-      | (pattern '$a - $b + $c':
-           match_when same(simplify(b), simplify(c))):
-          simplify(a)
-      | ~else: e
-  ~defn:
-    fun same(b, c):
-      b.unwrap() == c.unwrap()
-  ~repl:
-    simplify('(1 + (2 + 0) - 2)')
-    simplify('1 + 2 + 2')
 )
 
 }
@@ -321,8 +258,7 @@
   ~defn:
     syntax_class Parenthesized:
       root_swap: content group
-      pattern
-      | '($content)'
+    | '($content)'
   ~repl:
     match '(1 2 3)'
     | '$(p :: Parenthesized)':

--- a/rhombus/scribblings/syntax-class.scrbl
+++ b/rhombus/scribblings/syntax-class.scrbl
@@ -84,19 +84,7 @@ spliced sequences that have different lengths.
 Although Rhombus supports new binding operators through
 @rhombus(unquote_bind.macro), syntax classes provide a better way to
 organize most syntax abstractions. To define a new syntax class, use the
-@rhombus(syntax_class) form with a block that contains
-@rhombus(pattern) with pattern alternatives:
-
-@demo(
-  ~defn:
-    syntax_class Arithmetic:
-      pattern
-      | '$x + $y'
-      | '$x - $y'
-)
-
-An equivalent shorthand omits the use of @rhombus(pattern, ~syntax_class_clause)
-and inlines alternatives into the immediate @rhombus(syntax_class) form:
+@rhombus(syntax_class) form:
 
 @demo(
   ~defn:

--- a/rhombus/tests/syntax-class-clause-macro.rhm
+++ b/rhombus/tests/syntax-class-clause-macro.rhm
@@ -1,8 +1,7 @@
 #lang rhombus/and_meta
 
 syntax_class_clause.macro 'maybe_block $id $body':
-  '«fields: [$body, $('...')]
-    pattern
+  '«: fields: [$body, $('...')]
     | '$id: $('$')$body; $('...')'
     | '$id $('$')body0 $('...')':
         field [$body, $('...')] = ['$('$')body0 $('...')']»'

--- a/rhombus/tests/syntax-class.rhm
+++ b/rhombus/tests/syntax-class.rhm
@@ -57,8 +57,7 @@ check:
     fields:
       x: kind ~term
       y
-    pattern
-    | '$x $op $y'
+  | '$x $op $y'
   match '1+2'
   | '$(exp :: Arithmetic)': [exp.x, exp.y]
   ~prints_like ['1', '2']
@@ -179,9 +178,8 @@ block:
     meta:
       syntax_class Arithmetic:
         description: "an expression with addition or subtraction"
-        pattern
-        | '$x + $y'
-        | '$x - $y'
+      | '$x + $y'
+      | '$x - $y'
     expr.macro 'right_operand $(e :: Arithmetic)':
       values(e.y, '')
     right_operand 1 +
@@ -214,8 +212,7 @@ check:
 block:
   syntax_class Foo:
     kind: ~sequence
-    pattern
-    | '$x + $y'
+  | '$x + $y'
   check:
     match '0 + 1 + 2'
     | '0 + $(f :: Foo)': [f.x, f.y]
@@ -224,8 +221,7 @@ block:
 block:
   syntax_class Foo:
     kind: ~term
-    pattern
-    | '($x + $y)'
+  | '($x + $y)'
   check:
     match '0 + (1 + 2)'
     | '0 + $(f :: Foo)': [f.x, f.y]
@@ -235,8 +231,7 @@ check:
   ~eval
   syntax_class Foo:
     kind: ~term
-    pattern
-    | '$x + $y'
+  | '$x + $y'
   ~raises "not a single-term pattern"
 
 block:
@@ -295,9 +290,8 @@ block:
 block:
   syntax_class Foo:
     kind: ~block
-    pattern
-    | ': $x + $y
-         $z - $w'
+  | ': $x + $y
+       $z - $w'
   check:
     match ': 1 + 2
              3 - 4'
@@ -308,16 +302,14 @@ check:
   ~eval
   syntax_class Foo:
     kind: ~block
-    pattern
-    | '($x + $y,
-        $z - $w)'
+  | '($x + $y,
+      $z - $w)'
   ~raises "not a block pattern"
 
 block:
   syntax_class Foo:
     kind: ~multi
-    pattern
-    | '($x, $y)'
+  | '($x, $y)'
   check:
     match '((1 + 2, 3 - 4))'
     | '($(f :: Foo))': f
@@ -336,8 +328,7 @@ block:
 block:
   syntax_class Foo:
     kind: ~multi
-    pattern
-    | '$x'
+  | '$x'
   check:
     match '(1 + 2, 3 - 4)'
     | '($(f :: Foo))': f
@@ -348,16 +339,15 @@ block:
     ~prints_like '1 + 2; 3 - 4; 5 / 6'
 
 block:
-  syntax_class Foo:
-    pattern
-    | '$x $y':
-        match_when y.unwrap() == 1
-        field case: '1'
-    | '$x $y':
-        match_unless y.unwrap() == 5
-        field case: '2'
-    | '$x $y':
-        field case: '3'
+  syntax_class Foo
+  | '$x $y':
+      match_when y.unwrap() == 1
+      field case: '1'
+  | '$x $y':
+      match_unless y.unwrap() == 5
+      field case: '2'
+  | '$x $y':
+      field case: '3'
   check:
     def '$(f :: Foo)': 'a 1'
     [f.x, f.y, f.case]
@@ -372,18 +362,17 @@ block:
     ~prints_like ['c', '5', '3']
    
 block:
-  syntax_class Foo:
-    pattern
-    | '$x $y':
-        match_def '(1 + 1)': y
-        field case: '1'
-        field z: '0'
-    | '$x $y':
-        match_def '(1 + $z)': y
-        field case: '2'
-    | '$x $y':
-        field case: '3'
-        field z: 'no'
+  syntax_class Foo
+  | '$x $y':
+      match_def '(1 + 1)': y
+      field case: '1'
+      field z: '0'
+  | '$x $y':
+      match_def '(1 + $z)': y
+      field case: '2'
+  | '$x $y':
+      field case: '3'
+      field z: 'no'
   check:
     def '$(f :: Foo)': 'a 1'
     [f.x, f.y, f.case, f.z]
@@ -400,20 +389,18 @@ block:
 check:
   syntax_class Option:
     kind: ~term
-    pattern
-    | '~lang':
-        field form: '~lang'
+  | '~lang':
+      field form: '~lang'
   match '(~lang, ~lang)'
   | '($(o :: Option), ...)': [o.form, ...]
   ~prints_like ['~lang', '~lang']
 
 check:
-  syntax_class Option:
-    pattern
-    | '~lang':
-        field form: '~lang'
-    | '~lang ~and':
-        field form: '~and'
+  syntax_class Option
+  | '~lang':
+      field form: '~lang'
+  | '~lang ~and':
+      field form: '~and'
   match '(~lang, ~lang ~and)'
   | '($(o :: Option), ...)': [o.form, ...]
   ~prints_like ['~lang', '~and']
@@ -422,19 +409,17 @@ check:
   ~eval
   syntax_class Option:
     kind: ~term
-    pattern
-    | '~lang':
-        field form: '~lang'
+  | '~lang':
+      field form: '~lang'
   match '(~lang, ~lang)'
   | '($(o :: Option), ...)': [o.form]
   ~raises "field is a repetition"
 
 check:
   ~eval
-  syntax_class Option:
-    pattern
-    | '~lang':
-        field form: '~lang'
+  syntax_class Option
+  | '~lang':
+      field form: '~lang'
   match '(~lang, ~lang)'
   | '($(o :: Option), ...)': [o.form]
   ~raises "field is a repetition"
@@ -491,10 +476,9 @@ block:
 
 // empty pattern is a special case
 block:
-  syntax_class Maybe:
-    pattern
-    | '1'
-    | ''
+  syntax_class Maybe
+  | '1'
+  | ''
 
   check:
     def '$(x :: Maybe) 2' = '2'
@@ -529,21 +513,19 @@ check:
 
 // field value does not have to be syntax
 check:
-  syntax_class Foo:
-    pattern
-    | '$x':
-        field [y, ...] = [1, #'~q, 3]
+  syntax_class Foo
+  | '$x':
+      field [y, ...] = [1, #'~q, 3]
   match 'x'
   | '$(f :: Foo)': [f.y, ...]
   ~is [1, #'~q, 3]    
 
 // a field used both as a non-syntax and a sytax field
 block:
-  syntax_class Foo:
-    pattern
-    | '$x':
-        field [y, ...] = [1, #'~q, 3]
-    | '$x $y ...'
+  syntax_class Foo
+  | '$x':
+      field [y, ...] = [1, #'~q, 3]
+  | '$x $y ...'
   check:
     match 'x'
     | '$(f :: Foo)': [f.y, ...]
@@ -562,9 +544,8 @@ block:
 block:
   syntax_class Foo:
     kind: ~group
-    pattern
-    | '$x ($y + 1) ...'
-    | '$x $y ...'
+  | '$x ($y + 1) ...'
+  | '$x $y ...'
   check:
     match 'x (1 + 1) (2 + 1) 3'
     | '$(f :: Foo)': [f.y, ...]
@@ -578,10 +559,9 @@ block:
 block:
   fun m(stx):
     def '$(f2 :: (syntax_class:
-                    pattern
-                    | '9 $x $_'
-                    | '8 $x':
-                        match_when #true)); ...' = stx  
+                  | '9 $x $_'
+                  | '8 $x':
+                      match_when #true)); ...' = stx
     [f2.x, ...]
   check:
     m('8 1')
@@ -600,10 +580,9 @@ block:
 block:
   fun m(stx):
     def '$(f2 :: (syntax_class:
-                    pattern
-                    | '9 $x $_'
-                    | '8 $x':
-                        match_when #true):
+                  | '9 $x $_'
+                  | '8 $x':
+                      match_when #true):
              open); ...' = stx  
     [x, ...]
   check:
@@ -613,33 +592,185 @@ block:
     m('8 1; 9 2 3')
     ~prints_like ['1', '2']
 
+// pattern shorthand unquote
+block:
+  fun m(stx):
+    def '$(pattern
+           | '9 $x $_'
+           | '8 $x':
+               match_when #true); ...' = stx
+    [x, ...]
+  check:
+    m('8 1')
+    ~prints_like ['1']
+  check:
+    m('8 1; 9 2 3')
+    ~prints_like ['1', '2']
+
+block:
+  fun m(stx):
+    def '$(pattern:
+             kind ~sequence
+           | '9 $x $_'
+           | '8 $x':
+               match_when #true); ...' = stx
+    [x, ...]
+  check:
+    m('8 1')
+    ~prints_like ['1']
+  check:
+    m('8 1; 9 2 3')
+    ~prints_like ['1', '2']
+
+block:
+  fun m(stx):
+    def '$(pattern match
+           | '9 $x $_'
+           | '8 $x':
+               match_when #true); ...' = stx
+    [match.x, ...]
+  check:
+    m('8 1')
+    ~prints_like ['1']
+  check:
+    m('8 1; 9 2 3')
+    ~prints_like ['1', '2']
+
+block:
+  fun m(stx):
+    def '$(pattern match:
+             kind ~sequence
+           | '9 $x $_'
+           | '8 $x':
+               match_when #true); ...' = stx
+    [match.x, ...]
+  check:
+    m('8 1')
+    ~prints_like ['1']
+  check:
+    m('8 1; 9 2 3')
+    ~prints_like ['1', '2']
+
+// pattern shorthand binding
+block:
+  fun m(stx):
+    def [pattern
+         | '9 $x $_'
+         | '8 $x':
+             match_when #true, ...] = stx
+    [x, ...]
+  check:
+    m(['8 1'])
+    ~prints_like ['1']
+  check:
+    m(['8 1', '9 2 3'])
+    ~prints_like ['1', '2']
+
+block:
+  fun m(stx):
+    def [pattern:
+           kind ~sequence
+         | '9 $x $_'
+         | '8 $x':
+             match_when #true, ...] = stx
+    [x, ...]
+  check:
+    m(['8 1'])
+    ~prints_like ['1']
+  check:
+    m(['8 1', '9 2 3'])
+    ~prints_like ['1', '2']
+
+// The following two tests currently do not work due to how
+// repetitions are handled.  If these are to be fixed, the
+// corresponding `::` forms should also be fixed.
+#//
+block:
+  fun m(stx):
+    def [pattern match
+         | '9 $x $_'
+         | '8 $x':
+             match_when #true, ...] = stx
+    [match.x, ...]
+  check:
+    m(['8 1'])
+    ~prints_like ['1']
+  check:
+    m(['8 1', '9 2 3'])
+    ~prints_like ['1', '2']
+
+#//
+block:
+  fun m(stx):
+    def [pattern match:
+           kind ~sequence
+         | '9 $x $_'
+         | '8 $x':
+             match_when #true, ...] = stx
+    [match.x, ...]
+  check:
+    m(['8 1'])
+    ~prints_like ['1']
+  check:
+    m(['8 1', '9 2 3'])
+    ~prints_like ['1', '2']
+
 // check interaction of macro introduction and pattern variables
 block:
   import rhombus/meta open
   check:
     expr.macro 'matcher $(ex :: Term)':
       '«match '1 2'
-        | (pattern '$('$')x $('$')$ex'): x»'
+        | (pattern | '$('$')x $('$')$ex'): x»'
     matcher x
     ~prints_like '1'
   check:
     expr.macro 'matcher $(ex :: Term)':
       '«match '1 2'
-        | (pattern '$('$')x $('$')$ex'): $ex»'
-    matcher x
-    ~prints_like '2'  
-  check:
-    expr.macro 'matcher $(ex :: Term)':
-      '«match '1 2'
-        | (pattern '$('$')$ex $('$')x'): x»'
+        | (pattern | '$('$')x $('$')$ex'): $ex»'
     matcher x
     ~prints_like '2'
   check:
     expr.macro 'matcher $(ex :: Term)':
       '«match '1 2'
-        | (pattern '$('$')$ex $('$')x'): $ex»'
+        | (pattern | '$('$')$ex $('$')x'): x»'
+    matcher x
+    ~prints_like '2'
+  check:
+    expr.macro 'matcher $(ex :: Term)':
+      '«match '1 2'
+        | (pattern | '$('$')$ex $('$')x'): $ex»'
     matcher x
     ~prints_like '1'
+
+// field names are recognized symbolically
+// Is this the expected behavior?  I think it is.
+block:
+  import rhombus/meta open
+  check:
+    expr.macro 'matcher $(ex :: Term)':
+      '«match '1 2'
+        | (pattern who | '$('$')x $('$')$ex'): who.x»'
+    matcher x
+    ~prints_like '2'
+  check:
+    expr.macro 'matcher $(ex :: Term)':
+      '«match '1 2'
+        | (pattern who | '$('$')x $('$')$ex'): who . $ex»'
+    matcher x
+    ~prints_like '2'
+  check:
+    expr.macro 'matcher $(ex :: Term)':
+      '«match '1 2'
+        | (pattern who | '$('$')$ex $('$')x'): who.x»'
+    matcher x
+    ~prints_like '2'
+  check:
+    expr.macro 'matcher $(ex :: Term)':
+      '«match '1 2'
+        | (pattern who | '$('$')$ex $('$')x'): who . $ex»'
+    matcher x
+    ~prints_like '2'
 
 // infer ~multi mode
 check:
@@ -660,8 +791,7 @@ check:
 check:
   syntax_class C:
     root_swap: second terms
-    pattern
-    | '$_ $second'
+  | '$_ $second'
   match '1 2'
   | '$(c :: C)':
       [c, c.terms]
@@ -671,16 +801,14 @@ check:
   ~eval
   syntax_class C:
     root_swap: unknown terms
-    pattern
-    | '$_ $second'
+  | '$_ $second'
   ~raises "field to swap as root not found"
 
 check:
   ~eval
   syntax_class C:
     root_swap: second first
-    pattern
-    | '$first $second'
+  | '$first $second'
   ~raises "field for root already exists"
 
 
@@ -689,11 +817,10 @@ check:
     syntax_class ModPath:
       fields:
         [elem, ...]
-      pattern
-      | '$head':
-          field [elem, ...]: [head]
-      | '$head / $(mp :: ModPath)':
-          field [elem, ...] = [head, mp.elem, ...]
+    | '$head':
+        field [elem, ...]: [head]
+    | '$head / $(mp :: ModPath)':
+        field [elem, ...] = [head, mp.elem, ...]
   match 'a / b / c'
   | '$(mp :: ModPath)':
       [mp.elem, ...]

--- a/scribble/private/docmodule.rhm
+++ b/scribble/private/docmodule.rhm
@@ -31,16 +31,15 @@ meta:
   | pack_tree([v, ...]): [pack_tree(v), ...]
   | pack_tree(v): Syntax.make(v, #false)
 
-  syntax_class Option:
-    pattern
-    | '~lang':
-        field [form, ...]: ['~lang']
-    | '~no_declare':
-        field [form, ...]: ['#{#:no-declare}']
-    | '~use_sources: $modpath; ...':
-        field [form, ...]: ['#{#:use-sources}',
-                            pack_tree([ModulePath.s_exp(ModulePath('$modpath')),
-                                       ...])]
+  syntax_class Option
+  | '~lang':
+      field [form, ...]: ['~lang']
+  | '~no_declare':
+      field [form, ...]: ['#{#:no-declare}']
+  | '~use_sources: $modpath; ...':
+      field [form, ...]: ['#{#:use-sources}',
+                          pack_tree([ModulePath.s_exp(ModulePath('$modpath')),
+                                     ...])]
 
 decl.macro 'docmodule ($(option :: Option), ..., $mod ...)':
   let is_lang:


### PR DESCRIPTION
Now that we allow a block before alts, the `pattern` syntax class clause is redundant and arguably disfavored.  Not only that, it also ties the meaning of the corresponding (unquote) binding operator to it.  I think it’d be better that the syntax class clause simply be removed, and the (unquote) binding operator be changed into an actual shorthand for an inline syntax class matching.

My experience is that inline syntax classes are quite useful for the same reason complex patterns in `syntax/parse` are useful, but using them unfortunately requires an unnaturally large amount of rightward shift.  Moreover, supplying `open` with inline syntax classes is common but, again, looks ugly.  Therefore I believe `pattern` can serve a better purpose this way.

Interestingly, syntax class clause macros originally can supply spliced patterns through `pattern`.  This use is kept through changing the expected expansion to a block optionally followed by alts.

Two remaining problems:

1. ~~Some test cases that seem to be testing the “scopes” of attribute names don’t work anymore.  Actually, I’m not sure if they’re supposed to work at all in the first place since the corresponding syntax classes don’t work this way.  If they should work, then the fix should be generalizable to all syntax classes.~~  
   Reverted to the original behavior.

3. The handling of repetitions *above* the quasiquote doesn’t seem to cover attributes.  Although this is not directly related to `pattern` per se, the issue may be apparent when the `pattern` binding is used in a composite binding form.  Again, the fix should be generalizable.