### PR TITLE
fix missing main converter in `operator`

### DIFF
--- a/rhombus/private/operator.rkt
+++ b/rhombus/private/operator.rkt
@@ -1,8 +1,6 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
-                     racket/list
-                     "operator-parse.rkt"
                      "srcloc.rkt"
                      "consistent.rkt"
                      "same-expression.rkt"
@@ -39,88 +37,95 @@
   (define-syntax-class :not-op-or-block
     #:description "non-operator, non-block"
     #:datum-literals (op block alts)
-    (pattern (~not (~or (op _)
-                        (block . _)
-                        (alts . _)))))
-  
+    (pattern (~not (~or* (op _)
+                         (block . _)
+                         (alts . _)))))
+
   (define-splicing-syntax-class :prefix-case
     #:description "prefix operator case"
+    #:datum-literals (group block)
     (pattern (~seq (_::parens (~and g (group op-name-seq::dotted-operator-or-identifier-sequence arg::not-op)))
                    ret::ret-annotation
-                   ((~and tag block) (~var options (:prefix-operator-options '#f))
-                                     body ...))
+                   ((~and tag block)
+                    (~var options (:prefix-operator-options '#f))
+                    body ...))
              #:with op-name::dotted-operator-or-identifier #'op-name-seq
-             #:attr name #'op-name.name
-             #:attr extends #'op-name.extends
-             #:attr prec #'options.prec
-             #:attr rhs #'(tag body ...)
-             #:attr ret-predicate #'ret.converter
-             #:attr ret-static-infos #'ret.static-infos)
+             #:with name #'op-name.name
+             #:with extends #'op-name.extends
+             #:with prec #'options.prec
+             #:with rhs #'(tag body ...)
+             #:with ret-converter #'ret.converter
+             #:with ret-static-infos #'ret.static-infos)
     (pattern (~seq op-name-seq::dotted-operator-or-identifier-sequence arg::not-op-or-block
-                   ((~and tag block) (~var options (:prefix-operator-options '#f))
-                                     body ...))
+                   ((~and tag block)
+                    (~var options (:prefix-operator-options '#f))
+                    body ...))
              #:with op-name::dotted-operator-or-identifier #'op-name-seq
-             #:attr name #'op-name.name
-             #:attr extends #'op-name.extends
-             #:attr prec #'options.prec
-             #:attr rhs #'(tag body ...)
-             #:attr ret-predicate #'#f
-             #:attr ret-static-infos #'()
-             #:attr g #'(group op-name-seq arg)))
-  
+             #:with name #'op-name.name
+             #:with extends #'op-name.extends
+             #:with prec #'options.prec
+             #:with rhs #'(tag body ...)
+             #:with ret-converter #'#f
+             #:with ret-static-infos #'()
+             #:with g #'(group op-name-seq arg)))
+
   (define-splicing-syntax-class :infix-case
     #:description "infix operator case"
+    #:datum-literals (group block)
     (pattern (~seq (_::parens (~and g (group left::not-op op-name-seq::dotted-operator-or-identifier-sequence right::not-op)))
                    ret::ret-annotation
-                   ((~and tag block) (~var options (:infix-operator-options '#f))
-                                     body ...))
+                   ((~and tag block)
+                    (~var options (:infix-operator-options '#f))
+                    body ...))
              #:with op-name::dotted-operator-or-identifier #'op-name-seq
-             #:attr name #'op-name.name
-             #:attr extends #'op-name.extends
-             #:attr prec #'options.prec
-             #:attr assc #'options.assc
-             #:attr rhs #'(tag body ...)
-             #:attr ret-predicate #'ret.converter
-             #:attr ret-static-infos #'ret.static-infos)
+             #:with name #'op-name.name
+             #:with extends #'op-name.extends
+             #:with prec #'options.prec
+             #:with assc #'options.assc
+             #:with rhs #'(tag body ...)
+             #:with ret-converter #'ret.converter
+             #:with ret-static-infos #'ret.static-infos)
     (pattern (~seq left::not-op op-name-seq::dotted-operator-or-identifier-sequence right::not-op-or-block
-                   ret::ret-annotation
-                   ((~and tag block) (~var options (:infix-operator-options '#f))
-                                     body ...))
+                   ((~and tag block)
+                    (~var options (:infix-operator-options '#f))
+                    body ...))
              #:with op-name::dotted-operator-or-identifier #'op-name-seq
-             #:attr name #'op-name.name
-             #:attr extends #'op-name.extends
-             #:attr prec #'options.prec
-             #:attr assc #'options.assc
-             #:attr rhs #'(tag body ...)
-             #:attr ret-predicate #'#f
-             #:attr ret-static-infos #'()
-             #:attr g #'(group left op-name-seq right)))
+             #:with name #'op-name.name
+             #:with extends #'op-name.extends
+             #:with prec #'options.prec
+             #:with assc #'options.assc
+             #:with rhs #'(tag body ...)
+             #:with ret-converter #'#f
+             #:with ret-static-infos #'()
+             #:with g #'(group left op-name-seq right)))
 
   (define-splicing-syntax-class :postfix-case
     #:description "postfix operator case"
+    #:datum-literals (group block)
     (pattern (~seq (_::parens (~and g (group arg::not-op op-name-seq::dotted-operator-or-identifier-sequence)))
                    ret::ret-annotation
-                   ((~and tag block) (~var options (:prefix-operator-options '#f))
-                                     body ...))
+                   ((~and tag block)
+                    (~var options (:prefix-operator-options '#f))
+                    body ...))
              #:with op-name::dotted-operator-or-identifier #'op-name-seq
-             #:attr name #'op-name.name
-             #:attr extends #'op-name.extends
-             #:attr prec #'options.prec
-             #:attr rhs #'(tag body ...)
-             #:attr ret-predicate #'ret.converter
-             #:attr ret-static-infos #'ret.static-infos)
+             #:with name #'op-name.name
+             #:with extends #'op-name.extends
+             #:with prec #'options.prec
+             #:with rhs #'(tag body ...)
+             #:with ret-converter #'ret.converter
+             #:with ret-static-infos #'ret.static-infos)
     (pattern (~seq arg::not-op op-name-seq::dotted-operator-or-identifier-sequence
-                   ret::ret-annotation
-                   ((~and tag block) (~var options (:prefix-operator-options '#f))
-                                     body ...))
+                   ((~and tag block)
+                    (~var options (:prefix-operator-options '#f))
+                    body ...))
              #:with op-name::dotted-operator-or-identifier #'op-name-seq
-             #:attr name #'op-name.name
-             #:attr extends #'op-name.extends
-             #:attr prec #'options.prec
-             #:attr rhs #'(tag body ...)
-             #:attr ret-predicate #'#f
-             #:attr ret-static-infos #'()
-             #:attr g #'(group arg op-name-seq)))
+             #:with name #'op-name.name
+             #:with extends #'op-name.extends
+             #:with prec #'options.prec
+             #:with rhs #'(tag body ...)
+             #:with ret-converter #'#f
+             #:with ret-static-infos #'()
+             #:with g #'(group arg op-name-seq)))
 
   (define (make-prefix name op-proc prec static-infos)
     (with-syntax ([op-proc op-proc])
@@ -170,34 +175,35 @@
     (syntax-parse #`(group #,arg)
       [arg::binding #'arg.parsed]))
 
-  (define (build-unary-function orig-stx name args rhss start end ret-predicates)
+  (define (build-unary-function orig-stx name main-converter args rhss ret-converters)
     (define arg-parseds (map parse-binding args))
     (define falsess (for/list ([a (in-list args)]) #'(#f)))
     (define (->stx l) (datum->syntax #f l))
     (define-values (proc arity)
       (cond
-        [(= (length args) 1)
+        [(and (eqv? (length args) 1)
+              (not (syntax-e main-converter)))
          (build-function no-adjustments
                          name
                          (car falsess) (->stx args) (->stx arg-parseds) (car falsess)
                          #'#f #'#f
                          #'#f #'#f
-                         (car ret-predicates)
+                         (car ret-converters)
                          (car rhss)
                          orig-stx)]
         [else
          (define falses (->stx (for/list ([a (in-list args)]) #'#f)))
          (build-case-function no-adjustments
-                              name #'#f
+                              name main-converter
                               (->stx falsess) (->stx (map list args)) (->stx (map list arg-parseds))
                               falses falses
                               falses falses
-                              (->stx ret-predicates)
+                              (->stx ret-converters)
                               (->stx rhss)
                               orig-stx)]))
     proc)
 
-  (define (build-binary-function orig-stx name lefts rights rhss start end ret-predicates)
+  (define (build-binary-function orig-stx name main-converter lefts rights rhss ret-converters)
     (define-values (left-parseds right-parseds)
       (for/lists (left-parseds right-parseds) ([left (in-list lefts)]
                                                [right (in-list rights)])
@@ -206,7 +212,8 @@
     (define (->stx l) (datum->syntax #f l))
     (define-values (proc arity)
       (cond
-        [(= (length lefts) 1)
+        [(and (eqv? (length lefts) 1)
+              (not (syntax-e main-converter)))
          (build-function no-adjustments
                          name
                          (car falsess)
@@ -215,33 +222,35 @@
                          (car falsess)
                          #'#f #'#f
                          #'#f #'#f
-                         (car ret-predicates)
+                         (car ret-converters)
                          (car rhss)
                          orig-stx)]
         [else
          (define falses (->stx (for/list ([a (in-list lefts)]) #'#f)))
          (build-case-function no-adjustments
-                              name #'#f
+                              name main-converter
                               (->stx falsess)
                               (->stx (map list lefts rights))
                               (->stx (map list left-parseds right-parseds))
                               falses falses
                               falses falses
-                              (->stx ret-predicates)
+                              (->stx ret-converters)
                               (->stx rhss)
                               orig-stx)]))
     proc)
 
-  (define (generate-prefix stx form-id gs name extends args prec rhss ret-predicates ret-static-infos)
+  (define (generate-prefix stx name extends args prec rhss ret-converters ret-static-infos
+                           #:main-converter [main-converter #'#f])
     (with-syntax ([(op-proc) (generate-temporaries (list name))])
       (cons
        #`(define op-proc
-           #,(build-unary-function stx name args rhss form-id (last gs) ret-predicates))
+           #,(build-unary-function stx name main-converter args rhss ret-converters))
        (build-syntax-definitions/maybe-extension
         '(#f rhombus/repet) name extends
         (make-prefix name #'op-proc prec ret-static-infos)))))
 
-  (define (generate-infix stx form-id gs name extends lefts rights prec assc rhss ret-predicates ret-static-infos)
+  (define (generate-infix stx name extends lefts rights prec assc rhss ret-converters ret-static-infos
+                          #:main-converter [main-converter #'#f])
     (with-syntax ([(op-proc) (generate-temporaries (list name))])
       (add-top-level
        #'(op-proc)
@@ -251,9 +260,10 @@
          (make-infix name #'op-proc prec assc ret-static-infos))
         (list
          #`(define op-proc
-             #,(build-binary-function stx name lefts rights rhss form-id (last gs) ret-predicates)))))))
-    
-  (define (generate-postfix stx form-id gs name extends args prec rhss ret-predicates ret-static-infos)
+             #,(build-binary-function stx name main-converter lefts rights rhss ret-converters)))))))
+
+  (define (generate-postfix stx name extends args prec rhss ret-converters ret-static-infos
+                            #:main-converter [main-converter #'#f])
     (with-syntax ([(op-proc) (generate-temporaries (list name))])
       (add-top-level
        #'(op-proc)
@@ -263,11 +273,12 @@
          (make-postfix name #'op-proc prec ret-static-infos))
         (list
          #`(define op-proc
-             #,(build-unary-function stx name args rhss form-id (last gs) ret-predicates)))))))
+             #,(build-unary-function stx name main-converter args rhss ret-converters)))))))
 
   (define (generate-prefix+infix stx
-                                 p-gs p-name p-extends p-args p-prec p-rhss p-ret-predicates p-ret-static-infos
-                                 i-gs i-name i-extends i-lefts i-rights i-prec i-assc i-rhss i-ret-predicates i-ret-static-infos)
+                                 p-name p-extends p-args p-prec p-rhss p-ret-converters p-ret-static-infos
+                                 i-name i-extends i-lefts i-rights i-prec i-assc i-rhss i-ret-converters i-ret-static-infos
+                                 #:main-converter [main-converter #'#f])
     (with-syntax ([(p-op-proc i-op-proc) (generate-temporaries (list p-name i-name))])
       (add-top-level
        #'(p-op-proc i-op-proc)
@@ -283,13 +294,14 @@
               (repetition-prefix+infix-operator prefix-repet infix-repet))))
         (list
          #`(define p-op-proc
-             #,(build-unary-function stx p-name p-args p-rhss (first p-gs) (last p-gs) p-ret-predicates))
+             #,(build-unary-function stx p-name main-converter p-args p-rhss p-ret-converters))
          #`(define i-op-proc
-             #,(build-binary-function stx i-name i-lefts i-rights i-rhss (first i-gs) (last i-gs) i-ret-predicates)))))))
+             #,(build-binary-function stx i-name main-converter i-lefts i-rights i-rhss i-ret-converters)))))))
 
   (define (generate-prefix+postfix stx
-                                   p-gs p-name p-extends p-args p-prec p-rhss p-ret-predicates p-ret-static-infos
-                                   a-gs a-name a-extends a-args a-prec a-rhss a-ret-predicates a-ret-static-infos)
+                                   p-name p-extends p-args p-prec p-rhss p-ret-converters p-ret-static-infos
+                                   a-name a-extends a-args a-prec a-rhss a-ret-converters a-ret-static-infos
+                                   #:main-converter [main-converter #'#f])
     (with-syntax ([(p-op-proc a-op-proc) (generate-temporaries (list p-name a-name))])
       (add-top-level
        #'(p-op-proc a-op-proc)
@@ -305,9 +317,9 @@
               (repetition-prefix+infix-operator prefix-repet infix-repet))))
         (list
          #`(define p-op-proc
-             #,(build-unary-function stx p-name p-args p-rhss (first p-gs) (last p-gs) p-ret-predicates))
+             #,(build-unary-function stx p-name main-converter p-args p-rhss p-ret-converters))
          #`(define a-op-proc
-             #,(build-unary-function stx a-name a-args a-rhss (first a-gs) (last a-gs) a-ret-predicates)))))))
+             #,(build-unary-function stx a-name main-converter a-args a-rhss a-ret-converters)))))))
 
   (define (add-top-level binds defns)
     (if (eq? 'top-level (syntax-local-context))
@@ -315,97 +327,79 @@
         defns)))
 
 (begin-for-syntax
-  (struct opcase (g name extends prec rhs ret-predicate ret-static-infos))
+  (struct opcase (name extends prec rhs ret-converter ret-static-infos))
   (struct unary-opcase opcase (arg))
-  (struct binary-opcase opcase (left right assc))
+  (struct binary-opcase opcase (left right assc)))
 
-  (define (intersect-static-infos static-infoss)
-    (if (for/and ([static-infos (in-list (cdr static-infoss))])
-          (same-expression? (car static-infoss) static-infos))
-        (car static-infoss)
-        #'())))
-
+;; NOTE postfix case must be before infix case, otherwise something
+;; like `(arg some.op) :: Annot` will proceed as an "infix" case.
 (define-defn-syntax rhombus-operator
   (definition-transformer
     (lambda (stx)
       (syntax-parse stx
-        #:datum-literals (group)
-        [(form-id p::prefix-case)
-         (generate-prefix stx
-                          #'form-id (list #'p.g) #'p.name #'p.extends (list #'p.arg) #'p.prec (list #'p.rhs)
-                          (list #'p.ret-predicate) #'p.ret-static-infos)]
-        [(form-id i::infix-case)
-         (generate-infix stx
-                         #'form-id (list #'i.g) #'i.name #'i.extends (list #'i.left) (list #'i.right) #'i.prec #'i.assc (list #'i.rhs)
-                         (list #'i.ret-predicate) #'i.ret-static-infos)]
-        [(form-id p::postfix-case)
-         (generate-postfix stx
-                           #'form-id (list #'p.g) #'p.name #'p.extends (list #'p.arg) #'p.prec (list #'p.rhs)
-                           (list #'p.ret-predicate) #'p.ret-static-infos)]
-        [(form-id (_::alts . as))
-         (parse-operator-alts stx #'form-id #'as
+        [(_ p::prefix-case)
+         (generate-prefix stx #'p.name #'p.extends (list #'p.arg) #'p.prec (list #'p.rhs)
+                          (list #'p.ret-converter) #'p.ret-static-infos)]
+        [(_ p::postfix-case)
+         (generate-postfix stx #'p.name #'p.extends (list #'p.arg) #'p.prec (list #'p.rhs)
+                           (list #'p.ret-converter) #'p.ret-static-infos)]
+        [(_ i::infix-case)
+         (generate-infix stx #'i.name #'i.extends (list #'i.left) (list #'i.right) #'i.prec #'i.assc (list #'i.rhs)
+                         (list #'i.ret-converter) #'i.ret-static-infos)]
+        [(_ (_::alts . as))
+         (parse-operator-alts stx #'as
                               #f
-                              #'#f #'#f
+                              #'#f #f
                               #'() #'())]
-        [(form-id main-op-name-seq::dotted-operator-or-identifier-sequence
-                  main-ret::ret-annotation
-                  (~optional (_::block
-                              (~var options (:all-operator-options '#f))))
-                  (_::alts . as))
+        [(_ main-op-name-seq::dotted-operator-or-identifier-sequence
+            main-ret::ret-annotation
+            (~optional (_::block (~var options (:all-operator-options '#f))))
+            (_::alts . as))
          #:with main-op-name::dotted-operator-or-identifier #'main-op-name-seq
-         (parse-operator-alts stx #'form-id #'as
+         (parse-operator-alts stx #'as
                               #'main-op-name.name
                               #'main-ret.converter #'main-ret.static-infos
-                              (if (attribute options)
-                                  #'options.prec
-                                  #'())
-                              (if (attribute options)
-                                  #'options.assc
-                                  #'()))]))))
+                              #'(~? options.prec ())
+                              #'(~? options.assc ()))]))))
 
-(define-for-syntax (parse-operator-alts stx form-id as-stx
-                                        main-name main-ret-predicate main-ret-static-infos
+(define-for-syntax (parse-operator-alts stx as-stx
+                                        main-name
+                                        main-ret-converter main-ret-static-infos
                                         main-prec main-assc)
+  (define (maybe-static-infos/main ops)
+    (or main-ret-static-infos
+        (let ([static-infoss (map opcase-ret-static-infos ops)])
+          (and (for/and ([static-infos (in-list (cdr static-infoss))])
+                 (same-expression? (car static-infoss) static-infos))
+               (car static-infoss)))
+        #'()))
   (define-values (all pres ins posts)
-    (let loop ([as (syntax->list as-stx)] [all '()] [pres '()] [ins '()] [posts '()])
-      (cond
-        [(null? as) (values (reverse all) (reverse pres) (reverse ins) (reverse posts))]
-        [else
-         (syntax-parse (car as)
-           #:datum-literals (group)
-           [(_ (_ p::prefix-case))
-            (define opc (unary-opcase #'p.g #'p.name #'p.extends
-                                      #'p.prec #'p.rhs #'p.ret-predicate #'p.ret-static-infos
-                                      #'p.arg))
-            (loop (cdr as)
-                  (cons opc all)
-                  (cons opc pres)
-                  ins
-                  posts)]
-           [(_ (_ i::infix-case))
-            (define opc (binary-opcase #'i.g #'i.name #'i.extends
-                                       #'i.prec #'i.rhs #'i.ret-predicate #'i.ret-static-infos
-                                       #'i.left #'i.right #'i.assc))
-            (loop (cdr as)
-                  (cons opc all)
-                  pres
-                  (cons opc ins)
-                  posts)]
-           [(_ (_ p::postfix-case))
-            (define opc (unary-opcase #'p.g #'p.name #'p.extends
-                                      #'p.prec #'p.rhs #'p.ret-predicate #'p.ret-static-infos
-                                      #'p.arg))
-            (loop (cdr as)
-                  (cons opc all)
-                  pres
-                  ins
-                  (cons opc posts))])])))
+    (for/fold ([all '()] [pres '()] [ins '()] [posts '()]
+               #:result (values (reverse all) (reverse pres) (reverse ins) (reverse posts)))
+              ([a (in-list (syntax->list as-stx))])
+      (syntax-parse a
+        #:datum-literals (group block)
+        [(block (group p::prefix-case))
+         (define opc (unary-opcase #'p.name #'p.extends
+                                   #'p.prec #'p.rhs #'p.ret-converter #'p.ret-static-infos
+                                   #'p.arg))
+         (values (cons opc all) (cons opc pres) ins posts)]
+        [(block (group p::postfix-case))
+         (define opc (unary-opcase #'p.name #'p.extends
+                                   #'p.prec #'p.rhs #'p.ret-converter #'p.ret-static-infos
+                                   #'p.arg))
+         (values (cons opc all) pres ins (cons opc posts))]
+        [(block (group i::infix-case))
+         (define opc (binary-opcase #'i.name #'i.extends
+                                    #'i.prec #'i.rhs #'i.ret-converter #'i.ret-static-infos
+                                    #'i.left #'i.right #'i.assc))
+         (values (cons opc all) pres (cons opc ins) posts)])))
   (check-consistent stx
                     (let ([names (map opcase-name all)])
                       (if main-name
                           (cons main-name names)
                           names))
-                    #:has-main? main-name
+                    #:has-main? (and main-name #t)
                     "operator")
   (when (and (pair? ins) (pair? posts))
     (raise-syntax-error #f
@@ -440,39 +434,39 @@
                                             main-assc))
   (cond
     [(and (null? ins) (null? posts))
-     (generate-prefix stx
-                      form-id (map opcase-g pres) (opcase-name (car pres)) (opcase-extends (car pres))
+     (generate-prefix stx #:main-converter main-ret-converter
+                      (opcase-name (car pres)) (opcase-extends (car pres))
                       (map unary-opcase-arg pres) (opcase-prec/main (car pres)) (map opcase-rhs pres)
-                      (map opcase-ret-predicate pres) (intersect-static-infos (map opcase-ret-static-infos pres)))]
+                      (map opcase-ret-converter pres) (maybe-static-infos/main pres))]
     [(and (null? pres) (null? posts))
-     (generate-infix stx
-                     form-id (map opcase-g ins) (opcase-name (car ins)) (opcase-extends (car ins))
+     (generate-infix stx #:main-converter main-ret-converter
+                     (opcase-name (car ins)) (opcase-extends (car ins))
                      (map binary-opcase-left ins) (map binary-opcase-right ins)
                      (opcase-prec/main (car ins)) (binary-opcase-assc/main (car ins))
                      (map opcase-rhs ins)
-                     (map opcase-ret-predicate ins) (intersect-static-infos (map opcase-ret-static-infos ins)))]
+                     (map opcase-ret-converter ins) (maybe-static-infos/main ins))]
     [(and (null? pres) (null? ins))
-     (generate-postfix stx
-                       form-id (map opcase-g posts) (opcase-name (car posts)) (opcase-extends (car posts))
+     (generate-postfix stx #:main-converter main-ret-converter
+                       (opcase-name (car posts)) (opcase-extends (car posts))
                        (map unary-opcase-arg posts) (opcase-prec/main (car posts)) (map opcase-rhs posts)
-                       (map opcase-ret-predicate posts) (intersect-static-infos (map opcase-ret-static-infos posts)))]
+                       (map opcase-ret-converter posts) (maybe-static-infos/main posts))]
     [(pair? ins)
-     (generate-prefix+infix stx
-                            (map opcase-g pres) (opcase-name (car pres)) (opcase-extends (car pres))
+     (generate-prefix+infix stx #:main-converter main-ret-converter
+                            (opcase-name (car pres)) (opcase-extends (car pres))
                             (map unary-opcase-arg pres) (opcase-prec/main (car pres)) (map opcase-rhs pres)
-                            (map opcase-ret-predicate pres) (intersect-static-infos (map opcase-ret-static-infos pres))
+                            (map opcase-ret-converter pres) (maybe-static-infos/main pres)
 
-                            (map opcase-g ins) (opcase-name (car ins)) (opcase-extends (car ins))
+                            (opcase-name (car ins)) (opcase-extends (car ins))
                             (map binary-opcase-left ins) (map binary-opcase-right ins)
                             (opcase-prec/main (car ins)) (binary-opcase-assc/main (car ins))
                             (map opcase-rhs ins)
-                            (map opcase-ret-predicate ins) (intersect-static-infos (map opcase-ret-static-infos ins)))]
+                            (map opcase-ret-converter ins) (maybe-static-infos/main ins))]
     [else
-     (generate-prefix+postfix stx
-                              (map opcase-g pres) (opcase-name (car pres)) (opcase-extends (car pres))
+     (generate-prefix+postfix stx #:main-converter main-ret-converter
+                              (opcase-name (car pres)) (opcase-extends (car pres))
                               (map unary-opcase-arg pres) (opcase-prec/main (car pres)) (map opcase-rhs pres)
-                              (map opcase-ret-predicate pres) (intersect-static-infos (map opcase-ret-static-infos pres))
+                              (map opcase-ret-converter pres) (maybe-static-infos/main pres)
 
-                              (map opcase-g posts) (opcase-name (car posts)) (opcase-extends (car posts))
+                              (opcase-name (car posts)) (opcase-extends (car posts))
                               (map unary-opcase-arg posts) (opcase-prec/main (car posts)) (map opcase-rhs posts)
-                              (map opcase-ret-predicate posts) (intersect-static-infos (map opcase-ret-static-infos posts)))]))
+                              (map opcase-ret-converter posts) (maybe-static-infos/main posts))]))

--- a/rhombus/tests/operator.rhm
+++ b/rhombus/tests/operator.rhm
@@ -242,3 +242,90 @@ check:
   def [a, ...] = [1, 2, 3]
   [a??, ...]
   ~is [1, 2, 3]
+
+// check result annotations
+block:
+  use_static
+  check:
+    operator (>< (xs :: List)) :: List:
+      xs.reverse()
+    (>< [1, 2, 3])[0]
+    ~is 3
+  check:
+    operator >< :: List
+    | >< (xs :: List):
+        xs.reverse()
+    (>< [1, 2, 3])[0]
+    ~is 3
+  check:
+    operator
+    | (>< (xs :: List)) :: List:
+        xs.reverse()
+    (>< [1, 2, 3])[0]
+    ~is 3
+  check:
+    operator ((xs :: List) ><) :: List:
+      xs.reverse()
+    ([1, 2, 3] ><)[0]
+    ~is 3
+  check:
+    operator >< :: List
+    | (xs :: List) ><:
+        xs.reverse()
+    ([1, 2, 3] ><)[0]
+    ~is 3
+  check:
+    operator
+    | ((xs :: List) ><) :: List:
+        xs.reverse()
+    ([1, 2, 3] ><)[0]
+    ~is 3
+  check:
+    operator ((xs :: List) <> (ys :: List)) :: List:
+      xs ++ ys
+    ([1, 2, 3] <> [4, 5, 6])[0]
+    ~is 1
+  check:
+    operator <> :: List
+    | (xs :: List) <> (ys :: List):
+        xs ++ ys
+    ([1, 2, 3] <> [4, 5, 6])[0]
+    ~is 1
+  check:
+    operator
+    | ((xs :: List) <> (ys :: List)) :: List:
+        xs ++ ys
+    ([1, 2, 3] <> [4, 5, 6])[0]
+    ~is 1
+
+check:
+  operator ? :: converting(fun (_): println("main"))
+  | (? #false) :: converting(fun (_): println("prefix: false")):
+      #void
+  | (? #true) :: converting(fun (_): println("prefix: true")):
+      #void
+  | (#false ?) :: converting(fun (_): println("postfix: false")):
+      #void
+  | (#true ?) :: converting(fun (_): println("postfix: true")):
+      #void
+  ?#false
+  ?#true
+  #false?
+  #true?
+  ~prints "prefix: false\nmain\nprefix: true\nmain\npostfix: false\nmain\npostfix: true\nmain\n"
+
+check:
+  operator ? :: converting(fun (_): println("main"))
+  | (? #false) :: converting(fun (_): println("prefix: false")):
+      #void
+  | (? #true) :: converting(fun (_): println("prefix: true")):
+      #void
+  | (#false ? #false) :: converting(fun (_): println("infix: false")):
+      #void
+  | (#true ? #true) :: converting(fun (_): println("infix: true")):
+      #void
+  ?#false
+  ?#true
+  #false?#false
+  #true?#true
+  ~prints "prefix: false\nmain\nprefix: true\nmain\ninfix: false\nmain\ninfix: true\nmain\n"


### PR DESCRIPTION
Currently, `operator` is discarding the main converter (and the static infos for that matter) from the outer result annotation.  This commit fixes this issue and cleans up some of the code in `operator.rkt`.

Another bug revealed by the new test cases is that a postfix case can wrongly proceed as an “infix” case due to the presence of annotation operator.  This is also fixed.