### PR TITLE
define built-in classes with `define-primitive-class`

### DIFF
--- a/rhombus/private/arithmetic.rkt
+++ b/rhombus/private/arithmetic.rkt
@@ -1,15 +1,12 @@
 #lang racket/base
-(require (for-syntax racket/base
-                     syntax/parse/pre
-                     "srcloc.rkt")
+(require (for-syntax racket/base)
          "provide.rkt"
          "expression.rkt"
          "repetition.rkt"
          "define-operator.rkt"
-         "static-info.rkt"
-         "mutability.rkt"
          (only-in "dot.rkt"
-                  |.|))
+                  |.|)
+         "rhombus-primitive.rkt")
 
 (provide (for-spaces (#f
                       rhombus/repet)
@@ -37,6 +34,8 @@
 
                      ===
                      is_now))
+
+(set-primitive-contract! 'number? "Number")
 
 (define-infix rhombus+ +
   #:weaker-than (rhombus* rhombus/ div mod rem)
@@ -82,6 +81,8 @@
     #:same-as (rhombus> rhombus>= .= rhombus<=)
     #:stronger-than (\|\| &&)
     #:associate 'none))
+
+(set-primitive-who! '= '.=)
 
 (define-comp-infix rhombus< <)
 (define-comp-infix rhombus<= <=)

--- a/rhombus/private/class-constructor.rkt
+++ b/rhombus/private/class-constructor.rkt
@@ -2,7 +2,8 @@
 (require (for-syntax racket/base
                      syntax/parse/pre
                      "class-parse.rkt"
-                     "with-syntax.rkt")
+                     "with-syntax.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          racket/unsafe/undefined
          racket/stxparam
          "call-result-key.rkt"
@@ -272,7 +273,7 @@
     [(_ name predicate-id (parsed #:rhombus/expr e) stx-params)
      #'(with-syntax-parameters stx-params e)]
     [(_ name predicate-id (block g) stx-params)
-     (define adjustments (entry_point_meta.Adjustment
+     (define adjustments (entry-point-adjustment
                           '()
                           (lambda (arity body)
                             #`(parsed

--- a/rhombus/private/class-meta.rkt
+++ b/rhombus/private/class-meta.rkt
@@ -2,9 +2,9 @@
 (require (for-syntax racket/base)
          syntax/parse/pre
          enforest/syntax-local
+         "define-arity.rkt"
          "class-primitive.rkt"
          "name-root.rkt"
-         (submod "annotation.rkt" for-class)
          "class-parse.rkt"
          (for-template
           (only-in "class-clause-parse.rkt"
@@ -28,15 +28,10 @@
   [Info
    describe])
 
-(define (class_meta.Info.lookup info key)
-  (lookup info key))
-
-(define (class_meta.Info.lookup/method info)
-  (let ([lookup (lambda (key) (lookup info key))])
-    lookup))
+(define/method (class_meta.Info.lookup info key)
+  (lookup who info key))
 
 (define-primitive-class Info class-data
-  #:constructor-static-info ()
   #:new
   #:opaque
   #:fields
@@ -44,7 +39,8 @@
   #:properties
   ()
   #:methods
-  ([lookup 2 class_meta.Info.lookup class_meta.Info.lookup/method]))
+  ([lookup class_meta.Info.lookup]
+   ))
 
 (struct class-expand-data class-data (stx accum-stx))
 (struct class-describe-data class-data (desc private-idesc))
@@ -72,8 +68,7 @@
              #'constructor-field-mutables
              #'constructor-field-privates)]))
 
-(define (lookup info key)
-  (define who 'class_meta.Info.lookup)
+(define (lookup who info key)
   (unless (class-data? info)
     (raise-argument-error* who rhombus-realm "class_meta.Info" info))
   (unless (symbol? key)

--- a/rhombus/private/class-method.rkt
+++ b/rhombus/private/class-method.rkt
@@ -8,7 +8,8 @@
                      "interface-parse.rkt"
                      "tag.rkt"
                      "srcloc.rkt"
-                     "statically-str.rkt")
+                     "statically-str.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          racket/stxparam
          "expression.rkt"
          "parse.rkt"
@@ -831,7 +832,7 @@
      (with-continuation-mark
       syntax-parameters-key #'stx-params
       (syntax-parse #'expr
-        [(~var e (:entry-point (entry_point_meta.Adjustment
+        [(~var e (:entry-point (entry-point-adjustment
                                 (list #'this-obj)
                                 (lambda (arity stx)
                                   #`(parsed

--- a/rhombus/private/class-transformer.rkt
+++ b/rhombus/private/class-transformer.rkt
@@ -3,7 +3,8 @@
                      syntax/parse/pre
                      "tag.rkt"
                      "with-syntax.rkt"
-                     "srcloc.rkt")
+                     "srcloc.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          "parse.rkt"
          "entry-point.rkt"
          "pack.rkt"

--- a/rhombus/private/control.rkt
+++ b/rhombus/private/control.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
-                     "tag.rkt")
+                     "tag.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          syntax/parse/pre
          "provide.rkt"
          "name-root.rkt"

--- a/rhombus/private/define-arity.rkt
+++ b/rhombus/private/define-arity.rkt
@@ -1,58 +1,161 @@
 #lang racket/base
-(require (for-syntax racket/base
+(require racket/stxparam
+         (for-syntax racket/base
                      syntax/parse/pre)
-         "expression.rkt"
          "static-info.rkt"
+         "call-result-key.rkt"
          "function-arity-key.rkt"
          (only-in (submod "dot.rkt" for-dot-provider)
                   dot-provider)
-         "dot-provider-key.rkt")
+         "dot-provider-key.rkt"
+         "rhombus-primitive.rkt")
 
-(provide define/arity
+(provide who
+         define/arity
+         define/method
          (for-syntax set-function-dot-provider!))
 
 (module+ dot-provider
   (provide function-dot-provider))
 
-(define-syntax (define/arity stx)
+(define-syntax-parameter who-sym #f)
+
+(define-syntax (who stx)
   (syntax-parse stx
-    [(_ #:name name (id . args)
-        (~optional (~seq #:static-infos (si ...))
-                   #:defaults ([(si 1) '()]))
-        . body)
-     #'(begin
-         (define id
-           (let ([name (lambda args . body)])
-             name))
-         (define-static-info-syntax id
-           (#%dot-provider function-dot-provider)
-           (#%function-arity #,(extract-arity #'args))
-           si ...))]
-    [(_ id
-        (~optional (~seq #:static-infos (si ...))
-                   #:defaults ([(si 1) '()]))
-        (~and rhs
-              ((~literal case-lambda)
-               [args body ...]
-               ...)))
-     #'(begin
-         (define id rhs)
-         (define-static-info-syntax id
-           (#%dot-provider function-dot-provider)
-           (#%function-arity #,(apply
-                                bitwise-ior
-                                (map extract-arity (syntax->list #'(args ...)))))
-           si ...))]
-    [(_ (id . args)
-        (~optional (~seq #:static-infos (si ...))
-                   #:defaults ([(si 1) '()]))
-        . body)
+    [_:id
+     (define sym (syntax-parameter-value #'who-sym))
+     (unless sym
+       (raise-syntax-error #f "`who` is unknown" stx))
+     #`(quote #,sym)]))
+
+(define-syntax (define/arity stx)
+  (expand-define/arity stx build-define/arity))
+
+(define-syntax (define/method stx)
+  (expand-define/arity stx build-define/method))
+
+(define-for-syntax (expand-define/arity stx build)
+  (syntax-parse stx
+    [(~or* (~and (_ (~optional (~seq #:name name)) (id . args)
+                    (~optional (~and inline #:inline))
+                    (~optional (~seq #:primitive (primitive-id ...)))
+                    (~optional (~seq #:static-infos static-infos))
+                    . body)
+                 (~parse rhs #'(lambda args . body)))
+           (_ (~optional (~seq #:name name)) id
+              (~optional (~and inline #:inline))
+              (~optional (~seq #:primitive (primitive-id ...)))
+              (~optional (~seq #:static-infos static-infos))
+              rhs))
      #`(begin
-         (define (id . args) . body)
-         (define-static-info-syntax id
-           (#%dot-provider function-dot-provider)
-           (#%function-arity #,(extract-arity #'args))
-           si ...))]))
+         #,@(build #'id
+                   (attribute name)
+                   (and (attribute inline) #t)
+                   (if (attribute primitive-id)
+                       (syntax->list #'(primitive-id ...))
+                       '())
+                   (attribute static-infos)
+                   #'rhs))]))
+
+(define-for-syntax (build-define/arity id name inline? primitive-ids static-infos rhs [arity-mask #f])
+  (define name/id (or name id))
+  (define rhs/who
+    (with-syntax ([name-sym (syntax-e name/id)])
+      (syntax-parse rhs
+        #:literals (lambda case-lambda)
+        [(lambda args . body)
+         #'(lambda args
+             (syntax-parameterize ([who-sym 'name-sym])
+               . body))]
+        [(case-lambda [args . body] ...)
+         #'(case-lambda
+             [args (syntax-parameterize ([who-sym 'name-sym])
+                     . body)]
+             ...)])))
+  (append
+   (for/list ([primitive-id (in-list primitive-ids)])
+     #`(set-primitive-who! '#,primitive-id '#,name/id))
+   (list (let ([def #`(define #,id
+                        #,(if name (syntax-property rhs/who 'inferred-name name) rhs/who))])
+           (if inline?
+               (syntax-property def 'compiler-hint:cross-module-inline #t)
+               def))
+         #`(define-static-info-syntax #,id
+             (#%dot-provider function-dot-provider)
+             (#%function-arity #,(or arity-mask (extract-arity-mask rhs)))
+             . #,(or static-infos '())))))
+
+(define-for-syntax (build-define/method id name inline? primitive-ids static-infos rhs)
+  (define (format-id fmt)
+    (datum->syntax id (string->symbol (format fmt (syntax-e id)))))
+  (define dispatch-id (format-id "~a/dispatch"))
+  (define method-id (format-id "~a/method"))
+  (define arity-mask (extract-arity-mask rhs))
+  (define method-static-infos
+    (or (and static-infos
+             (cond
+               [(static-info-lookup static-infos #'#%call-results-at-arities)
+                => (lambda (infos)
+                     #`(lambda (n)
+                         (case n
+                           #,@(for/list ([info (in-list (syntax->list infos))]
+                                         #:do [(define-values (n infos)
+                                                 (syntax-parse info
+                                                   [(n infos)
+                                                    (values (sub1 (syntax-e #'n)) #'infos)]))]
+                                         #:when (n . >= . 0))
+                                (with-syntax ([infos infos])
+                                  #`[(#,n) #`infos]))
+                           [else #f])))]
+               [(static-info-lookup static-infos #'#%call-result)
+                => (lambda (infos)
+                     (with-syntax ([infos infos])
+                       #`#`infos))]
+               [else #f]))
+        #'#f))
+  (define-values (obj method)
+    (syntax-parse rhs
+      #:literals (lambda case-lambda)
+      [(lambda (~or* ((~or* [obj . _] obj) . args)
+                     (~and args (~parse obj #'obj)))
+         . _)
+       (values #'obj
+               #`(lambda args
+                   #,(make-apply id #'obj #'args)))]
+      [(case-lambda [(~or* () (_ . argss) argss) . _] ...)
+       (values #'obj
+               #`(case-lambda
+                   #,@(for/list ([args (in-list (attribute argss))]
+                                 #:when args)
+                        #`[#,args #,(make-apply id #'obj args)])))]))
+  (list* #`(define-for-syntax #,dispatch-id
+             (lambda (nary)
+               (nary #,(arithmetic-shift arity-mask -1) #'#,id #'#,method-id #,method-static-infos)))
+         #`(define #,method-id
+             (lambda (#,obj)
+               ;; TODO what should we name the partially applied method?
+               ;; This also applies to class methods in general
+               #,(syntax-property method 'inferred-name (or name id))))
+         (build-define/arity id name inline? primitive-ids static-infos rhs arity-mask)))
+
+(define-for-syntax (make-apply rator obj rands)
+  (define (extract-arg arg)
+    (syntax-parse arg
+      [[id . _] #'id]
+      [_ arg]))
+  (syntax-parse rands
+    [(_ ...)
+     #`(#,rator #,obj #,@(map extract-arg (syntax->list rands)))]
+    [(arg ... . rest-arg)
+     #`(apply #,rator #,obj #,@(map extract-arg (syntax->list #'(arg ...))) rest-arg)]))
+
+(define-for-syntax (extract-arity-mask rhs)
+  (syntax-parse rhs
+    #:literals (lambda case-lambda)
+    [(lambda args . _)
+     (extract-arity #'args)]
+    [(case-lambda [args . _] ...)
+     (apply bitwise-ior (map extract-arity (syntax->list #'(args ...))))]))
 
 (define-for-syntax (extract-arity args)
   (let loop ([args args] [mask 1] [allowed-kws '()] [req-kws '()])

--- a/rhombus/private/entry-point-adjustment.rkt
+++ b/rhombus/private/entry-point-adjustment.rkt
@@ -1,32 +1,49 @@
 #lang racket/base
-(require (for-syntax racket/base
-                     syntax/parse/pre)
+(require (for-syntax racket/base ; for `unsyntax` binding
+                     )
          "provide.rkt"
          "class-primitive.rkt"
+         "dot-property.rkt"
+         "realm.rkt"
          "function-arity-key.rkt"
          "index-result-key.rkt"
          (submod "list.rkt" for-compound-repetition)
-         (submod "syntax-object.rkt" for-quasiquote)
-         (prefix-in rkt: (for-template "entry-point.rkt")))
+         (submod "syntax-object.rkt" for-quasiquote))
 
 (provide (for-spaces (rhombus/namespace
                       #f
                       rhombus/bind
                       rhombus/annot)
                      entry_point_meta.Adjustment)
-         (for-syntax (rename-out [rkt:entry_point_meta.Adjustment-static-infos
-                                  entry_point_meta.Adjustment-static-infos])))
+         (for-syntax entry-point-adjustment-static-infos))
 
-(define-primitive-class entry_point_meta.Adjustment rkt:entry_point_meta.Adjustment
-  #:constructor-static-info ()
+(module+ for-struct
+  (provide (struct-out entry-point-adjustment)
+           no-adjustments)
+  (define no-adjustments
+    (entry-point-adjustment '() (lambda (arity stx) stx) #f)))
+
+(define-primitive-class entry_point_meta.Adjustment entry-point-adjustment
   #:existing
   #:transparent
   #:fields
-  ([(prefix-arguments prefix_arguments) ((#%index-result #,syntax-static-infos)
-                                         #,@list-static-infos)]
-   [(wrap-body wrap_body) ((#%function-arity 4))]
-   [(method? is_method) ()])
+  ([(prefix_arguments prefix-arguments) ((#%index-result #,syntax-static-infos)
+                                         . #,list-static-infos)]
+   [(wrap_body wrap-body) ((#%function-arity 4))]
+   [(is_method method?)])
   #:properties
   ()
   #:methods
   ())
+
+(struct entry-point-adjustment (prefix-arguments wrap-body method?)
+  #:property prop:field-name->accessor
+  (list* null
+         entry-point-adjustment-method-table
+         #hasheq())
+  #:guard (lambda (args wrap is-method? info)
+            (unless (and (list? args) (andmap identifier? args))
+              (raise-argument-error* 'entry_point_meta.Adjustment rhombus-realm "List.of(Identifier)" args))
+            (unless (and (procedure? wrap) (procedure-arity-includes? wrap 2))
+              (raise-argument-error* 'entry_point_meta.Adjustment rhombus-realm "Function.of_arity(2)" wrap))
+            (values args wrap (and is-method? #t))))

--- a/rhombus/private/entry-point-macro.rkt
+++ b/rhombus/private/entry-point-macro.rkt
@@ -10,8 +10,7 @@
                      "entry-point-adjustment.rkt"
                      (for-syntax racket/base))
          "space-provide.rkt"
-         (except-in "entry-point.rkt"
-                    entry_point_meta.Adjustment)
+         "entry-point.rkt"
          "space.rkt"
          "name-root.rkt"
          "macro-macro.rkt"
@@ -35,7 +34,7 @@
 (define-identifier-syntax-definition-transformer macro
   rhombus/entry_point
   #:extra ([#:mode (quote-syntax ()) value]
-           [#:adjustment entry_point_meta.Adjustment-static-infos value])
+           [#:adjustment entry-point-adjustment-static-infos value])
   #'make-entry-point-transformer)
 
 (begin-for-syntax

--- a/rhombus/private/entry-point.rkt
+++ b/rhombus/private/entry-point.rkt
@@ -5,9 +5,7 @@
                      enforest/property
                      enforest/proc-name
                      "introducer.rkt"
-                     "macro-result.rkt"
-                     "dot-property.rkt"
-                     "realm.rkt")
+                     "macro-result.rkt")
          "enforest.rkt")
 
 (module+ for-class
@@ -19,9 +17,7 @@
   (provide (property-out entry-point-transformer)
            :entry-point
            :entry-point-arity
-           (struct-out entry_point_meta.Adjustment)
-           check-entry-point-arity-result
-           no-adjustments)
+           check-entry-point-arity-result)
 
   (property entry-point-transformer transformer (arity-extract))
 
@@ -45,22 +41,6 @@
     (datum->syntax #f form))
 
   (define in-entry-point-space (make-interned-syntax-introducer/add 'rhombus/entry_point))
-
-  (struct entry_point_meta.Adjustment (prefix-arguments wrap-body method?)
-    #:property prop:field-name->accessor
-    (list* null
-           (hasheq 'prefix_arguments (lambda (a) (entry_point_meta.Adjustment-prefix-arguments a))
-                   'wrap_body (lambda (a) (entry_point_meta.Adjustment-wrap-body a))
-                   'is_method (lambda (a) (entry_point_meta.Adjustment-method? a)))
-           #hasheq())
-    #:guard (lambda (args wrap is-method? info)
-              (unless (and (list? args) (andmap identifier? args))
-                (raise-argument-error* 'entry_point_meta.Adjustment rhombus-realm "List.of(Identifier)" args))
-              (unless (and (procedure? wrap) (procedure-arity-includes? wrap 2))
-                (raise-argument-error* 'entry_point_meta.Adjustment rhombus-realm "Function.of_arity(2)" wrap))
-              (values args wrap (and is-method? #t))))
-    
-  (define no-adjustments (entry_point_meta.Adjustment '() (lambda (arity stx) stx) #f))
   
   (define-rhombus-transform
     #:syntax-class (:entry-point adjustments)

--- a/rhombus/private/exn-object.rkt
+++ b/rhombus/private/exn-object.rkt
@@ -20,13 +20,12 @@
   (provide get-exn-method-table))
 
 (define-primitive-class Exn exn
-  #:constructor-static-info ()
   #:existing
   #:class
   #:transparent
   #:fields
-  ([message ()]
-   [(continuation-marks marks) ()])
+  ([(message)]
+   [(marks continuation-marks)])
   #:namespace-fields
   (Fail
    Break)
@@ -40,7 +39,6 @@
                       #:fields (field ...)
                       #:children (child ...))
   (define-primitive-class Name name
-    #:constructor-static-info ()
     #:existing
     #:class
     #:transparent
@@ -97,13 +95,13 @@
 
 (define-exn Variable exn:fail:contract:variable
   #:parent Contract exn:fail:contract
-  #:fields ([id ()])
+  #:fields ([(id)])
   #:children ())
 
 (define-exn Syntax exn:fail:syntax
   #:parent Fail exn:fail
-  #:fields ([exprs ((#%index-result #,syntax-static-infos)
-                    . #,list-static-infos)])
+  #:fields ([(exprs) ((#%index-result #,syntax-static-infos)
+                      . #,list-static-infos)])
   #:children (Unbound
               MissingModule))
 
@@ -114,13 +112,13 @@
 
 (define-exn MissingModule exn:fail:syntax:missing-module
   #:parent Syntax exn:fail:syntax
-  #:fields ([path ()])
+  #:fields ([(path)])
   #:children ())
 
 (define-exn Read exn:fail:read
   #:parent Fail exn:fail
-  #:fields ([srclocs ((#%index-result #,srcloc-static-infos)
-                      . #,list-static-infos)])
+  #:fields ([(srclocs) ((#%index-result #,srcloc-static-infos)
+                        . #,list-static-infos)])
   #:children (EOF
               NonChar))
 
@@ -154,12 +152,12 @@
 
 (define-exn Errno exn:fail:filesystem:errno
   #:parent Filesystem exn:fail:filesystem
-  #:fields ([errno ()])
+  #:fields ([(errno)])
   #:children ())
 
 (define-exn fs_MissingModule exn:fail:filesystem:missing-module
   #:parent Filesystem exn:fail:filesystem
-  #:fields ([path ()])
+  #:fields ([(path)])
   #:children ())
 
 (define-exn Network exn:fail:network
@@ -169,7 +167,7 @@
 
 (define-exn new_Errno exn:fail:network:errno
   #:parent Network exn:fail:network
-  #:fields ([errno ()])
+  #:fields ([(errno)])
   #:children ())
 
 (define-exn OutOfMemory exn:fail:out-of-memory
@@ -189,7 +187,7 @@
 
 (define-exn Break exn:break
   #:parent Exn exn
-  #:fields ([continuation ()])
+  #:fields ([(continuation)])
   #:children (HangUp
               Terminate))
 

--- a/rhombus/private/function-parse.rkt
+++ b/rhombus/private/function-parse.rkt
@@ -12,14 +12,14 @@
                      "with-syntax.rkt"
                      "tag.rkt"
                      "same-expression.rkt"
-                     "static-info-pack.rkt")
+                     "static-info-pack.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          racket/unsafe/undefined
          "provide.rkt"
          "parens.rkt"
          "expression.rkt"
          "binding.rkt"
          "definition.rkt"
-         "entry-point.rkt"
          "parse.rkt"
          "nested-bindings.rkt"
          "name-root.rkt"
@@ -337,7 +337,7 @@
     #:attributes [kwarg kwparsed]
     #:datum-literals (group)
     (pattern (~seq (group _::~&-bind a ...))
-             #:with kwarg::non-...-binding #`(#,group-tag rest-bind #,map-static-info
+             #:with kwarg::non-...-binding #`(#,group-tag rest-bind #,map-static-infos
                                               #:annot-prefix? #f
                                               (#,group-tag a ...))
              #:with kwparsed #'kwarg.parsed
@@ -450,7 +450,7 @@
           (define arity (summarize-arity kws defaults (syntax-e rest-arg) (syntax-e kwrest-arg)))
           (define body
             (wrap-expression
-             ((entry_point_meta.Adjustment-wrap-body adjustments)
+             ((entry-point-adjustment-wrap-body adjustments)
               arity
               #`(parsed
                  #:rhombus/expr
@@ -467,7 +467,7 @@
                      #,function-name #,converter #f
                      (rhombus-body-expression rhs))))))))
           (define (adjust-args args)
-            (append (entry_point_meta.Adjustment-prefix-arguments adjustments)
+            (append (entry-point-adjustment-prefix-arguments adjustments)
                     args))
           (values
            (relocate+reraw
@@ -503,7 +503,7 @@
        (map fcase kwss argss arg-parsedss rest-args rest-parseds kwrest-args kwrest-parseds converters rhss)))
     (define pos-arity
       (normalize-arity
-       (let ([adj (length (entry_point_meta.Adjustment-prefix-arguments adjustments))])
+       (let ([adj (length (entry-point-adjustment-prefix-arguments adjustments))])
          (for/list ([n+same (in-list n+sames)])
            (define n (car n+same))
            (cond
@@ -556,7 +556,7 @@
                              [maybe-kwrest-tmp-use (if kws?
                                                        #'kwrest-tmp
                                                        #''#hashalw())])
-                 #`[(#,@(entry_point_meta.Adjustment-prefix-arguments adjustments) pos-arg-id ...)
+                 #`[(#,@(entry-point-adjustment-prefix-arguments adjustments) pos-arg-id ...)
                     maybe-rest-tmp ... maybe-kwrest-tmp ...
                     #,(let loop ([same same])
                         (cond
@@ -627,7 +627,7 @@
                                           maybe-bind-kwrest-seq ...
                                           maybe-bind-kwrest ...
                                           #,(wrap-expression
-                                             ((entry_point_meta.Adjustment-wrap-body adjustments)
+                                             ((entry-point-adjustment-wrap-body adjustments)
                                               (summarize-arity (fcase-kws fc) (for/list ([kw (in-list (fcase-kws fc))])
                                                                                 #'#f)
                                                                (syntax-e (fcase-rest-arg fc)) (syntax-e (fcase-kwrest-arg fc)))

--- a/rhombus/private/interface-meta.rkt
+++ b/rhombus/private/interface-meta.rkt
@@ -2,9 +2,9 @@
 (require (for-syntax racket/base)
          syntax/parse/pre
          enforest/syntax-local
+         "define-arity.rkt"
          "class-primitive.rkt"
          "name-root.rkt"
-         (submod "annotation.rkt" for-class)
          "interface-parse.rkt"
          (only-in "class-parse.rkt"
                   in-class-desc-space)
@@ -30,15 +30,10 @@
   [Info
    describe])
 
-(define (interface_meta.Info.lookup info key)
-  (lookup info key))
-
-(define (interface_meta.Info.lookup/method info)
-  (let ([lookup (lambda (key) (lookup info key))])
-    lookup))
+(define/method (interface_meta.Info.lookup info key)
+  (lookup who info key))
 
 (define-primitive-class Info interface-data
-  #:constructor-static-info ()
   #:new
   #:opaque
   #:fields
@@ -46,7 +41,8 @@
   #:properties
   ()
   #:methods
-  ([lookup 2 interface_meta.Info.lookup interface_meta.Info.lookup/method]))
+  ([lookup interface_meta.Info.lookup]
+   ))
 
 (struct interface-expand-data interface-data (stx accum-stx))
 (struct interface-describe-data interface-data (desc include-private?))
@@ -59,8 +55,7 @@
         . _)
      #'name]))
 
-(define (lookup info key)
-  (define who 'interface_meta.Info.lookup)
+(define (lookup who info key)
   (unless (interface-data? info)
     (raise-argument-error* who rhombus-realm "interface_meta.Info" info))
   (unless (symbol? key)

--- a/rhombus/private/macro-expr-parse.rkt
+++ b/rhombus/private/macro-expr-parse.rkt
@@ -1,11 +1,11 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
-                     "srcloc.rkt")
+                     "srcloc.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          syntax/parse/pre
          "pack.rkt"
          "macro-rhs.rkt"
-         "entry-point.rkt"
          "macro-macro.rkt"
          "function-arity-key.rkt"
          "static-info.rkt"
@@ -60,7 +60,7 @@
 (define-for-syntax (expose-arity adjustments e)
   (wrap-static-info e
                     #'#%function-arity
-                    #`(#,(+ 1 (length (entry_point_meta.Adjustment-prefix-arguments adjustments)))
+                    #`(#,(+ 1 (length (entry-point-adjustment-prefix-arguments adjustments)))
                        ()
                        ())))
 

--- a/rhombus/private/macro-rhs.rkt
+++ b/rhombus/private/macro-rhs.rkt
@@ -6,7 +6,8 @@
                      enforest/name-parse
                      shrubbery/print
                      "srcloc.rkt"
-                     "pack.rkt")
+                     "pack.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          (submod "quasiquote.rkt" convert)
          "quasiquote.rkt"
          (only-in "ellipsis.rkt"
@@ -25,7 +26,6 @@
          "unquote-binding.rkt"
          "op-literal.rkt"
          "pack.rkt"
-         "entry-point.rkt"
          "parens.rkt"
          "repetition.rkt"
          (only-in "static-info.rkt"
@@ -166,7 +166,7 @@
              (cond
                [(syntax-e #'parsed-right-id)
                 (define right-id #'parsed-right-id)
-                (define extra-args (entry_point_meta.Adjustment-prefix-arguments adjustments))
+                (define extra-args (entry-point-adjustment-prefix-arguments adjustments))
                 #`(lambda (#,@extra-args left #,right-id self-id)
                     (define-syntax #,(in-static-info-space #'left) (make-static-infos syntax-static-infos))
                     (define-syntax #,(in-static-info-space right-id) (make-static-infos syntax-static-infos))
@@ -208,7 +208,7 @@
              (cond
                [(syntax-e #'parsed-right-id)
                 (define arg-id #'parsed-right-id)
-                (define extra-args (entry_point_meta.Adjustment-prefix-arguments adjustments))
+                (define extra-args (entry-point-adjustment-prefix-arguments adjustments))
                 #`(lambda (#,@extra-args #,arg-id self-id)
                     (define-syntax #,(in-static-info-space arg-id) (make-static-infos syntax-static-infos))
                     (define-syntax #,(in-static-info-space #'self-id) (make-static-infos syntax-static-infos))
@@ -308,7 +308,7 @@
      (let ([#,(parsed-name p)
             #,(if (parsed-parsed-right? p)
                   (parsed-impl p)
-                  (let ([extra-args (entry_point_meta.Adjustment-prefix-arguments adjustments)])
+                  (let ([extra-args (entry-point-adjustment-prefix-arguments adjustments)])
                     #`(lambda (#,@extra-args #,@(if prefix? '() (list #'left)) tail self)
                         #,(adjust-result
                            adjustments
@@ -382,7 +382,7 @@
              #,(build-cases infixes #f make-infix-id space-sym adjustments orig-stx case-shape))]))
 
 (define-for-syntax (adjust-result adjustments arity b)
-  (wrap-expression ((entry_point_meta.Adjustment-wrap-body adjustments) arity #`(parsed #:rhombus/expr #,b))))
+  (wrap-expression ((entry-point-adjustment-wrap-body adjustments) arity #`(parsed #:rhombus/expr #,b))))
 
 ;; ----------------------------------------
 

--- a/rhombus/private/macro.rkt
+++ b/rhombus/private/macro.rkt
@@ -6,7 +6,8 @@
                      "macro-rhs.rkt"
                      "operator-parse.rkt"
                      "srcloc.rkt"
-                     "tag.rkt")
+                     "tag.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          syntax/parse/pre
          "provide.rkt"
          "macro-expr-parse.rkt"

--- a/rhombus/private/match.rkt
+++ b/rhombus/private/match.rkt
@@ -5,7 +5,8 @@
                      enforest/name-parse
                      "srcloc.rkt"
                      "annotation-string.rkt"
-                     "tag.rkt")
+                     "tag.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          "expression.rkt"
          "binding.rkt"
          "parse.rkt"
@@ -13,7 +14,6 @@
          (submod "function-parse.rkt" for-build)
          "realm.rkt"
          "parens.rkt"
-         (only-in "entry-point.rkt" no-adjustments)
          (submod "quasiquote.rkt" for-match)
          (only-in "literal.rkt" literal-infoer))
 

--- a/rhombus/private/operator.rkt
+++ b/rhombus/private/operator.rkt
@@ -5,7 +5,8 @@
                      "operator-parse.rkt"
                      "srcloc.rkt"
                      "consistent.rkt"
-                     "same-expression.rkt")
+                     "same-expression.rkt"
+                     (submod "entry-point-adjustment.rkt" for-struct))
          "expression.rkt"
          (only-in "repetition.rkt"
                   in-repetition-space
@@ -18,8 +19,7 @@
          "definition.rkt"
          "static-info.rkt"
          "parens.rkt"
-         (submod "function-parse.rkt" for-build)
-         (only-in "entry-point.rkt" no-adjustments))
+         (submod "function-parse.rkt" for-build))
 
 ;; The `operator` form takes something that looks like a function-style
 ;; operator definition and generates a combination of a transformer and

--- a/rhombus/private/rhombus-primitive.rkt
+++ b/rhombus/private/rhombus-primitive.rkt
@@ -1,0 +1,25 @@
+#lang racket/base
+(provide set-primitive-contract!
+         get-primitive-contract
+         set-primitive-who!
+         get-primitive-who)
+
+(define primitive-contract-table (make-hash))
+
+(define primitive-who-table (make-hasheq))
+
+(define (set-primitive-contract! contract/rkt contract/rhm)
+  (hash-set! primitive-contract-table contract/rkt contract/rhm))
+
+(define (get-primitive-contract contract/rkt)
+  (hash-ref primitive-contract-table contract/rkt #f))
+
+(define (set-primitive-who! who/rkt who/rhm)
+  (hash-set! primitive-who-table who/rkt who/rhm))
+
+(define (get-primitive-who who/rkt)
+  (hash-ref primitive-who-table who/rkt #f))
+
+(set-primitive-contract! 'exact-nonnegative-integer? "NonnegInt")
+
+(set-primitive-who! 'application '|function call|)

--- a/rhombus/private/setmap.rkt
+++ b/rhombus/private/setmap.rkt
@@ -36,7 +36,7 @@
                  (if (eq? shape 'set) #'set-extend* #'hash-extend*)
                  (if (eq? shape 'set) #'set-append #'hash-append)
                  (if (eq? shape 'set) #'set-assert #'hash-assert)
-                 (if (eq? shape 'set) set-static-info map-static-info)
+                 (if (eq? shape 'set) set-static-infos map-static-infos)
                  #:repetition? repetition?
                  #:list->setmap (if (eq? shape 'set) #'list->set #'list->map))))
   

--- a/rhombus/private/srcloc-object.rkt
+++ b/rhombus/private/srcloc-object.rkt
@@ -7,6 +7,7 @@
          "function-arity-key.rkt"
          "call-result-key.rkt"
          "define-arity.rkt"
+         "realm.rkt"
          (submod "string.rkt" static-infos))
 
 (provide (for-spaces (rhombus/namespace
@@ -21,27 +22,24 @@
 (module+ for-static-info
   (provide (for-syntax srcloc-static-infos)))
 
-(define/arity #:name Srcloc.to_report_string (srcloc->report-string s)
-  #:static-infos ((#%call-result #,string-static-infos))
-  (string->immutable-string (srcloc->string s)))
-
-(define srcloc->report-string/method (method1 srcloc->report-string))
-
-(define (srcloc->string/method s)
-  (lambda ()
-    (srcloc->string s)))
-
 (define-primitive-class Srcloc srcloc
-  #:constructor-static-info ()
+  #:lift-declaration
   #:existing
   #:transparent
   #:fields
-  ([source ()]
-   [line ()]
-   [column ()]
-   [position ()]
-   [span ()])
+  ([(source)]
+   [(line)]
+   [(column)]
+   [(position)]
+   [(span)])
   #:properties
   ()
   #:methods
-  ([to_report_string 1 srcloc->report-string srcloc->report-string/method string-static-infos]))
+  (to_report_string
+   ))
+
+(define/method (Srcloc.to_report_string v)
+  #:inline
+  #:primitive (srcloc->string)
+  #:static-infos ((#%call-result #,string-static-infos))
+  (string->immutable-string (srcloc->string v)))

--- a/rhombus/private/string.rhm
+++ b/rhombus/private/string.rhm
@@ -1,7 +1,7 @@
 #lang rhombus/private/core
 import:
   "core-meta.rkt" open
-  lib("rhombus/private/core.rkt")
+  lib("racket/base.rkt").#{string->immutable-string}
 
 export:
   ReadableString
@@ -10,9 +10,9 @@ namespace ReadableString:
   export:
     to_string
 
-  fun to_string(s :: ReadableString):
-    core.to_string(s)
+  fun to_string(s :: ReadableString) :~ String:
+    #{string->immutable-string}(s)
 
   annot.macro 'to_string':
-    'converting(fun (s :: ReadableString) :: String:
-                 to_string(s))'
+    'converting(fun (s :: ReadableString) :~ String:
+                 #{string->immutable-string}(s))'

--- a/rhombus/private/vector-append.rkt
+++ b/rhombus/private/vector-append.rkt
@@ -3,8 +3,6 @@
 (provide vector-append)
 
 (define (vector-append v1 v2)
-  (unless (vector? v1) (raise-argument-error 'vector-append "vector?" v1))
-  (unless (vector? v2) (raise-argument-error 'vector-append "vector?" v2))
   (define v3 (make-vector (+ (vector-length v1) (vector-length v2))))
   (for ([v (in-vector v1)]
         [i (in-naturals 0)])
@@ -13,5 +11,3 @@
         [i (in-naturals (vector-length v1))])
     (vector-set! v3 i v))
   v3)
-
-    

--- a/rhombus/tests/import.rhm
+++ b/rhombus/tests/import.rhm
@@ -136,6 +136,8 @@ check:
   beta
   ~raises "beta: undefined"
 
+// This test assumes too much about the implementation of `Pair`
+#//
 check:
   import:
     lib("racket/base.rkt") as r:
@@ -144,6 +146,18 @@ check:
       only:
         make_pair
   r.make_pair
+  ~is Pair.cons
+
+check:
+  import:
+    rhombus/meta.expr
+    rhombus.Pair as p:
+      only_space expr
+      rename:
+        cons as make_pair
+      only:
+        make_pair
+  p.make_pair
   ~is Pair.cons
 
 check:

--- a/rhombus/tests/map.rhm
+++ b/rhombus/tests/map.rhm
@@ -22,7 +22,7 @@ check:
 
 check:
   Map.length({1, 2, 3})
-  ~raises values("contract violation", "expected: Map")
+  ~raises values("contract violation", "expected: ReadableMap")
 
 block:
   use_static


### PR DESCRIPTION
The (ab)use of `define-primitive-class` makes the code significantly more organized.  In particular, method tables and dot providers can be automatically generated as opposed to the error-prone manual approach.  To make everything even more automated, an extension of `define/arity` to methods is implemented.  A more detailed changelog:

- Extend `define-primitive-class` to allow the definition of built-in “classes” like `List`;
- Implement `define/method` to generate method definition and dot dispatch;
- Allow `who` in `define/arity` and `define/method`;
- Try to generate error adjusting entries;
- Refactor relevant definitions.