### PR TITLE
fix generation of attributes in inline `pattern`s

### DIFF
--- a/rhombus/private/attribute-name.rkt
+++ b/rhombus/private/attribute-name.rkt
@@ -1,10 +1,19 @@
 #lang racket/base
 
-(provide compose-attr-name)
+(provide compose-attr-name
+         inline-attr-depth
+         inline-form-id)
 
-(define (compose-attr-name match-id sym id bind-counter)
-  ;; when `match-id` is #f, then we're opening an inline syntax class, and
-  ;; we want to avoid clashes in symbolic names (as long as they have different scopes)
+(define (compose-attr-name match-id sym id)
+  ;; when `match-id` is #f, then we're dealing with inline `pattern`s
   (if match-id
       (datum->syntax match-id (string->symbol (format "~a.~a" (syntax-e match-id) sym)) id)
-      (datum->syntax id (string->symbol (format "inline~a.~a" bind-counter sym)) id)))
+      (datum->syntax (or id (inline-form-id))
+                     (string->symbol (format "~a.~a.~a" (syntax-e (inline-form-id)) (inline-attr-depth) sym))
+                     id)))
+
+;; handle nested inline `pattern`s
+(define inline-attr-depth (make-parameter #f))
+
+;; handle `open`ed syntax classes
+(define inline-form-id (make-parameter #f))

--- a/rhombus/private/pattern.rkt
+++ b/rhombus/private/pattern.rkt
@@ -3,18 +3,17 @@
                      syntax/parse/pre
                      (only-in shrubbery/print
                               shrubbery-syntax->string)
-                     "annotation-string.rkt"
-                     "srcloc.rkt")
+                     "annotation-string.rkt")
          "binding.rkt"
+         "unquote-binding.rkt"
+         (submod "unquote-binding-primitive.rkt" for-parse-pattern)
          (only-in "unquote-binding-primitive.rkt"
-                  pattern
                   #%parens)
          (only-in "quasiquote.rkt"
                   #%quotes)
          (only-in "dollar.rkt"
                   $)
-         "parse.rkt"
-         "parens.rkt")
+         "parse.rkt")
 
 (provide (for-space rhombus/bind
                     pattern))
@@ -22,29 +21,28 @@
 ;; the `pattern` form for a binding context is here;
 ;; the `pattern` form for `$` is in "unquote-binding-primitive.rkt"
 
+(define-unquote-binding-syntax bounce-to-pattern
+  (unquote-binding-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(_ . tail)
+        (parse-pattern #'tail)]))))
+
 (define-binding-syntax pattern
   (binding-transformer
    (lambda (stx)
-     (define (expand s)
-       (syntax-parse #`(group #%quotes
-                              (quotes (group (op $)
-                                             (parens ;; needs `#%parens` binding
-                                              (group . #,s)))))
-         [b::binding
-          #:with b-form::binding-form #'b.parsed
-          (binding-form
-           #'pattern-infoer
-           #`[#,(annotation-string-from-pattern (shrubbery-syntax->string stx))
-              b-form.infoer-id b-form.data])]))
-     (with-syntax ([pattern (syntax-parse stx
-                              [(head . _)
-                               (datum->syntax #'here 'pattern #'head #'head)])])
-       (syntax-parse stx
-         [(_ . tail)
-          (values (expand (relocate+reraw
-                           (respan stx)
-                           #'(pattern . tail)))
-                  #'())])))))
+     (syntax-parse #`(group #%quotes
+                            (quotes (group (op $)
+                                           (parens ;; needs `#%parens` binding
+                                            (group bounce-to-pattern . #,stx)))))
+       [b::binding
+        #:with b-form::binding-form #'b.parsed
+        (values
+         (binding-form
+          #'pattern-infoer
+          #`[#,(annotation-string-from-pattern (shrubbery-syntax->string stx))
+             b-form.infoer-id b-form.data])
+         #'())]))))
 
 (define-syntax (pattern-infoer stx)
   (syntax-parse stx

--- a/rhombus/tests/syntax-class.rhm
+++ b/rhombus/tests/syntax-class.rhm
@@ -772,6 +772,120 @@ block:
     matcher x
     ~prints_like '2'
 
+// check (not) `open`ing named `pattern`s
+check:
+  ~eval
+  match '1'
+  | '$(pattern any | '$x')': x
+  ~raises "cannot reference an identifier before its definition"
+
+check:
+  ~eval
+  match '1'
+  | (pattern any | '$x'): x
+  ~raises "cannot reference an identifier before its definition"
+
+// check generated attributes in inline `pattern`s
+block:
+  fun m(stx):
+    match stx
+    | (pattern
+       | '$_ $_': field one = 1; field two = 2
+       | '$_': field two = 1):
+        two
+  check:
+    m('foo')
+    ~is 1
+  check:
+    m('foo bar')
+    ~is 2
+
+block:
+  fun m(stx):
+    syntax_class Rhs:
+      kind ~sequence
+    | '= $_ ...'
+    match stx
+    | (pattern
+       | '$lhs ... $(rhs :: Rhs)'
+       | '$lhs ...: $(rhs :: Block)'):
+        '($lhs ..., $rhs)'
+  check:
+    m('foo bar = baz')
+    ~prints_like '(foo bar, = baz)'
+  check:
+    m('foo bar: baz')
+    ~prints_like '(foo bar, :« baz »)'
+
+// check handling of nested `pattern`s
+block:
+  fun m(stx):
+    match stx
+    | (pattern
+       | '$(pattern
+            | '$who'
+            | '$_ $who')'):
+        who
+  check:
+    m('foo')
+    ~prints_like 'foo'
+  check:
+    m('foo bar')
+    ~prints_like 'bar'
+
+block:
+  fun m(stx):
+    match stx
+    | (pattern
+       | '$(pattern
+            | '$who')'
+       | '$_ $who'):
+        who
+  check:
+    m('foo')
+    ~prints_like 'foo'
+  check:
+    m('foo bar')
+    ~prints_like 'bar'
+
+// check handling of `open`ed syntax classes
+block:
+  fun m(op):
+    syntax_class Header:
+      kind ~sequence
+    | '$lbind $name $rbind'
+    | '$name $rbind': field lbind = #false
+    match op
+    | (pattern:
+         kind ~group
+       | '$(_ :: Header: open): $_'
+       | '($(_ :: Header: open)): $_'):
+        '$(lbind || '') $name $rbind'
+  check:
+    m('x + y: add(x, y)')
+    ~prints_like 'x + y'
+  check:
+    m('(+ y): add(x, y)')
+    ~prints_like '+ y'
+
+block:
+  fun m(op):
+    syntax_class Header:
+      kind ~sequence
+    | '$lbind $name $rbind'
+    match op
+    | (pattern:
+         kind ~group
+       | '$(_ :: Header: open): $_'
+       | '($name $rbind): $_': field lbind = #false):
+        '$(lbind || '') $name $rbind'
+  check:
+    m('x + y: add(x, y)')
+    ~prints_like 'x + y'
+  check:
+    m('(+ y): add(x, y)')
+    ~prints_like '+ y'
+
 // infer ~multi mode
 check:
   syntax_class C


### PR DESCRIPTION
I’m not sure what’s the exact purpose of `bind-counter`, as the scopes are already provided by the identifier.  It also doesn’t appear to do the right thing at all, as evidenced by the test cases.

Instead, symbolic names are kept distinct at each *depth* level of `pattern`, which is required for the proper propagation of attributes in nested `pattern`s.  Moreover, attributes in `open`ed syntax classes can get their context from the `pattern` form id, and therefore the implementation of binding `pattern` is changed to not alter its context.

Also fix a bug accidentally introduced in 053523c that `open`s named `pattern`s.