### PR TITLE
fix `Pair.cons` and `Pair.of`

### DIFF
--- a/rhombus/private/pair.rkt
+++ b/rhombus/private/pair.rkt
@@ -11,11 +11,12 @@
          "rhombus-primitive.rkt")
 
 (provide (for-spaces (rhombus/namespace
-                      #f
+                      rhombus/annot)
+                     Pair)
+         (for-spaces (#f
                       rhombus/bind
-                      rhombus/annot
                       rhombus/statinfo)
-                     Pair))
+                     (rename-out [Pair.cons Pair])))
 
 (module+ for-builtin
   (provide pair-method-table))
@@ -27,7 +28,7 @@
   #:opaque
   #:fields ()
   #:namespace-fields
-  ([cons Pair]
+  ([cons Pair.cons]
    of
    )
   #:properties
@@ -43,7 +44,7 @@
 
 (set-primitive-contract! 'pair? "Pair")
 
-(define/arity (Pair a d)
+(define/arity #:name Pair (Pair.cons a d)
   #:inline
   #:static-infos ((#%call-result #,pair-static-infos))
   (cons a d))
@@ -58,7 +59,7 @@
   #:primitive (cdr)
   (cdr p))
 
-(define-binding-syntax Pair
+(define-binding-syntax Pair.cons
   (binding-transformer
    (make-composite-binding-transformer "Pair"
                                        #'pair?
@@ -82,10 +83,10 @@
 
 (define-syntax (pair-build-convert arg-id build-convert-stxs kws data)
   #`(#,(car build-convert-stxs)
-     (car arg-id)
+     (car #,arg-id)
      (lambda (a)
        (#,(cadr build-convert-stxs)
-        (cdr arg-id)
-        (lambda (d) (cons a d)))
-       (lambda () #f))
+        (cdr #,arg-id)
+        (lambda (d) (cons a d))
+        (lambda () #f)))
      (lambda () #f)))

--- a/rhombus/tests/list.rhm
+++ b/rhombus/tests/list.rhm
@@ -87,6 +87,14 @@ block:
 
 block:
   check:
+    [1, 2, 3] :: List.of(converting(fun (n :: Int): n+1))
+    ~is [2, 3, 4]
+  check:
+    [1, 2, 3] :: NonemptyList.of(converting(fun (n :: Int): n+1))
+    ~is [2, 3, 4]
+
+block:
+  check:
     dynamic([1, 2, 3]).length()
     ~is 3
   check:

--- a/rhombus/tests/map.rhm
+++ b/rhombus/tests/map.rhm
@@ -65,6 +65,14 @@ block:
 
 block:
   check:
+    {1: 2, 2: 3, 3: 4} :: Map.of(
+      converting(fun (n :: Int): n+1),
+      converting(fun (n :: Int): n-1)
+    )
+    ~is {2: 1, 3: 2, 4: 3}
+
+block:
+  check:
     dynamic({"a": 1, "b": 2}).length() ~is 2
     dynamic({"a": 1, "b": 2})["a"] ~is 1
     dynamic({"a": 1, "b": 2}).get("a") ~is 1

--- a/rhombus/tests/pair.rhm
+++ b/rhombus/tests/pair.rhm
@@ -33,6 +33,13 @@ check:
   ["ok", "fine"] :: Pair.of(String, List)
   ~is ["ok", "fine"]
 
+check:
+  Pair(1, 2) :: Pair.of(
+    converting(fun (1): 2),
+    converting(fun (2): 1)
+  )
+  ~is Pair(2, 1)
+
 block:
   use_static
   check:
@@ -56,10 +63,18 @@ block:
     x
     ~is 1
   check:
+    def Pair.cons(x, y) = [1, 2, 3]
+    x
+    ~is 1
+  check:
     (["ok", "fine"] :: Pair.of(String, List)).rest
     ~is ["fine"]
   check:
     def Pair(x :: List, y) = [[1, 2, 3]]
+    x.length()
+    ~is 3
+  check:
+    def Pair.cons(x :: List, y) = [[1, 2, 3]]
     x.length()
     ~is 3
   check:

--- a/rhombus/tests/set.rhm
+++ b/rhombus/tests/set.rhm
@@ -47,6 +47,11 @@ block:
 
 block:
   check:
+    {1, 2, 3} :: Set.of(converting (fun (n :: Int): n+1))
+    ~is {2, 3, 4}
+
+block:
+  check:
     dynamic({"a", "b"}).length()
     ~is 2
   check:


### PR DESCRIPTION
I accidentally exported too much for `Pair.cons`.  Also, it went unnoticed that `Pair.of` in converter mode was broken.

Also add some test cases for `of` annotations in converter mode.