### PR TITLE
miscellaneous cleanups

### DIFF
--- a/rhombus/private/array.rkt
+++ b/rhombus/private/array.rkt
@@ -161,7 +161,6 @@
   (syntax-parse stx
     [(_ accum v) #'(cons v accum)]))
 
-;; TODO fix mutability in docs
 (set-primitive-contract! 'vector? "Array")
 (set-primitive-contract! '(and/c vector? (not/c immutable?)) "MutableArray")
 
@@ -185,11 +184,13 @@
   (check-array who v2)
   (vector-append v1 v2))
 
-(define/arity (Array.make len [val 0])
+(define/arity Array.make
   #:inline
   #:primitive (make-vector)
   #:static-infos ((#%call-result #,array-static-infos))
-  (make-vector len val))
+  (case-lambda
+    [(len) (make-vector len)]
+    [(len val) (make-vector len val)]))
 
 (define/method (Array.length v)
   #:inline
@@ -204,10 +205,13 @@
   (vector-copy! new-v 0 v 0 len)
   new-v)
 
-(define/method (Array.copy_from v dest-start src [src-start 0] [src-end (and (vector? src) (vector-length src))])
+(define/method Array.copy_from
   #:inline
   #:primitive (vector-copy!)
-  (vector-copy! v dest-start src src-start src-end))
+  (case-lambda
+    [(v dest-start src) (vector-copy! v dest-start src)]
+    [(v dest-start src src-start) (vector-copy! v dest-start src src-start)]
+    [(v dest-start src src-start src-end) (vector-copy! v dest-start src src-start src-end)]))
 
 (define-binding-syntax Array
   (binding-prefix-operator

--- a/rhombus/private/box.rkt
+++ b/rhombus/private/box.rkt
@@ -36,7 +36,6 @@
    later_of
    )
   #:properties
-  ;; TODO undocumented (as function)
   ([value Box.value #:mutator Box.value
           (lambda (e)
             (syntax-local-static-info e #'unbox))]

--- a/rhombus/private/define-arity.rkt
+++ b/rhombus/private/define-arity.rkt
@@ -63,8 +63,11 @@
     (with-syntax ([name-sym (syntax-e name/id)])
       (syntax-parse rhs
         #:literals (lambda case-lambda)
-        [(lambda args . body)
-         #'(lambda args
+        [(lambda ((~seq (~optional kw:keyword) (~or* [id expr] id))
+                  ... . rst)
+           . body)
+         #'(lambda ((~@ (~? kw) (~? [id (syntax-parameterize ([who-sym 'name-sym]) expr)] id))
+                    ... . rst)
              (syntax-parameterize ([who-sym 'name-sym])
                . body))]
         [(case-lambda [args . body] ...)

--- a/rhombus/private/equatable.rkt
+++ b/rhombus/private/equatable.rkt
@@ -4,12 +4,8 @@
          racket/hash-code
          "provide.rkt"
          "name-root.rkt"
-         (submod "annotation.rkt" for-class)
-         (submod "dot.rkt" for-dot-provider)
          "realm.rkt"
-         "class-dot.rkt"
          (only-in "class-desc.rkt" define-class-desc-syntax)
-         "static-info.rkt"
          "define-arity.rkt")
 
 (provide (for-spaces (rhombus/class
@@ -68,40 +64,36 @@
 (define/arity (identity_hash v)
   (eq-hash-code v))
 
+(define (check-int who i)
+  (unless (exact-integer? i)
+    (raise-argument-error* who rhombus-realm "Int" i)))
+
 (define/arity hash_code_combine
   (case-lambda
     [() (hash-code-combine)]
     [(a)
-     (unless (exact-integer? a)
-       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Int" a))
+     (check-int who a)
      (hash-code-combine a)]
     [(a b)
-     (unless (exact-integer? a)
-       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Int" a))
-     (unless (exact-integer? b)
-       (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Int" b))
+     (check-int who a)
+     (check-int who b)
      (hash-code-combine a b)]
     [lst
      (for ([e (in-list lst)])
-       (unless (exact-integer? e)
-         (raise-argument-error* 'Equatable.hash_code_combine rhombus-realm "Int" e)))
+       (check-int who e))
      (hash-code-combine* lst)]))
-                                                               
+
 (define/arity hash_code_combine_unordered
   (case-lambda
     [() (hash-code-combine-unordered)]
     [(a)
-     (unless (exact-integer? a)
-       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Int" a))
+     (check-int who a)
      (hash-code-combine-unordered a)]
     [(a b)
-     (unless (exact-integer? a)
-       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Int" a))
-     (unless (exact-integer? b)
-       (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Int" b))
+     (check-int who a)
+     (check-int who b)
      (hash-code-combine-unordered a b)]
     [lst
      (for ([e (in-list lst)])
-       (unless (exact-integer? e)
-         (raise-argument-error* 'Equatable.hash_code_combine_unordered rhombus-realm "Int" e)))
+       (check-int who e))
      (hash-code-combine-unordered* lst)]))

--- a/rhombus/private/eval.rkt
+++ b/rhombus/private/eval.rkt
@@ -3,7 +3,6 @@
          "provide.rkt"
          "parse.rkt"
          "pack.rkt"
-         "expression.rkt"
          "define-arity.rkt"
          "function-arity-key.rkt"
          "static-info.rkt"
@@ -46,7 +45,7 @@
 (define/arity #:name eval (rhombus-eval e
                                         #:as_interaction [as_interaction #f])
   (unless (syntax? e)
-    (raise-argument-error* 'eval rhombus-realm "Syntax" e))
+    (raise-argument-error* who rhombus-realm "Syntax" e))
   (if as_interaction
       (eval `(#%top-interaction . ,#`(top #,@(unpack-multi e 'eval #f))))
       (eval #`(rhombus-top #,@(unpack-multi e 'eval #f)))))
@@ -55,5 +54,6 @@
   (#%function-arity 6))
 
 (define/arity (import mod-path)
-  (unless (module-path? mod-path) (raise-argument-error* 'eval rhombus-realm "ModulePath" mod-path))
+  (unless (module-path? mod-path)
+    (raise-argument-error* who rhombus-realm "ModulePath" mod-path))
   (namespace-require (module-path-raw mod-path)))

--- a/rhombus/private/function.rkt
+++ b/rhombus/private/function.rkt
@@ -77,7 +77,6 @@
             (check-list who lst1)
             (check-list who lst2)
             (map fn lst1 lst2)]
-           ;; TODO fix documented arity
            [(fn lst1 . lsts)
             (check-proc who fn)
             (check-list who lst1)

--- a/rhombus/private/list.rkt
+++ b/rhombus/private/list.rkt
@@ -69,7 +69,7 @@
   ([cons List.cons]
    [empty null]
    [iota List.iota]
-   repet ; TODO undocumented
+   repet
    of
    )
   #:properties

--- a/rhombus/private/module-path-object.rkt
+++ b/rhombus/private/module-path-object.rkt
@@ -107,11 +107,10 @@
 
 (define/arity (ModulePath.s_exp mp)
   (unless (module-path? mp)
-    (raise-argument-error* 'ModulePath.s_exp rhombus-realm "ModulePath" mp))
+    (raise-argument-error* who rhombus-realm "ModulePath" mp))
   (module-path-raw mp))
 
 (define/arity (ModulePath stx)
-  (define who 'ModulePath)
   (define g (and (syntax? stx) (unpack-group stx #f #f)))
   (unless g (raise-argument-error* who rhombus-realm "Group" stx))
   (define (bad)
@@ -159,4 +158,4 @@
                                                                  "/"
                                                                  accum))])))))
                      #'(sub ...))]
-    [else (bad)]))
+    [_ (bad)]))

--- a/rhombus/private/pair.rkt
+++ b/rhombus/private/pair.rkt
@@ -7,7 +7,6 @@
          "static-info.rkt"
          "call-result-key.rkt"
          "define-arity.rkt"
-         "realm.rkt"
          "class-primitive.rkt"
          "rhombus-primitive.rkt")
 

--- a/rhombus/private/print.rkt
+++ b/rhombus/private/print.rkt
@@ -1,17 +1,14 @@
 #lang racket/base
-(require (for-syntax racket/base)
+(require (for-syntax racket/base ; for `default-pretty`
+                     )
          racket/symbol
          racket/keyword
-         racket/unsafe/undefined
          shrubbery/write
          "provide.rkt"
          (submod "set.rkt" for-ref)
          "adjust-name.rkt"
          "printer-property.rkt"
          "define-arity.rkt"
-         "function-arity-key.rkt"
-         "static-info.rkt"
-         "expression.rkt"
          "mutability.rkt"
          "realm.rkt"
          "print-desc.rkt")
@@ -55,20 +52,20 @@
 (define (check-mode who mode)
   (unless (or (eq? mode 'expr)
               (eq? mode 'text))
-    (raise-argument-error* who rhombus-realm "#'text || #'expr" mode)))
-  
+    (raise-argument-error* who rhombus-realm "Any.of(#'text, #'expr)" mode)))
+
 (define/arity #:name print (rhombus-print v [op (current-output-port)]
                                           #:mode [mode 'text]
                                           #:pretty [pretty? default-pretty])
-  (check-output-port 'print op)
-  (check-mode 'print mode)
+  (check-output-port who op)
+  (check-mode who mode)
   (do-print v op mode pretty?))
 
 (define/arity (println v [op (current-output-port)]
                        #:mode [mode 'text]
                        #:pretty [pretty? default-pretty])
-  (check-output-port 'println op)
-  (check-mode 'println mode)
+  (check-output-port who op)
+  (check-mode who mode)
   (do-print v op mode pretty?)
   (newline op))
 

--- a/rhombus/private/syntax-parameter-macro.rkt
+++ b/rhombus/private/syntax-parameter-macro.rkt
@@ -73,10 +73,10 @@
     (define id (or (unpack-term id-in #f #f)
                    id-in))
     (unless (identifier? id)
-      (raise-argument-error* 'syntax_parameter_meta.lookup rhombus-realm "Identifier" id))
+      (raise-argument-error* who rhombus-realm "Identifier" id))
     (define p (syntax-local-value* (in-syntax-parameter-space id) syntax-parameter-ref))
     (unless p
-      (raise-arguments-error* 'syntax_parameter_meta.lookup rhombus-realm
+      (raise-arguments-error* who rhombus-realm
                               "identifier is not bound as a syntax parameter"
                               "identifier" id))
     (let loop ([iter (current-syntax-parameters-iterator)])

--- a/rhombus/scribblings/ref-array.scrbl
+++ b/rhombus/scribblings/ref-array.scrbl
@@ -138,7 +138,7 @@ mutable and immutable arrays, while @rhombus(MutableArray, ~annot) and
 }
 
 @doc(
-  fun Array.make(length :: Int, val = 0) :: Array
+  fun Array.make(length :: NonnegInt, val :: Any = 0) :: MutableArray
 ){
 
   Creates a fresh array with @rhombus(length) slots, where each slot
@@ -164,7 +164,7 @@ mutable and immutable arrays, while @rhombus(MutableArray, ~annot) and
 
 
 @doc(
-  fun Array.copy(arr :: Array) :: Array
+  fun Array.copy(arr :: Array) :: MutableArray
 ){
 
  Returns a fresh array string with the same initial content as
@@ -173,7 +173,7 @@ mutable and immutable arrays, while @rhombus(MutableArray, ~annot) and
 }
 
 @doc(
-  fun Array.copy_from(dest_arr :: Array,
+  fun Array.copy_from(dest_arr :: MutableArray,
                       dest_start :: NonnegInt,
                       src_arr :: Array,
                       src_start :: NonnegInt = 0,

--- a/rhombus/scribblings/ref-box.scrbl
+++ b/rhombus/scribblings/ref-box.scrbl
@@ -8,8 +8,9 @@ A @deftech{box} is an object with a single value field, which can be
 accessed from a box @rhombus(bx) as
 @rhombus(#,(@rhombus(bx, ~var)).value) or set to the value of
 @nontermref(expr) using
-@rhombus(#,(@rhombus(bx, ~var)).value := @nontermref(expr))
-or other @tech{assignment operators} like @rhombus(:=).
+@rhombus(#,(@rhombus(bx, ~var)).value := #,(@nontermref(expr)))
+or other @tech{assignment operators} like @rhombus(:=). The function
+@rhombus(Box.value) can also be directly used.
 
 A box is normally mutable, but immutable boxes can originate from
 Racket. Assignment is statically allowed by fails dynamically for an
@@ -96,6 +97,23 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
   def Box(x): Box(1)
   x
   ~error: def Box(sv :: String): Box(1)
+)
+
+}
+
+
+@doc(
+  fun Box.value(box :: Box) :: Any
+  fun Box.value(box :: Box, val :: Any) :: Void
+){
+
+ Accesses or updates the value field of @rhombus(box).
+
+@examples(
+  def box: Box(1)
+  Box.value(box)
+  Box.value(box, 2)
+  Box.value(box)
 )
 
 }

--- a/rhombus/scribblings/ref-bytes.scrbl
+++ b/rhombus/scribblings/ref-bytes.scrbl
@@ -41,6 +41,20 @@ and @rhombus(ImmutableBytes, ~annot) require one or the other.
 
 
 @doc(
+  fun Bytes.make(length :: NonnegInt, byte :: Byte = 0) :: MutableBytes
+){
+
+ Creates a fresh byte string with @rhombus(length) bytes, where each
+ byte is initialized to @rhombus(byte).
+
+@examples(
+  Bytes.make(5, 33)
+)
+
+}
+
+
+@doc(
   fun Bytes.length(bstr :: Bytes) :: NonnegInt
 ){
 
@@ -57,7 +71,8 @@ and @rhombus(ImmutableBytes, ~annot) require one or the other.
 @doc(
   fun Bytes.subbytes(bstr :: Bytes,
                      start :: NonnegInt,
-                     end :: NonnegInt = Bytes.length(bstr)) :: Bytes
+                     end :: NonnegInt = Bytes.length(bstr))
+    :: MutableBytes
 ){
 
  Returns the substring of @rhombus(bstr) from @rhombus(start) (inclusive)
@@ -96,17 +111,17 @@ and @rhombus(ImmutableBytes, ~annot) require one or the other.
 
 @doc(
   fun Bytes.utf8_string(bstr :: Bytes,
-                        err_char :: Optional[Char] = #false,
+                        err_char :: maybe(Char) = #false,
                         start :: NonnegInt = 0,
                         end :: NonnegInt = Bytes.length(bstr)) :: String
   fun Bytes.latin1_string(bstr :: Bytes,
-                          err_char :: Optional[Char] = #false,
+                          err_char :: maybe(Char) = #false,
                           start :: NonnegInt = 0,
-                          end :: NonnegInt = Bytes.length(bstr)) :: Bytes
-  fun Bytes.locale_string(str :: String,
-                          err_char :: Optional[Char] = #false,
+                          end :: NonnegInt = Bytes.length(bstr)) :: String
+  fun Bytes.locale_string(bstr :: Bytes,
+                          err_char :: maybe(Char) = #false,
                           start :: NonnegInt = 0,
-                          end :: NonnegInt = Bytes.length(bstr)) :: Bytes
+                          end :: NonnegInt = Bytes.length(bstr)) :: String
 ){
 
  Converts a byte string to a string, decoding as UTF-8, Latin-1, or the

--- a/rhombus/scribblings/ref-control.scrbl
+++ b/rhombus/scribblings/ref-control.scrbl
@@ -70,7 +70,7 @@
  Captures the continuation of the @rhombus(Continuation.capture)
  expression, binds it to @rhombus(id), and then evaluates the
  @rhombus(body) sequence in tail position.
- The continuation is represented as a procedure that
+ The continuation is represented as a function that
  accepts values to deliver to the continuation.
 
  The captured continuation is delimited by a prompt with the tag
@@ -99,7 +99,7 @@
 }
 
 @doc(
-  fun Continuation.make_prompt_tag(name :: String || Symbol || False)
+  fun Continuation.make_prompt_tag(name :: ReadableString || Symbol || False)
   def Continuation.default_prompt_tag
 ){
 
@@ -150,12 +150,26 @@
   fun Continuation.call_with_immediate_mark(
     key,
     ~default: default = #false,
-    proc :: Function.of_arity(1)
+    fn :: Function.of_arity(1)
   )
 ){
 
- Calls @rhombus(proc) in tail position, providing as its argument the
+ Calls @rhombus(fn) in tail position, providing as its argument the
  current frame's mark value for @rhombus(key), or @rhombus(default) if the
  current frame has no mark for @rhombus(key).
+
+}
+
+
+@doc(
+  fun Continuation.call_in(
+    cont :: Continuation,
+    fn :: Function.of_arity(0)
+  )
+){
+
+ Calls @rhombus(fn) with the current continuation extended with
+ @rhombus(cont). This means the extension happens before the call, not
+ after.
 
 }

--- a/rhombus/scribblings/ref-exn.scrbl
+++ b/rhombus/scribblings/ref-exn.scrbl
@@ -102,9 +102,9 @@
 }
 
 @doc(
-  fun error(message :: String)
-  fun error(who :: String || Symbol || Identifier || Operator || False,
-            message :: String)
+  fun error(message :: ReadableString)
+  fun error(who :: ReadableString || Symbol || Identifier || Operator || False,
+            message :: ReadableString)
 ){
 
  Throws the @rhombus(Exn.Fail, ~class) exception with @rhombus(message) as the
@@ -116,7 +116,7 @@
 }
 
 @doc(
-  class Exn(message :: String, marks :: Continuation.Marks)
+  class Exn(message :: ReadableString, marks :: Continuation.Marks)
   class Exn.Fail():
     extends Exn
   class Exn.Fail.Contract():
@@ -131,13 +131,13 @@
     extends Exn.Fail.Contract
   class Exn.Fail.Contract.Variable(id :: Symbol):
     extends Exn.Fail.Contract
-  class Exn.Fail.Syntax(exprs :: Listof(Syntax)):
+  class Exn.Fail.Syntax(exprs :: List.of(Syntax)):
     extends Exn.Fail
   class Exn.Fail.Syntax.Unbound():
     extends Exn.Fail.Syntax
   class Exn.Fail.Syntax.MissingModule(path):
     extends Exn.Fail.Syntax
-  class Exn.Fail.Read(srclocs :: Listof(Srcloc)):
+  class Exn.Fail.Read(srclocs :: List.of(Srcloc)):
     extends Exn.Fail
   class Exn.Fail.Read.EOF():
     extends Exn.Fail.Read
@@ -165,7 +165,7 @@
     extends Exn.Fail
   class Exn.Fail.User():
     extends Exn.Fail
-  class Exn.Break(continuation :: continuation):
+  class Exn.Break(continuation :: Continuation):
     extends Exn
   class Exn.Break.HangUp():
     extends Exn.Break

--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -379,11 +379,13 @@ Only one @rhombus(~& map_bind) can appear in a @rhombus(rest) sequence.
 
 
 @doc(
-  fun Function.map(f :: Function, args :: List, ...) :: List,
-  fun Function.for_each(f :: Function, args :: List, ...) :: Void,
+  fun Function.map(f :: Function, args0 :: List, args :: List, ...)
+    :: List,
+  fun Function.for_each(f :: Function, args0 :: List, args :: List, ...)
+    :: Void,
 ){
 
- Applies @rhombus(f) to each element of each @rhombus(args), iterating
+ Applies @rhombus(f) to each element of each @rhombus(args) (including @rhombus(args0)), iterating
  through the @rhombus(args) lists together, so @rhombus(f) must take as
  many arguments as the number of given @rhombus(args) lists. For
  @rhombus(Function.map), the result is a list constaining the result of
@@ -400,7 +402,7 @@ Only one @rhombus(~& map_bind) can appear in a @rhombus(rest) sequence.
 }
 
 @doc(
-  fun Function.pass(& args, &~ kw_args) :: Void
+  fun Function.pass(& _, ~& _) :: Void
 ){
 
  Accepts any arguments and returns @rhombus(#void).

--- a/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/scribblings/ref-io.scrbl
@@ -20,7 +20,7 @@
 @doc(
   fun print(v,
             out :: Port.Output = Port.current_output(),
-            ~mode: mode :: (#'text || #'expr) = #'text,
+            ~mode: mode :: Any.of(#'text, #'expr) = #'text,
             ~pretty: pretty = Printable.current_pretty())
     :: Void
 ){
@@ -46,7 +46,7 @@
 @doc(
   fun println(v,
               out :: Port.Output = Port.output_port(),
-              ~mode: mode :: (#'text || #'expr) = #'text,
+              ~mode: mode :: Any.of(#'text, #'expr) = #'text,
               ~pretty: pretty = Printable.current_pretty())
     :: Void
 ){
@@ -122,7 +122,7 @@
 
 @doc(
   fun Printable.describe(v,
-                         ~mode: mode :: (#'text || #'expr) = #'text)
+                         ~mode: mode :: Any.of(#'text, #'expr) = #'text)
     :: PrintDesc
 ){
 

--- a/rhombus/scribblings/ref-keyword.scrbl
+++ b/rhombus/scribblings/ref-keyword.scrbl
@@ -20,7 +20,7 @@ See also @rhombus(#'), which works for keywords as well as symbols.
 
 
 @doc(
-  fun Keyword.from_string(str :: String) :: Keyword
+  fun Keyword.from_string(str :: ReadableString) :: Keyword
   fun Keyword.from_symbol(sym :: Symbol) :: Keyword
 ){
 

--- a/rhombus/scribblings/ref-list.scrbl
+++ b/rhombus/scribblings/ref-list.scrbl
@@ -230,6 +230,25 @@ it supplies its elements in order.
 
 }
 
+
+@doc(
+  repet.macro 'List.repet($lst)'
+){
+
+ Creates a repetition from a list. This is a shorthand for using
+ @rhombus(..., ~bind) with a @rhombus(List, ~bind) binding.
+
+@examples(
+  def lst = [1, 2, 3]
+  block:
+    let [x, ...] = lst
+    [x+1, ...]
+  [List.repet(lst) + 1, ...]
+)
+
+}
+
+
 @doc(
   fun List.length(lst :: List) :: NonnegInt
 ){

--- a/rhombus/scribblings/ref-string.scrbl
+++ b/rhombus/scribblings/ref-string.scrbl
@@ -19,6 +19,7 @@ immutable strings.
 @dispatch_table(
   "string"
   @rhombus(String)
+  [str.append(more_str, ...), String.append(str, more_str, ...)]
   [str.length(), String.length(str)]
   [str.substring(arg, ...), String.substring(str, arg, ...)]
   [str.utf8_bytes(arg, ...), String.utf8_bytes(str, arg, ...)]
@@ -35,6 +36,8 @@ immutable strings.
   [str.normalize_nfkd(), String.normalize_nfkd(str)]
   [str.normalize_nfc(), String.normalize_nfc(str)]
   [str.normalize_nfkc(), String.normalize_nfkc(str)]
+  [str.grapheme_span(arg, ...), String.grapheme_span(str, arg, ...)]
+  [str.grapheme_count(arg, ...), String.grapheme_count(str, arg, ...)]
 )
 
 @doc(
@@ -52,7 +55,7 @@ immutable strings.
 }
 
 @doc(
-  fun to_string(v, ~mode: mode :: #'text || #'expr = #'text) :: String
+  fun to_string(v, ~mode: mode :: Any.of(#'text, #'expr) = #'text) :: String
 ){
 
  Coerces @rhombus(v)  to a string.
@@ -84,6 +87,21 @@ immutable strings.
   "hello" +& "world"
   "it goes to " +& 11
   "the list " +& [1, 2, 3] +& " has " +& 3 +& " elements"
+)
+
+}
+
+
+@doc(
+  fun String.append(str :: ReadableString, ...) :: String
+){
+
+ Appends all @rhombus(str)s to create a new string.
+
+@examples(
+  String.append()
+  String.append("this")
+  String.append("this", " and ", "that")
 )
 
 }

--- a/rhombus/scribblings/ref-stxobj-meta.scrbl
+++ b/rhombus/scribblings/ref-stxobj-meta.scrbl
@@ -8,8 +8,8 @@
 
 @doc(
   fun syntax_meta.error(at_stx :: Syntax)
-  fun syntax_meta.error(message :: String, at_stx :: Syntax)
-  fun syntax_meta.error(message :: String, in_stx :: Syntax, at_stx :: Syntax)
+  fun syntax_meta.error(message :: ReadableString, at_stx :: Syntax)
+  fun syntax_meta.error(message :: ReadableString, in_stx :: Syntax, at_stx :: Syntax)
 ){
 
 @provided_meta()

--- a/rhombus/scribblings/ref-stxobj.scrbl
+++ b/rhombus/scribblings/ref-stxobj.scrbl
@@ -678,7 +678,7 @@ Metadata for a syntax object can include a source location and the raw
 }
 
 @doc(
-  fun Syntax.make_id(str :: String, ctx_stx :: maybe(Term) = #false) :: Identifier
+  fun Syntax.make_id(str :: ReadableString, ctx_stx :: maybe(Term) = #false) :: Identifier
 ){
 
  Composes @rhombus(Syntax.make) and @rhombus(Symbol.from_string).

--- a/rhombus/scribblings/ref-symbol.scrbl
+++ b/rhombus/scribblings/ref-symbol.scrbl
@@ -47,9 +47,9 @@ they are equal by @rhombus(==) only when they are equal by
 }
 
 @doc(
-  fun Symbol.from_string(str :: String) :: Symbol
-  fun Symbol.uninterned_from_string(str :: String) :: Symbol
-  fun Symbol.unreadable_from_string(str :: String) :: Symbol
+  fun Symbol.from_string(str :: ReadableString) :: Symbol
+  fun Symbol.uninterned_from_string(str :: ReadableString) :: Symbol
+  fun Symbol.unreadable_from_string(str :: ReadableString) :: Symbol
 ){
 
  Converts a string to a symbol with the same character content. An
@@ -72,7 +72,7 @@ they are equal by @rhombus(==) only when they are equal by
 
 @doc(
   fun Symbol.gen() :: Symbol
-  fun Symbol.gen(name :: String || Symbol) :: Symbol
+  fun Symbol.gen(name :: ReadableString || Symbol) :: Symbol
 ){
 
  Produces an @tech{uninterned} symbol with a character content optionally derived

--- a/rhombus/tests/control.rhm
+++ b/rhombus/tests/control.rhm
@@ -120,6 +120,12 @@ check:
      )]
   ~is [#'none]
 
-    
-    
-    
+check:
+  Continuation.call_in(
+    Continuation.prompt:
+      1 + (Continuation.capture cont:
+             Continuation.escape(cont))
+      ~catch cont: cont,
+    fun (): 2
+  )
+  ~is 3

--- a/rhombus/tests/exn.rhm
+++ b/rhombus/tests/exn.rhm
@@ -49,3 +49,17 @@ block:
 check:
   error(#'example, "~a oops")
   ~raises "~a oops"
+
+block:
+  check:
+    error("who-str", "message")
+    ~raises values("who-str: ", "message")
+  check:
+    error(#'who_sym, "message")
+    ~raises values("who_sym: ", "message")
+  check:
+    error(Syntax.make(#'who_id), "message")
+    ~raises values("who_id: ", "message")
+  check:
+    error(Syntax.make_op(#'who_op), "message")
+    ~raises values("who_op: ", "message")

--- a/rhombus/tests/string.rhm
+++ b/rhombus/tests/string.rhm
@@ -85,3 +85,11 @@ check:
   String.grapheme_count("Hello", 2) ~is 3
   String.grapheme_span("Hello", 2, 4) ~is 1
   String.grapheme_count("Hello", 2, 4) ~is 2
+
+block:
+  import:
+    lib("racket/base.rkt").#{string-copy} as copy
+  check:
+    String.append() ~is ""
+    String.append(copy("this")) ~is "this"
+    String.append(copy("this"), " and ", copy("that")) ~is "this and that"

--- a/scribble/private/typeset-doc.rkt
+++ b/scribble/private/typeset-doc.rkt
@@ -604,7 +604,7 @@
              #'gs
              (extract-binding-group #'(tag t ...) vars))]))))
     (syntax-parse stx
-      #:datum-literals (brackets braces parens)
+      #:datum-literals (brackets braces parens [hole _])
       [(brackets . (~or* (g ... rst:rst/dot)
                          (g ... rst:rst/and)
                          (g ...)))
@@ -627,6 +627,7 @@
                 _)
           (extract-list-rest (attribute rst) vars)])]
       [(parens b) (extract-binding-term #'b vars)]
+      [hole vars]
       [id:identifier (add-metavariable vars #'id #f)]
       [_ vars]))
   (syntax-parse stx


### PR DESCRIPTION
This is a follow-up to 74f5ae2:
- Use more `who` in `define/arity` definitions;
- Use more `case-lambda` to enable inlining;
- Finish up the to-dos that I left;
- Fix things that I noticed during the process.