### PR TITLE
scribble/rhombus: fix missing unquote in result annotation

### DIFF
--- a/scribble/private/rhombus-spacer.rhm
+++ b/scribble/private/rhombus-spacer.rhm
@@ -104,7 +104,7 @@ meta:
          | '$(p && '($_)')': field tag = #false):
           let new_tag = if tag | spacer.set(tag, #'~expr) | ''
           let new_p = spacer.adjust_term(p, #'~annot, esc)
-          '$new_tag new_p'
+          '$new_tag $new_p'
       | ~else: spacer.adjust_sequence(res_ann, #'~annot, esc)
     '$new_op $new_res_ann'.relocate(stx)
 


### PR DESCRIPTION
A bug introduced in 29ba3e9.