### PR TITLE
scribble/rhombus: don’t use `$tail ...` in simple expression macros

### DIFF
--- a/scribble/private/doc.rhm
+++ b/scribble/private/doc.rhm
@@ -8,12 +8,11 @@ export:
   nonterminal
   nontermref
 
-expr.macro 'doc $parens $tail ...':
+expr.macro 'doc $(parens :: Term)':
   ~op_stx: me
   match parens
   | '($_ ..., ..., [$_ ..., ...])':
-      values(expr_meta.pack_s_exp(['#{typeset-doc}', me, parens]),
-             '$tail ...')
+      expr_meta.pack_s_exp(['#{typeset-doc}', me, parens])
   | ~else:
       syntax_meta.error("expected forms and documentation content", '$me $parens')
 

--- a/scribble/private/docmodule.rhm
+++ b/scribble/private/docmodule.rhm
@@ -57,18 +57,17 @@ decl.macro 'docmodule ($(option :: Option), ..., $mod ...)':
        '#{#:module-paths}', pack_tree([ModulePath.s_exp(ModulePath('$mod ...'))]),
        option.form, ..., ...])
 
-expr.macro 'rhombusmodname ($mod ...) $tail ...':
-  values(expr_meta.pack_s_exp(['racketmodlink',
-                               pack_tree(ModulePath.s_exp(ModulePath('$mod ...'))),
-                               expr_meta.pack_expr('@rhombus($mod ..., ~datum)')]),
-         '$tail ...')
+expr.macro 'rhombusmodname ($mod ...)':
+  expr_meta.pack_s_exp(['racketmodlink',
+                        pack_tree(ModulePath.s_exp(ModulePath('$mod ...'))),
+                        expr_meta.pack_expr('@rhombus($mod ..., ~datum)')])
 
-expr.macro 'rhombuslangname ($mod ...) $tail ...':
-  values(expr_meta.pack_s_exp(['racketmodlink',
-                               as_racket_mod_name('$mod ...'),
-                               expr_meta.pack_expr('@rhombus($mod ..., ~datum)')]))
+expr.macro 'rhombuslangname ($mod ...)':
+  expr_meta.pack_s_exp(['racketmodlink',
+                        as_racket_mod_name('$mod ...'),
+                        expr_meta.pack_expr('@rhombus($mod ..., ~datum)')])
 
-expr.macro 'racketmodname ($mod ...) $tail ...':
-  values(expr_meta.pack_s_exp(['racketmodlink',
-                               as_racket_mod_name('$mod ...'),
-                               expr_meta.pack_expr('@rhombus($mod ..., ~datum)')]))
+expr.macro 'racketmodname ($mod ...)':
+  expr_meta.pack_s_exp(['racketmodlink',
+                        as_racket_mod_name('$mod ...'),
+                        expr_meta.pack_expr('@rhombus($mod ..., ~datum)')])


### PR DESCRIPTION
Also fix `rhombuslangname`/`racketmodname` dropping the tail.  We probably haven’t hit this bug because the tail is usually empty.