### PR TITLE
use chaperones for `{Array,Box}.later_of`

### DIFF
--- a/rhombus/scribblings/ref-array.scrbl
+++ b/rhombus/scribblings/ref-array.scrbl
@@ -32,8 +32,8 @@ mutable and immutable arrays, while @rhombus(MutableArray, ~annot) and
   annot.macro 'ImmutableArray'
 ){
 
- The @rhombus(Array, ~annot) annotation (without @rhombus(of) or
- @rhombus(now_of)) matches any array.
+ The @rhombus(Array, ~annot) annotation (without @rhombus(now_of) or
+ @rhombus(later_of)) matches any array.
  
  The @rhombus(Array.now_of, ~annot) form constructs a @tech{predicate
   annotation} that matches an array whose elements all currently satisfy
@@ -52,7 +52,8 @@ mutable and immutable arrays, while @rhombus(MutableArray, ~annot) and
  accessing an element of the array or a value to be installed into the
  array. (A different view of the array might changes an element to one that
  does not astisfy @rhombus(annot).) Static information from
- @rhombus(annot) is propagated to accesses of the array.
+ @rhombus(annot) is propagated to accesses of the array. Note that a
+ converter @rhombus(annot) is applied for each access or update.
 
  @rhombus(MutableArray, ~annot) matches only mutable arrays, and
  @rhombus(ImmutableArray, ~annot) matches only immutable arrays (that may

--- a/rhombus/scribblings/ref-box.scrbl
+++ b/rhombus/scribblings/ref-box.scrbl
@@ -19,18 +19,16 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
 @rhombus(ImmutableBox, ~annot) require one or the other.
 
 @doc(
-  ~nonterminal:
-    val_annot: :: annot
   annot.macro 'Box'
-  annot.macro 'Box.now_of($val_annot)'
-  annot.macro 'Box.later_of($val_annot)'
+  annot.macro 'Box.now_of($annot)'
+  annot.macro 'Box.later_of($annot)'
   annot.macro 'MutableBox'
   annot.macro 'ImmutableBox'
 
 ){
 
- The @rhombus(Box, ~annot) annotation (without @rhombus(of) or
- @rhombus(now_of)) matches any box.
+ The @rhombus(Box, ~annot) annotation (without @rhombus(now_of) or
+ @rhombus(later_of)) matches any box.
  
  The @rhombus(Box.now_of, ~annot) form constructs a @tech{predicate
   annotation} that matches a box whose values satisfies
@@ -49,7 +47,8 @@ mutable and immutable boxes, while @rhombus(MutableBox, ~annot) and
  the box or for a value to be installed into the box. (A different view
  of the box might changes its value to one that does not astisfy
  @rhombus(annot).) Static information from @rhombus(annot) is propagated
- to accesses of the box's value.
+ to accesses of the box's value. Note that a converter @rhombus(annot)
+ is applied for each access or update.
 
  @rhombus(MutableBox, ~annot) matches only mutable boxes, and
  @rhombus(ImmutableBox, ~annot) matches only immutable boxes (that may

--- a/rhombus/tests/array.rhm
+++ b/rhombus/tests/array.rhm
@@ -83,24 +83,48 @@ block:
 
 
 check:
-  def a :: Array.now_of(String) = Array(1)
-  #void
+  10 :: Array
   ~raises "does not satisfy annotation"
 
 check:
-  def a :: Array.now_of(String) = Array(1)
-  #void
+  10 :: Array.now_of(Any)
   ~raises "does not satisfy annotation"
 
 check:
-  def a :: Array.later_of(String) = Array(1)
-  #void
+  10 :: Array.later_of(Any)
+  ~raises "does not satisfy annotation"
+
+check:
+  10 :: Array.later_of(converting(fun (_): #false))
+  ~raises "does not satisfy annotation"
+
+check:
+  Array(1) :: Array.now_of(String)
+  ~raises "does not satisfy annotation"
+
+check:
+  Array(1) :: Array.later_of(String)
   ~completes
+
+check:
+  def a :: Array.later_of(
+    converting(fun (n :: Int):
+                 println("run")
+                 n+1)):
+    Array(1)
+  println(a[0])
+  a[0] := 1
+  println(a[0])
+  ~prints "run\n2\nrun\nrun\n3\n"
 
 check:
   def a :: Array.later_of(String) = Array(1)
   a[0]
-  ~raises "current element does not satisfy the array's annotation"
+  ~raises values(
+    "current element does not satisfy the array's annotation",
+    "0",
+    "String",
+  )
 
 check:
   def a :: Array.later_of(String) = Array(1, "ok")
@@ -111,12 +135,16 @@ check:
   def a :: Array.later_of(String) = Array("apple")
   a[0]
   a[0] := #'oops
-  ~raises "new element does not satisfy the array's annotation"
+  ~raises values(
+    "new element does not satisfy the array's annotation",
+    "0",
+    "String",
+  )
 
 check:
   ~eval
-  def a :: Array.now_of(Array.later_of(String)) = Array(Array("apple"))
-  ~raises "converting annotation not supported for element"
+  Array(Array("apple")) :: Array.now_of(Array.later_of(String))
+  ~raises "converter annotation not supported for element"
 
 check:
   use_static

--- a/rhombus/tests/box.rhm
+++ b/rhombus/tests/box.rhm
@@ -53,35 +53,61 @@ check:
   ~is 11
 
 check:
-  def bx :: Box = 10
-  #void
+  10 :: Box
   ~raises "does not satisfy annotation"
 
 check:
-  def bx :: Box.now_of(String) = Box(1)
-  #void
+  10 :: Box.now_of(Any)
   ~raises "does not satisfy annotation"
 
 check:
-  def bx :: Box.later_of(String) = Box(1)
-  #void
+  10 :: Box.later_of(Any)
+  ~raises "does not satisfy annotation"
+
+check:
+  10 :: Box.later_of(converting(fun (_): #false))
+  ~raises "does not satisfy annotation"
+
+check:
+  Box(1) :: Box.now_of(String)
+  ~raises "does not satisfy annotation"
+
+check:
+  Box(1) :: Box.later_of(String)
   ~completes
+
+check:
+  def bx :: Box.later_of(
+    converting(fun (n :: Int):
+                 println("run")
+                 n+1)):
+    Box(1)
+  println(bx.value)
+  bx.value := 1
+  println(bx.value)
+  ~prints "run\n2\nrun\nrun\n3\n"
 
 check:
   def bx :: Box.later_of(String) = Box(1)
   bx.value
-  ~raises "current value does not satisfy the box's annotation"
+  ~raises values(
+    "current value does not satisfy the box's annotation",
+    "String",
+  )
 
 check:
   def bx :: Box.later_of(String) = Box("apple")
   bx.value
   bx.value := #'oops
-  ~raises "new value does not satisfy the box's annotation"
+  ~raises values(
+    "new value does not satisfy the box's annotation",
+    "String",
+  )
 
 check:
   ~eval
-  def bx :: Box.now_of(Box.later_of(String)) = Box(Box("apple"))
-  ~raises "converting annotation not supported for value"
+  Box(Box("apple")) :: Box.now_of(Box.later_of(String))
+  ~raises "converter annotation not supported for value"
 
 check:
   use_static

--- a/rhombus/tests/list.rhm
+++ b/rhombus/tests/list.rhm
@@ -87,8 +87,26 @@ block:
 
 block:
   check:
+    1 :: List
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: List.of(Any)
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: List.of(converting(fun (_): #false))
+    ~raises "does not satisfy annotation"
+  check:
     [1, 2, 3] :: List.of(converting(fun (n :: Int): n+1))
     ~is [2, 3, 4]
+  check:
+    1 :: NonemptyList
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: NonemptyList.of(Any)
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: NonemptyList.of(converting(fun (_): #false))
+    ~raises "does not satisfy annotation"
   check:
     [1, 2, 3] :: NonemptyList.of(converting(fun (n :: Int): n+1))
     ~is [2, 3, 4]

--- a/rhombus/tests/map.rhm
+++ b/rhombus/tests/map.rhm
@@ -65,6 +65,18 @@ block:
 
 block:
   check:
+    1 :: Map
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: Map.of(Any, Any)
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: Map.of(
+      converting(fun (_): #false),
+      converting(fun (_): #false)
+    )
+    ~raises "does not satisfy annotation"
+  check:
     {1: 2, 2: 3, 3: 4} :: Map.of(
       converting(fun (n :: Int): n+1),
       converting(fun (n :: Int): n-1)

--- a/rhombus/tests/pair.rhm
+++ b/rhombus/tests/pair.rhm
@@ -33,13 +33,6 @@ check:
   ["ok", "fine"] :: Pair.of(String, List)
   ~is ["ok", "fine"]
 
-check:
-  Pair(1, 2) :: Pair.of(
-    converting(fun (1): 2),
-    converting(fun (2): 1)
-  )
-  ~is Pair(2, 1)
-
 block:
   use_static
   check:
@@ -84,6 +77,26 @@ block:
     def x :: Pair.of(List, Any) = [[1, 2, 3]]
     x.first.length()
     ~is 3
+
+block:
+  check:
+    Pair(1, 2) :: Pair.of(
+      converting(fun (1): 2),
+      converting(fun (2): 1)
+    )
+    ~is Pair(2, 1)
+  check:
+    1 :: Pair
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: Pair.of(Any, Any)
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: Pair.of(
+      converting(fun (_): #false),
+      converting(fun (_): #false)
+    )
+    ~raises "does not satisfy annotation"
 
 block:
   check:

--- a/rhombus/tests/set.rhm
+++ b/rhombus/tests/set.rhm
@@ -47,7 +47,16 @@ block:
 
 block:
   check:
-    {1, 2, 3} :: Set.of(converting (fun (n :: Int): n+1))
+    1 :: Set
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: Set.of(Any)
+    ~raises "does not satisfy annotation"
+  check:
+    1 :: Set.of(converting(fun (_): #false))
+    ~raises "does not satisfy annotation"
+  check:
+    {1, 2, 3} :: Set.of(converting(fun (n :: Int): n+1))
     ~is {2, 3, 4}
 
 block:


### PR DESCRIPTION
This commit changes `{Array,Box}.later_of` to use chaperones for the predicate case, and only use impersonators for the binding case.  The binding case is changed to *not* discard the converted value.  Moreover, the error message is improved by including the annotation and, for arrays, the position.

A bug was found that the binding case of `of` annotations did not check the predicate before continuing.  This was fixed and some test cases were added.