### PR TITLE
fix `case` expansion when all patterns are literal

### DIFF
--- a/rhombus/private/match.rkt
+++ b/rhombus/private/match.rkt
@@ -2,7 +2,6 @@
 (require (for-syntax racket/base
                      racket/list
                      syntax/parse/pre
-                     enforest/name-parse
                      "srcloc.rkt"
                      "annotation-string.rkt"
                      "tag.rkt"
@@ -108,11 +107,12 @@
   (define b-parseds (syntax->list b-parseds-stx))
   (define rhss (syntax->list rhss-stx))
   (define maybe-idx
-    (for/first ([parsed (in-list b-parseds)]
-                [idx (in-naturals 0)]
-                #:unless (syntax-parse parsed
-                           [b::binding-form
-                            (free-identifier=? #'b.infoer-id #'literal-infoer)]))
+    (for/fold ([maybe-idx #f])
+              ([parsed (in-list b-parseds)]
+               [idx (in-naturals 0)])
+      #:break (syntax-parse parsed
+                [b::binding-form
+                 (not (free-identifier=? #'b.infoer-id #'literal-infoer))])
       idx))
   (cond
     [maybe-idx


### PR DESCRIPTION
I don’t know why I have missed this for so long, but here is a fix.

See #417.