### PR TITLE
Add support for using ~matches with multiple values in a check test

### DIFF
--- a/rhombus/private/check.rhm
+++ b/rhombus/private/check.rhm
@@ -2,7 +2,6 @@
 import:
   "core-meta.rkt" open
   "call-capture-exn.rkt" open
-  lib("racket/syntax-srcloc.rkt") as srcloc
   lib("racket/base.rkt").#{error-print-source-location}
   lib("rackunit/log.rkt").#{test-log!}
   lib("racket/base.rkt")
@@ -97,12 +96,16 @@ expr.macro
                 #'$result2.mode)'
 
 expr.macro
-| 'matcher(~matches, : $binding)':
-    'fun | (): (fun | ($binding): #true | (& _): #false)
-         | (x): $("" +& '$binding')'
+| 'matcher(~matches, : $(pattern g:
+                           kind ~group
+                         | '$(bound_as bind_meta.space: 'values') ($bind, ...) $()'
+                         | '($bind, ...) $()'
+                         | '$b': field [bind, ...] = [b]))':
+    'fun | (): (fun | ($g.bind, ...): #true | (& _): #false)
+         | (_): #%literal $(to_string(g))'
 | 'matcher(~is_a, : $ann)':
     'fun | (): (fun (x): x is_a ($ann))
-         | (x): $("" +& '$ann')'
+         | (_): #%literal $(to_string(ann))'
 | 'matcher($_, $body)': 'fun () $body'
 
 fun check_same(loc_where :~ List, thunk, expected_thunk, maybe_loc_mode):
@@ -110,7 +113,7 @@ fun check_same(loc_where :~ List, thunk, expected_thunk, maybe_loc_mode):
     match maybe_loc_mode
     | [mode, srcloc]: maybe_loc_mode
     | mode: [mode, loc_where[1]]
