### PR TITLE
include annotation in result failure

### DIFF
--- a/rhombus/private/class-method-result.rkt
+++ b/rhombus/private/class-method-result.rkt
@@ -2,16 +2,17 @@
 (require (for-syntax racket/base
                      syntax/parse/pre
                      enforest/syntax-local
+                     shrubbery/print
                      "srcloc.rkt"
                      "tag.rkt"
-                     "with-syntax.rkt")
-         (only-in "annotation.rkt" ::)
+                     "with-syntax.rkt"
+                     "annotation-string.rkt")
          (submod "annotation.rkt" for-class)
          "binding.rkt"
          "static-info.rkt"
-         "dot-provider-key.rkt"
          "call-result-key.rkt"
          "function-arity-key.rkt"
+         ;; see `gen-bounce`
          "index-result-key.rkt"
          "index-key.rkt"
          "append-indirect-key.rkt"
@@ -25,7 +26,7 @@
            syntax-local-method-result))
 
 (begin-for-syntax
-  (struct method-result (handler-expr predicate? static-infos arity))
+  (struct method-result (handler-expr predicate? annot-str static-infos arity))
   (define (method-result-ref v)
     (and (method-result? v) v))
 
@@ -34,7 +35,7 @@
         (raise-syntax-error #f "could not get method result information" id))))
 
 (define-syntax (define-method-result-syntax stx)
-  (define (parse check? result-handler result-static-infos predicate-handler?)
+  (define (parse check? result-handler result-annot-str result-static-infos predicate-handler?)
     (syntax-parse stx
       #:datum-literals (op)
       [(_ id _ (super-result-id ...) maybe-final-id convert-ok? kind arity
@@ -42,26 +43,35 @@
           maybe-ref-statinfo-id+id
           maybe-set-statinfo-id+id
           maybe-append-statinfo-id+id)
-       #:do [(define super-results (map syntax-local-method-result
-                                        (syntax->list #'(super-result-id ...))))]
-       #:with handler (for/fold ([handler (and check? result-handler)])
-                                ([r (in-list super-results)]
-                                 #:when (method-result-handler-expr r))
-                        (define super-pred (method-result-handler-expr r))
-                        (if handler
-                            (if predicate-handler?
-                                #`(let ([p #,handler]
-                                        [pp #,super-pred])
-                                    (lambda (v)
-                                      (and (p v) (pp v))))
-                                #`(let ([c #,handler]
-                                        [pp #,super-pred])
-                                    (lambda (v fail-k)
-                                      (let ([v (c v fail-k)])
-                                        (if (pp v)
-                                            v
-                                            (fail-k))))))
-                            super-pred))
+       #:do [(define super-results
+               (map syntax-local-method-result
+                    (syntax->list #'(super-result-id ...))))
+             (define-values (handler-stx annot-str)
+               (for/fold ([handler (and check? result-handler)]
+                          [annot-str (or result-annot-str annotation-any-string)])
+                         ([r (in-list super-results)]
+                          #:do [(define super-pred
+                                  (method-result-handler-expr r))]
+                          #:when super-pred
+                          #:do [(define super-annot-str
+                                  (method-result-annot-str r))])
+                 (if handler
+                     (values (if predicate-handler?
+                                 #`(let ([p #,handler]
+                                         [pp #,super-pred])
+                                     (lambda (v)
+                                       (and (p v) (pp v))))
+                                 #`(let ([c #,handler]
+                                         [pp #,super-pred])
+                                     (lambda (v fail-k)
+                                       (let ([v (c v fail-k)])
+                                         (if (pp v)
+                                             v
+                                             (fail-k))))))
+                             (annotation-string-and annot-str
+                                                    super-annot-str))
+                     (values super-pred super-annot-str))))]
+       #:with handler handler-stx
        #:with (static-info ...) result-static-infos
        #:with ((super-static-info ...) ...) (map method-result-static-infos super-results)
        #:with all-static-infos #'(static-info ... super-static-info ... ...)
@@ -81,6 +91,7 @@
                                                         #'(quote-syntax handler))
                                                     #'#f)
                                               #,predicate-handler?
+                                              '#,annot-str
                                               (quote-syntax all-static-infos)
                                               (quote arity)))))
        (cond
@@ -120,12 +131,14 @@
   (syntax-parse stx
     #:datum-literals ()
     [(_ _ () . _)
-     (parse #f #'#f #'() #t)]
+     (parse #f #'#f #f #'() #t)]
     [(_ _ (op::annotate-op ret ...) _ _ convert-ok? . _)
-     #:with c::annotation (respan #`(#,group-tag ret ...))
+     #:do [(define annot #`(#,group-tag ret ...))]
+     #:with c::annotation (respan annot)
+     #:do [(define annot-str (shrubbery-syntax->string annot))]
      (syntax-parse #'c.parsed
        [c-parsed::annotation-predicate-form
-        (parse (syntax-e #'op.check?) #'c-parsed.predicate #'c-parsed.static-infos #t)]
+        (parse (syntax-e #'op.check?) #'c-parsed.predicate annot-str #'c-parsed.static-infos #t)]
        [c-parsed::annotation-binding-form
         (unless (syntax-e #'convert-ok?)
           (raise-syntax-error #f
@@ -147,4 +160,4 @@
                                                        ...
                                                        c-parsed.body)
                                                      (fail-k))))
-          (parse (syntax-e #'op.check?) converter #'c-parsed.static-infos #f))])]))
+          (parse (syntax-e #'op.check?) converter annot-str #'c-parsed.static-infos #f))])]))

--- a/rhombus/private/class-method.rkt
+++ b/rhombus/private/class-method.rkt
@@ -1,12 +1,9 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
-                     racket/stxparam-exptime
                      enforest/syntax-local
-                     enforest/transformer
                      "class-parse.rkt"
                      "interface-parse.rkt"
-                     "tag.rkt"
                      "srcloc.rkt"
                      "statically-str.rkt"
                      (submod "entry-point-adjustment.rkt" for-struct))
@@ -17,7 +14,6 @@
          "entry-point.rkt"
          "class-this.rkt"
          "class-method-result.rkt"
-         "dot-provider-key.rkt"
          "function-indirect-key.rkt"
          "index-key.rkt"
          "append-indirect-key.rkt"
@@ -25,7 +21,6 @@
          (submod "dot.rkt" for-dot-provider)
          (submod "assign.rkt" for-assign)
          "parens.rkt"
-         "op-literal.rkt"
          (submod "function-parse.rkt" for-call)
          "is-static.rkt"
          "realm.rkt"
@@ -857,13 +852,17 @@
                                               (if (method-result-predicate? result-desc)
                                                   #`(let ([result #,body])
                                                       (unless (#,(method-result-handler-expr result-desc) result)
-                                                        (raise-result-failure 'method-name result))
+                                                        (raise-result-failure 'method-name
+                                                                              result
+                                                                              '#,(method-result-annot-str result-desc)))
                                                       result)
                                                   #`(let ([result #,body])
                                                       (#,(method-result-handler-expr result-desc)
                                                        result
                                                        (lambda ()
-                                                         (raise-result-failure 'method-name result)))))]
+                                                         (raise-result-failure 'method-name
+                                                                               result
+                                                                               '#,(method-result-annot-str result-desc))))))]
                                              [else body])))))
                                 #t)))
          #'e.parsed]))]))

--- a/rhombus/private/control.rkt
+++ b/rhombus/private/control.rkt
@@ -17,7 +17,7 @@
          (submod "function-parse.rkt" for-build)
          (submod "equal.rkt" for-parse)
          "if-blocked.rkt")
-         
+
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
                      Continuation)
@@ -195,7 +195,7 @@
                      (rhombus-body-at tag g ...))
                    (rhombus-expression (#,group-tag tag-expr ...)))
                 #'())]))))
-       
+
 (define-syntax prompt
   (expression-transformer
    (lambda (stx)
@@ -222,18 +222,20 @@
                          (define argss (reverse rev-argss))
                          (define arg-parsedss (reverse rev-arg-parsedss))
                          (define rhss (reverse rev-rhss))
-                         (define falses (datum->syntax #f (map (lambda (f) #f) argss)))
+                         (define falses (map (lambda (f) #f) argss))
+                         (define falses-stx (datum->syntax #f (map (lambda (f) #'#f) argss)))
                          (define-values (proc arity)
                            (build-case-function no-adjustments
-                                                #'prompt_handler #'#f
+                                                #'prompt_handler
+                                                #f #f
                                                 (datum->syntax #f
                                                                (for/list ([args (in-list argss)])
                                                                  (for/list ([arg (in-list (syntax->list args))])
-                                                                   #f)))
+                                                                   #'#f)))
                                                 (datum->syntax #f argss) (datum->syntax #f arg-parsedss)
+                                                falses-stx falses-stx
+                                                falses-stx falses-stx
                                                 falses falses
-                                                falses falses
-                                                falses
                                                 (datum->syntax #f rhss)
                                                 (car gs)))
                          proc]
@@ -259,14 +261,14 @@
                   (define handler
                     (syntax-parse #`(#,group-tag bind ...)
                       [(parens-tag::parens arg::binding ...)
-                       (define falses (datum->syntax #f (map (lambda (a) #f) (syntax->list #'(arg ...)))))
+                       (define falses (datum->syntax #f (map (lambda (a) #'#f) (syntax->list #'(arg ...)))))
                        (define-values (proc arity)
                          (build-function no-adjustments
                                          #'prompt_handler
                                          falses #'(arg ...) #'(arg.parsed ...) falses
                                          #'#f #'#f
                                          #'#f #'#f
-                                         #'#f
+                                         #f #f
                                          #'rhs
                                          (car gs)))
                        proc]
@@ -277,7 +279,7 @@
                                          #'(#f) #'(arg) #'(arg.parsed) #'(#f)
                                          #'#f #'#f
                                          #'#f #'#f
-                                         #'#f
+                                         #f #f
                                          #'rhs
                                          (car gs)))
                        proc]))

--- a/rhombus/private/function.rkt
+++ b/rhombus/private/function.rkt
@@ -180,12 +180,13 @@
          (check-consistent stx names "name")
          (define-values (proc arity)
            (build-case-function no-adjustments
-                                the-name #'#f
+                                the-name
+                                #f #f
                                 #'((arg.kw ...) ...)
                                 #'((arg ...) ...) #'((arg.parsed ...) ...)
                                 #'(rest.arg ...) #'(rest.parsed ...)
                                 #'(rest.kwarg ...) #'(rest.kwparsed ...)
-                                #'(ret.converter ...)
+                                (attribute ret.converter) (attribute ret.annot-str)
                                 #'(rhs ...)
                                 stx))
          (maybe-add-function-result-definition
@@ -206,12 +207,13 @@
          (check-consistent stx (cons the-name names) "name" #:has-main? #t)
          (define-values (proc arity)
            (build-case-function no-adjustments
-                                the-name #'main-ret.converter
+                                the-name
+                                (attribute main-ret.converter) (attribute main-ret.annot-str)
                                 #'((arg.kw ...) ...)
                                 #'((arg ...) ...) #'((arg.parsed ...) ...)
                                 #'(rest.arg ...) #'(rest.parsed ...)
                                 #'(rest.kwarg ...) #'(rest.kwparsed ...)
-                                #'(ret.converter ...)
+                                (attribute ret.converter) (attribute ret.annot-str)
                                 #'(rhs ...)
                                 stx))
          (maybe-add-function-result-definition
@@ -229,7 +231,7 @@
                            #'(arg.kw ...) #'(arg ...) #'(arg.parsed ...) #'(arg.default ...)
                            #'rest.arg #'rest.parsed
                            #'rest.kwarg #'rest.kwparsed
-                           #'ret.converter
+                           (attribute ret.converter) (attribute ret.annot-str)
                            #'rhs
                            stx))
          (maybe-add-function-result-definition
@@ -279,12 +281,13 @@
                ...+))
      (define-values (proc arity)
        (build-case-function adjustments
-                            (get-local-name #'form-id) #'main-ret.converter
+                            (get-local-name #'form-id)
+                            (attribute main-ret.converter) (attribute main-ret.annot-str)
                             #'((arg.kw ...) ...)
                             #'((arg ...) ...) #'((arg.parsed ...) ...)
                             #'(rest.arg ...) #'(rest.parsed ...)
                             #'(rest.kwarg ...) #'(rest.kwparsed ...)
-                            #'(ret.converter ...)
+                            (attribute ret.converter) (attribute ret.annot-str)
                             #'(rhs ...)
                             stx))
      (values (wrap-function-static-info
@@ -301,7 +304,7 @@
                        #'(arg.kw ...) #'(arg ...) #'(arg.parsed ...) #'(arg.default ...)
                        #'rest.arg #'rest.parsed
                        #'rest.kwarg #'rest.kwparsed
-                       #'ret.converter
+                       (attribute ret.converter) (attribute ret.annot-str)
                        #'rhs
                        stx))
      (values (let* ([fun (if (pair? (syntax-e #'ret.static-infos))

--- a/rhombus/private/indexable.rkt
+++ b/rhombus/private/indexable.rkt
@@ -1,27 +1,20 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
-                     enforest/syntax-local
                      "srcloc.rkt"
                      "statically-str.rkt"
                      "interface-parse.rkt")
          "provide.rkt"
-         "expression.rkt"
          "repetition.rkt"
          (submod "annotation.rkt" for-class)
          "parse.rkt"
-         (submod "map.rkt" for-build)
          "index-key.rkt"
          "index-result-key.rkt"
          "index-indirect-key.rkt"
          "call-result-key.rkt"
          "static-info.rkt"
          (submod "assign.rkt" for-assign)
-         "op-literal.rkt"
-         (only-in "string.rkt"
-                  +&)
          (submod "set.rkt" for-ref)
-         (submod "set.rkt" for-build)
          "repetition.rkt"
          "compound-repetition.rkt"
          "realm.rkt"
@@ -112,8 +105,7 @@
                   '(get set)))
 
 (define-syntax void-result
-  (method-result #'void? #t #'() 0))
-
+  (method-result #'void? #t "Void" #'() 0))
 
 (define-for-syntax (parse-indexable-ref-or-set indexable-in stxes more-static?
                                                #:repetition? [repetition? #f])

--- a/rhombus/private/match.rkt
+++ b/rhombus/private/match.rkt
@@ -2,7 +2,6 @@
 (require (for-syntax racket/base
                      racket/list
                      syntax/parse/pre
-                     enforest/name-parse
                      "srcloc.rkt"
                      "annotation-string.rkt"
                      "tag.rkt"
@@ -30,18 +29,22 @@
   (expression-transformer
    (lambda (stx)
      (define ((make-fallback-k else else-parsed else-rhs) val bs b-parseds rhss)
+       (define (make-consts const)
+         (cons const (map (lambda (x) const) bs)))
        (define (make-consts-stx const)
-         (datum->syntax #f (cons const (map (lambda (x) const) bs))))
-       (define falses-stx (make-consts-stx #f))
+         (datum->syntax #f (make-consts const)))
+       (define falses (make-consts #f))
+       (define falses-stx (make-consts-stx #'#f))
        (define-values (proc arity)
          (build-case-function no-adjustments
-                              #'match #'#f
-                              (make-consts-stx '(#f))
+                              #'match
+                              #f #f
+                              (make-consts-stx #'(#f))
                               #`(#,@(map list bs) (#,else))
                               #`(#,@(map list b-parseds) (#,else-parsed))
                               falses-stx falses-stx
                               falses-stx falses-stx
-                              falses-stx
+                              falses falses
                               #`(#,@rhss #,else-rhs)
                               stx))
        #`(#,proc #,val))

--- a/rhombus/private/sequenceable.rkt
+++ b/rhombus/private/sequenceable.rkt
@@ -17,7 +17,7 @@
                                (lambda (self)
                                  (define s ((vector-ref (Sequenceable-ref self) 0) self))
                                  (unless (sequence? s)
-                                   (raise-result-failure 'to_sequence s))
+                                   (raise-result-failure 'to_sequence s "Sequence"))
                                  s))))))
 
 (define-class-desc-syntax Sequenceable

--- a/rhombus/tests/annot-convert.rhm
+++ b/rhombus/tests/annot-convert.rhm
@@ -96,10 +96,13 @@ check:
     method m() :: String
   class Hello():
     implements Greeter
-    override method m() :: converting(fun (_::String): 0):
+    override method m() :: converting(fun (_ :: String): 0):
       "100"
   Hello().m()
-  ~raises "result does not satisfy annotation"
+  ~raises values(
+    "result does not satisfy annotation",
+    "converting(fun (_ :: String): 0)",
+  )
 
 check:
   ~eval

--- a/rhombus/tests/class-method-result.rhm
+++ b/rhombus/tests/class-method-result.rhm
@@ -20,10 +20,16 @@ block:
     ~is 3
   check:
     Posn(1, 2).n()
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "String",
+    )
   check:
     Posn(1, 2).n_f()
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "String",
+    )
   check:
     Posn(1, 2).p()
     ~is 3
@@ -32,14 +38,17 @@ block:
     class Posn3D(z):
       extends Posn
       override m():
-        "oops"   
+        "oops"
       override n():
         "ok"
       override p():
-        0 
+        0
     check:
       Posn3D(1, 2, 3).m()
-      ~raises "result does not satisfy annotation"
+      ~raises values(
+        "result does not satisfy annotation",
+        "Int",
+      )
     check:
       Posn3D(1, 2, 3).p()
       ~is 0
@@ -89,17 +98,29 @@ block:
     ~is Magenta()
   check:
     Bottom().m(Magenta())
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Green",
+    )
 
   check:
     Top().m(Cyan())
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Red",
+    )
   check:
     Middle().m(Cyan())
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Blue",
+    )
   check:
     Bottom().m(Cyan())
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Green",
+    )
 
 // class self-reference
 block:
@@ -153,10 +174,16 @@ block:
     ~is #true
   check:
     Point(1, 2).visible()
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Boolean",
+    )
   check:
     Point(1, 2).invisible()
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Boolean",
+    )
   check:
     Point(1, 2).really_invisible()
     ~is #false
@@ -181,16 +208,19 @@ block:
 
   check:
     Apple().example(#false)
-    ~is Apple()    
+    ~is Apple()
   check:
     Sky().example(#false)
-    ~is Sky()    
+    ~is Sky()
   check:
     RacketLogo().example()
-    ~is RacketLogo()    
+    ~is RacketLogo()
   check:
     RacketLogo().example(#false)
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Red", "Blue",
+    )
 
 // alternate method forms, internal versus external annotations
 block:
@@ -204,29 +234,35 @@ block:
         x
   class Bottom():
     extends Top
-    override m (x):
+    override m(x):
       x
-    override m2 (x):
+    override m2(x):
       x
   check:
     [Top().m(1), Top().m2(2)]
     ~is [1, 2]
   check:
     Top().m("apple")
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Int",
+    )
   check:
     Bottom().m("apple")
     ~is "apple"
   check:
     Bottom().m2("apple")
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Int",
+    )
 
 // abstract override
 block:
   interface Left
   interface Right
   class Both():
-    implements: Left Right    
+    implements: Left Right
   class LeftC():
     implements: Left
   class RightC():
@@ -251,10 +287,19 @@ block:
     ~is Both()
   check:
     C(#false).m()
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Right",
+    )
   check:
     C(LeftC()).m()
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Right",
+    )
   check:
     C(RightC()).m()
-    ~raises "result does not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "Right",
+    )

--- a/rhombus/tests/fun.rhm
+++ b/rhombus/tests/fun.rhm
@@ -34,18 +34,20 @@ check:
 
 // function result contracts
 
-fun add1(x) :: Int:
-  match x
-  | n :: Int : x + 1
-  | ~else: x
-
-check:
-  add1(100)
-  ~is 101
-
-check:
-  add1("oops")
-  ~raises "result does not satisfy annotation"
+block:
+  fun add1(x) :: Int:
+    match x
+    | n :: Int : x + 1
+    | ~else: x
+  check:
+    add1(100)
+    ~is 101
+  check:
+    add1("oops")
+    ~raises values(
+      "result does not satisfy annotation",
+      "Int",
+    )
 
 fun
 | add_two(x) :: Number:
@@ -152,12 +154,26 @@ block:
       values(0, "oops")
     def (x, y) = f()
     10
-    ~raises "results do not satisfy annotation"
+    ~raises values(
+      "results do not satisfy annotation",
+      "(Int, Int)"
+    )
   check:
     fun f() :: (Int, Int):
       0
     f()
-    ~raises "results do not satisfy annotation"
+    ~raises values(
+      "result does not satisfy annotation",
+      "(Int, Int)"
+    )
+  check:
+    fun f() :: Int:
+      values(0, "oops")
+    f()
+    ~raises values(
+      "results do not satisfy annotation",
+      "Int"
+    )
   check:
     ~eval
     fun oops():

--- a/rhombus/tests/indexable.rhm
+++ b/rhombus/tests/indexable.rhm
@@ -38,7 +38,7 @@ class A2():
 
 interface I3:
   extends MutableIndexable
-  
+
 class A3():
   implements I3
   field saved = #false
@@ -48,7 +48,7 @@ class A3():
     saved := [index, val]
     if index == "bad"
     | "bad"
-    | #void  
+    | #void
 
 class A4():
   private implements Indexable
@@ -62,19 +62,22 @@ check:
   C()[4].v ~is 4
   A2()[3].v ~is 3
   A2()["good"] := #'ok ~is #void
-  A2()["bad"] := #'no ~raises "result does not satisfy annotation"
+  A2()["bad"] := #'no ~raises values(
+    "result does not satisfy annotation",
+    "Void",
+  )
   A3()[0].v ~is 0
   (A3() :: I3)[0] ~is O(0)
   A4()[10].v ~is 10
 
 block:
-  def b = B()  
+  def b = B()
   check:
     b[0] := 1 ~is #void
     b.saved ~is [0, 1]
 
 block:
-  def c = C()  
+  def c = C()
   check:
     c[0] := 1 ~is #void
     c.saved ~is [0, 1]
@@ -108,4 +111,3 @@ check:
   { 1: 2 }.copy() is_a MutableIndexable ~is #true
   { 1, 2 }.copy() is_a MutableIndexable ~is #true
   #"apple".copy() is_a MutableIndexable ~is #true
-  


### PR DESCRIPTION
This commit improves result failure message by including (the raw text of) annotation.  This covers result annotations in functions and methods.