-  let values(got :~ List, exn_msg, output) = call_capturing_exn(thunk, mode == #'~prints)
+  let (got :~ List, exn_msg, output) = call_capturing_exn(thunk, mode == #'~prints)
   let expected :~ List = call_capturing_values(expected_thunk)
   let ok:
     match mode
@@ -131,8 +134,7 @@ fun check_same(loc_where :~ List, thunk, expected_thunk, maybe_loc_mode):
     | #'~matches:
         !exn_msg && expected[0](& got)
   #{test-log!}(ok)
-  if ok
-  | #void
+  unless ok
   | fun
     | values_str([v]): to_string(v, ~mode: #'expr)
     | values_str(lst): "values " +& to_string(lst, ~mode: #'expr)

--- a/rhombus/private/port.rkt
+++ b/rhombus/private/port.rkt
@@ -1,8 +1,10 @@
 #lang racket/base
 (require (for-syntax racket/base)
          "provide.rkt"
+         "call-result-key.rkt"
          "function-arity-key.rkt"
-         "indirect-static-info-key.rkt"
+         (submod "bytes.rkt" static-infos)
+         (submod "string.rkt" static-infos)
          "static-info.rkt"
          "define-arity.rkt"
          "class-primitive.rkt"
@@ -39,22 +41,56 @@
   #:properties ()
   #:methods ())
 
-(define/method (Output.flush [p (current-output-port)])
-  (unless (output-port? p)
-    (raise-argument-error* who rhombus-realm "Output" p))
-  (flush-output p))
-
 (define-primitive-class Output output-port
+  #:lift-declaration
   #:existing
   #:translucent
   #:fields ()
   #:namespace-fields
   ([current current-output-port]
-   [current_error current-error-port])
+   [current_error current-error-port]
+   [open_bytes Port.Output.open_bytes]
+   [open_string Port.Output.open_string])
   #:properties ()
   #:methods
-  (flush))
+  ([get_bytes Port.Output.get_bytes]
+   [get_string Port.Output.get_string]
+   [flush Port.Output.flush]))
 
 (define-static-info-syntaxes (current-input-port current-output-port current-error-port)
   (#%function-arity 3)
   (#%indirect-static-info indirect-function-static-info))
+
+;; TODO these need a more specific annotation
+(define/arity Port.Output.open_bytes
+  #:inline
+  #:primitive (open-output-bytes)
+  #:static-infos ((#%call-result #,output-port-static-infos))
+  (case-lambda
+    [() (open-output-bytes)]
+    [(name) (open-output-bytes name)]))
+
+(define/arity Port.Output.open_string
+  #:inline
+  #:primitive (open-output-string)
+  #:static-infos ((#%call-result #,output-port-static-infos))
+  (case-lambda
+    [() (open-output-string)]
+    [(name) (open-output-string name)]))
+
+(define/method (Port.Output.get_bytes port)
+  #:inline
+  #:primitive (get-output-bytes)
+  #:static-infos ((#%call-result #,bytes-static-infos))
+  (get-output-bytes port))
+
+(define/method (Port.Output.get_string port)
+  #:inline
+  #:primitive (get-output-string)
+  #:static-infos ((#%call-result #,string-static-infos))
+  (string->immutable-string (get-output-string port)))
+
+(define/method (Port.Output.flush [p (current-output-port)])
+  (unless (output-port? p)
+    (raise-argument-error* who rhombus-realm "Port.Output" p))
+  (flush-output p))

--- a/rhombus/private/string.rkt
+++ b/rhombus/private/string.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre)
+         (only-in racket/string string-contains?)
          racket/symbol
          racket/keyword
          "provide.rkt"
@@ -63,6 +64,7 @@
   #:methods
   ([length String.length]
    [get String.get]
+   [contains String.contains]
    [append String.append]
    [substring String.substring]
    [utf8_bytes String.utf8_bytes]
@@ -95,6 +97,7 @@
    [append String.append]
    [length String.length]
    [get String.get]
+   [contains String.contains]
    [substring String.substring]
    [utf8_bytes String.utf8_bytes]
    [latin1_bytes String.latin1_bytes]
@@ -183,6 +186,11 @@
 (define/method (String.to_number s)
   (check-readable-string who s)
   (string->number s))
+
+(define/method (String.contains s1 s2)
+  (check-readable-string who s1)
+  (check-readable-string who s2)
+  (string-contains? s1 s2))
 
 (define/method String.substring
   #:inline

--- a/rhombus/scribblings/ref-check.scrbl
+++ b/rhombus/scribblings/ref-check.scrbl
@@ -18,7 +18,7 @@
   ~nonterminal:
     expected_expr: block expr
     expected_body: block body
-    expected_bind: def bind ~defn
+    expected_bind: def lhs_bind ~defn
     evaluator_expr: block expr
   expr.macro 'check:
                 $maybe_eval
@@ -45,7 +45,7 @@
     ~prints_like $expected_expr
     ~prints_like: $expected_body; ...
     ~matches $expected_bind
-    ~matches: $expected_bind; ...
+    ~matches: $expected_bind
     ~prints $expected_expr
     ~prints: $expected_body; ...
     ~throws $expected_expr

--- a/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/scribblings/ref-io.scrbl
@@ -11,6 +11,8 @@ input, while an @deftech{output port} is specifically for output.
 @dispatch_table(
   "output port"
   Port.Output
+  out.get_bytes()
+  out.get_string()
   out.flush()
 )
 
@@ -92,6 +94,39 @@ input, while an @deftech{output port} is specifically for output.
 
 }
 
+
+@doc(
+  fun Port.Output.open_bytes(name :: Symbol) :: Port.Output
+  fun Port.Output.open_string(name :: Symbol) :: Port.Output
+){
+
+ Creates an @tech{output port} that accumulates the output into a
+ @tech{byte string}. The optional @rhombus(name) argument is used as
+ the name for the returned port.
+
+ @rhombus(Port.Output.open_string) does the same as
+ @rhombus(Port.Output.open_bytes), but can be used to clarify the
+ intention together with @rhombus(Port.Output.get_string).
+
+}
+
+@doc(
+  fun Port.Output.get_bytes(out :: Port.Output) :: Bytes
+  fun Port.Output.get_string(out :: Port.Output) :: String
+){
+
+ @rhombus(Port.Output.get_bytes) returns the bytes accumulated in the
+ @tech{output port} @rhombus(out) so far in a freshly allocated
+ @tech{byte string} (including any bytes written after the port's
+ current position, if any).
+
+ @rhombus(Port.Output.get_string) is like
+ @rhombus(Port.Output.get_bytes), but returns a string converted from
+ the byte string instead.
+
+}
+
+
 @doc(
   fun Port.Output.flush(out :: Port.Output = Port.Output.current())
     :: Void
@@ -100,6 +135,7 @@ input, while an @deftech{output port} is specifically for output.
  Flushes the content of @rhombus(out)'s buffer.
 
 }
+
 
 @doc(
   interface Printable

--- a/rhombus/scribblings/ref-string.scrbl
+++ b/rhombus/scribblings/ref-string.scrbl
@@ -24,6 +24,7 @@ immutable strings.
   str.length()
   str.get(n)
   str.substring(arg, ...)
+  str.contains(substr)
   str.utf8_bytes(arg, ...)
   str.latin1_bytes(arg, ...)
   str.locale_bytes(arg, ...)
@@ -120,6 +121,25 @@ immutable strings.
 @examples(
   String.length("hello")
   "hello".length()
+)
+
+}
+
+
+@doc(
+  fun String.contains(str :: ReadableString,
+                      substr :: ReadableString)
+    :: Boolean
+){
+
+ Checks whether @rhombus(str) contains @rhombus(substr) as a
+ substring.
+
+@examples(
+  String.contains("howdy", "how")
+  "howdy".contains("how")
+  String.contains("howdy", "nope")
+  "howdy".contains("nope")
 )
 
 }

--- a/rhombus/tests/check.rhm
+++ b/rhombus/tests/check.rhm
@@ -1,0 +1,80 @@
+#lang rhombus/and_meta
+import:
+  lib("rackunit/log.rkt")
+
+fun check_error(thunk, is_ok, form_str, should_str):
+  let str:
+    let out = Port.Output.open_string()
+    parameterize { Port.Output.current_error: out,
+                   log.#{test-log-enabled?}: #false }:
+      thunk()
+    out.get_string()
+  let ok = is_ok(str)
+  log.#{test-log!}(ok)
+  unless ok
+  | print("`" ++ form_str ++ "` did not " ++ should_str
+            ++ "\n" ++ str,
+          Port.Output.current_error())
+
+expr.macro 'check_check:
+              $what
+              ~success:
+                $success_mode $success ...
+                ...
+              ~failure:
+                $failure_mode $failure ... ~expected $expected
+                ...':
+  ~op_stx self
+  let check = 'check'.relocate(self)
+  fun make_check(mode, rhs, is_ok, should):
+    fun make_one(spec):
+      'check_error(fun (): $check: $what; $spec,
+                   $is_ok,
+                   #%literal $(to_string(spec)),
+                   #%literal $should)'
+    'block:
+       $(make_one('$mode $rhs'))
+       $(if rhs matches '' | '' | make_one('$mode: $rhs'))'
+  fun make_success(mode, rhs):
+    make_check(mode, rhs,
+               'fun (str): str == ""',
+               "succeed")
+  fun make_failure(mode, rhs, expected):
+    let expected = "  expected: " ++ expected
+    make_check(mode, rhs,
+               'fun (str :~ String): str.contains(#%literal $expected)',
+               "fail with expected message")
+  'block:
+     $(make_success(success_mode, '$success ...'))
+     ...
+     $(make_failure(failure_mode, '$failure ...', expected.unwrap()))
+     ...'
+
+check_check:
+  [1, 2, 3]
+  ~success:
+    ~is [1, 2, 3]
+    ~is_now [1, 2, 3]
+    ~is_a List.of(PosInt)
+    ~prints_like [1, 2, 3]
+    ~matches [1, 2, 3]
+    ~completes
+  ~failure:
+    ~is PairList[1, 2, 3] ~expected "PairList[1, 2, 3]"
+    ~is_now PairList[1, 2, 3] ~expected "PairList[1, 2, 3]"
+    ~is_a PairList.of(PosInt) ~expected "satisfying PairList . of (PosInt)"
+    ~prints_like PairList[1, 2, 3] ~expected "PairList[1, 2, 3]"
+    ~matches PairList[1, 2, 3] ~expected "matching PairList [1, 2, 3]"
+    ~throws "anything" ~expected "exception \"anything\""
+
+check_check:
+  values(1, [2, 3])
+  ~success:
+    ~matches values(a, [b, c])
+    ~matches (a, [b, c])
+    ~completes
+  ~failure:
+    ~matches a ~expected "matching a"
+    ~matches [b, c] ~expected "matching [b, c]"
+    ~matches (a, [b, c], d) ~expected "matching (a, [b, c], d)"
+    ~throws "anything" ~expected "exception \"anything\""

--- a/rhombus/tests/port.rhm
+++ b/rhombus/tests/port.rhm
@@ -4,6 +4,10 @@ block:
   import "static_arity.rhm"
   static_arity.check:
     Port.Input.current([in])
+    Port.Output.open_bytes([name])
+    Port.Output.open_string([name])
+    Port.Output.get_bytes(out) ~method
+    Port.Output.get_string(out) ~method
     Port.Output.flush([out]) ~method
     Port.Output.current([out])
     Port.Output.current_error([out])

--- a/rhombus/tests/string.rhm
+++ b/rhombus/tests/string.rhm
@@ -6,6 +6,7 @@ block:
     to_string(v)
     String.length(str) ~method
     String.get(str, i) ~method
+    String.contains(str, substr) ~method
     String.to_string(str) ~method
     ReadableString.to_string(str) ~method
     String.to_int(str) ~method
@@ -63,6 +64,8 @@ block:
     "Hello".grapheme_count(2) ~is 3
     "Hello".grapheme_span(2, 4) ~is 1
     "Hello".grapheme_count(2, 4) ~is 2
+    "Hello".contains("ello") ~is #true
+    "Hello".contains("howdy") ~is #false
 
 check:
   dynamic("hello").length() ~is 5
@@ -94,6 +97,8 @@ check:
   dynamic("Hello").grapheme_count(2) ~is 3
   dynamic("Hello").grapheme_span(2, 4) ~is 1
   dynamic("Hello").grapheme_count(2, 4) ~is 2
+  dynamic("Hello").contains("ello") ~is #true
+  dynamic("Hello").contains("howdy") ~is #false
 
 check:
   String.length("hello") ~is 5
@@ -117,6 +122,8 @@ check:
   String.grapheme_count("Hello", 2) ~is 3
   String.grapheme_span("Hello", 2, 4) ~is 1
   String.grapheme_count("Hello", 2, 4) ~is 2
+  String.contains("Hello", "ello") ~is #true
+  String.contains("Hello", "howdy") ~is #false
 
 block:
   import:


### PR DESCRIPTION
Previously something like this wouldn't work:

```
check: values(1, [2, 3, 4])
       ~matches values(a, [b, c, d])
```

Now it does!

I'd be happy to add unit tests—I need someone to show me where they're at if there are any. Thanks!