### PR TITLE
support multiple-result annotations in methods

### DIFF
--- a/rhombus/private/class-method-result.rkt
+++ b/rhombus/private/class-method-result.rkt
@@ -2,23 +2,17 @@
 (require (for-syntax racket/base
                      syntax/parse/pre
                      enforest/syntax-local
-                     shrubbery/print
-                     "srcloc.rkt"
-                     "tag.rkt"
-                     "with-syntax.rkt"
                      "annotation-string.rkt")
-         (submod "annotation.rkt" for-class)
-         "binding.rkt"
          "static-info.rkt"
          (submod "define-arity.rkt" for-info)
          "indirect-static-info-key.rkt"
          "call-result-key.rkt"
          "function-arity-key.rkt"
-         ;; see `gen-bounce`
          "index-result-key.rkt"
          "index-key.rkt"
          "append-indirect-key.rkt"
-         "if-blocked.rkt")
+         "values-key.rkt"
+         (submod "function-parse.rkt" for-build))
 
 (provide define-method-result-syntax)
 
@@ -28,7 +22,7 @@
            syntax-local-method-result))
 
 (begin-for-syntax
-  (struct method-result (handler-expr predicate? annot-str static-infos arity))
+  (struct method-result (handler-expr predicate? count annot-str static-infos arity))
   (define (method-result-ref v)
     (and (method-result? v) v))
 
@@ -37,130 +31,151 @@
         (raise-syntax-error #f "could not get method result information" id))))
 
 (define-syntax (define-method-result-syntax stx)
-  (define (parse check? result-handler result-annot-str result-static-infos predicate-handler?)
-    (syntax-parse stx
-      #:datum-literals (op)
-      [(_ id _ (super-result-id ...) maybe-final-id convert-ok? kind arity
-          maybe-call-statinfo-id
-          maybe-ref-statinfo-id+id
-          maybe-set-statinfo-id+id
-          maybe-append-statinfo-id+id)
-       #:do [(define super-results
-               (map syntax-local-method-result
-                    (syntax->list #'(super-result-id ...))))
-             (define-values (handler-stx annot-str)
-               (for/fold ([handler (and check? result-handler)]
-                          [annot-str (or result-annot-str annotation-any-string)])
-                         ([r (in-list super-results)]
-                          #:do [(define super-pred
-                                  (method-result-handler-expr r))]
-                          #:when super-pred
-                          #:do [(define super-annot-str
-                                  (method-result-annot-str r))])
-                 (if handler
-                     (values (if predicate-handler?
-                                 #`(let ([p #,handler]
-                                         [pp #,super-pred])
-                                     (lambda (v)
-                                       (and (p v) (pp v))))
-                                 #`(let ([c #,handler]
-                                         [pp #,super-pred])
-                                     (lambda (v fail-k)
-                                       (let ([v (c v fail-k)])
-                                         (if (pp v)
-                                             v
-                                             (fail-k))))))
-                             (annotation-string-and annot-str
-                                                    super-annot-str))
-                     (values super-pred super-annot-str))))]
-       #:with handler handler-stx
-       #:with (static-info ...) result-static-infos
-       #:with ((super-static-info ...) ...) (map method-result-static-infos super-results)
-       #:with all-static-infos #'(static-info ... super-static-info ... ...)
-       #:with handler-id (and (syntax-e #'handler)
-                              (not (identifier? #'handler))
-                              ((make-syntax-introducer)
-                               (datum->syntax #f (string->symbol
-                                                  (format "~a-result-handler" (syntax-e #'id))))))
-       (define def
-         #`(begin
-             #,@(if (syntax-e #'handler-id)
-                    (list #'(define handler-id handler))
-                    null)
-             (define-syntax id (method-result #,(if (syntax-e #'handler)
-                                                    (if (syntax-e #'handler-id)
-                                                        #'(quote-syntax handler-id)
-                                                        #'(quote-syntax handler))
-                                                    #'#f)
-                                              #,predicate-handler?
-                                              '#,annot-str
-                                              (quote-syntax all-static-infos)
-                                              (quote arity)))))
-       (cond
-         [(or (syntax-e #'maybe-final-id)
-              (syntax-e #'maybe-call-statinfo-id)
-              (syntax-e #'maybe-ref-statinfo-id+id)
-              (syntax-e #'maybe-set-statinfo-id+id)
-              (syntax-e #'maybe-append-statinfo-id+id))
-          (define (gen id)
-            (if (syntax-e id)
-                #`((define-static-info-syntax #,id
+  (syntax-parse stx
+    [(_ id (ret::ret-annotation) (super-result-id ...)
+        maybe-final-id convert-ok? kind arity
+        maybe-call-statinfo-id
+        maybe-ref-statinfo-id+id
+        maybe-set-statinfo-id+id
+        maybe-append-statinfo-id+id)
+     #:do [(define-values (proc predicate? count annot-str static-infos)
+             (cond
+               [(attribute ret.converter)
+                => (lambda (cvtr)
+                     (define predicate? (converter-predicate? cvtr))
+                     (unless (or predicate?
+                                 (syntax-e #'convert-ok?))
+                       (raise-syntax-error
+                        #f
+                        (string-append
+                         "declared result annotation must be a predicate annotation;"
+                         "\n non-final method cannot have a converter annotation")
+                        #'id
+                        #'ret))
+                     (values (converter-proc cvtr)
+                             predicate?
+                             (converter-count cvtr)
+                             (attribute ret.annot-str)
+                             #'ret.static-infos))]
+               [else (values #f #t #f #f #'())]))
+           (define super-results
+             (map syntax-local-method-result
+                  (syntax->list #'(super-result-id ...))))
+           (define all-count
+             (for/foldr ([all-count count])
+                        ([r (in-list super-results)]
+                         #:do [(define count (method-result-count r))]
+                         #:when count)
+               ;; TODO improve this error message
+               (when (and all-count (not (eqv? count all-count)))
+                 (raise-syntax-error
+                  #f
+                  "incompatible result arities found in the inheritance chain"
+                  #'id))
+               count))
+           (define-values (handler-stx all-annot-str)
+             (cond
+               [all-count
+                (with-syntax ([(val ...) (generate-temporaries
+                                          (for/list ([_ (in-range all-count)])
+                                            'val))]
+                              [(pred ...) (for/list ([r (in-list super-results)]
+                                                     #:do [(define pred (method-result-handler-expr r))]
+                                                     #:when pred)
+                                            pred)])
+                  (values (cond
+                            [predicate?
+                             (define all-pred
+                               (syntax-parse #'(pred ...)
+                                 [(only-pred) #'only-pred]
+                                 [_ #'(lambda (val ...)
+                                        (and (pred val ...) ...))]))
+                             (if proc
+                                 #`(lambda (val ...)
+                                     (#,proc val ... #,all-pred (lambda () #f)))
+                                 all-pred)]
+                            ;; converter case: `proc` must be non-`#f`
+                            [else
+                             (if (null? (syntax-e #'(pred ...)))
+                                 proc
+                                 #`(lambda (val ... success-k fail-k)
+                                     (#,proc
+                                      val ...
+                                      (lambda (val ...)
+                                        (if (and (pred val ...) ...)
+                                            (success-k val ...)
+                                            (fail-k)))
+                                      fail-k)))])
+                          (for/foldr ([all-annot-str annotation-any-string])
+                                     ([annot-str (in-list (cons annot-str
+                                                                (map method-result-annot-str super-results)))]
+                                      #:when annot-str)
+                            (annotation-string-and annot-str all-annot-str))))]
+               ;; no annotation in the inheritance chain
+               [else (values #f #f)]))
+           (define (extract-static-infoss infos)
+             (syntax-parse infos
+               #:literals (#%values)
+               [((#%values (si ...))) (syntax->list #'(si ...))]
+               [_ (list infos)]))
+           (define static-infoss (extract-static-infoss static-infos))
+           (define static-infoss-count (length static-infoss))
+           ;; Like `Super_1 && ... && Super_n && This`, in reverse of
+           ;; the actual checks (checks happen "bottom-up"); or in
+           ;; other words, a variant of `&&` that prioritizes the
+           ;; left-hand side static infos.
+           (define all-static-infos
+             (for/foldr ([all-static-infoss (for/list ([_ (in-range static-infoss-count)])
+                                              '())]
+                         #:result (if (eqv? static-infoss-count 1)
+                                      (car all-static-infoss)
+                                      #`((#%values #,all-static-infoss))))
+                        ([infos (in-list (cons static-infos
+                                               (map method-result-static-infos super-results)))]
+                         #:do [(define infoss (extract-static-infoss infos))]
+                         #:when (eqv? (length infoss) static-infoss-count))
+               (for/list ([infos (in-list infoss)]
+                          [all-static-infos (in-list all-static-infoss)])
+                 (static-infos-union infos all-static-infos))))]
+     #:attr handler handler-stx
+     #:attr handler-id (and handler-stx
+                            (not (identifier? handler-stx))
+                            ((make-syntax-introducer)
+                             (datum->syntax #f
+                                            (string->symbol
+                                             (format "~a-result-handler" (syntax-e #'id))))))
+     (define (gen id)
+       (if (syntax-e id)
+           (list #`(define-static-info-syntax #,id
                      #,(if (eq? (syntax-e #'kind) 'property)
-                           #`(#%call-results-at-arities ((1 all-static-infos)))
-                           #`(#%call-result all-static-infos))
+                           #`(#%call-results-at-arities ((1 #,all-static-infos)))
+                           #`(#%call-result #,all-static-infos))
                      #,@(if (syntax-e #'arity)
-                            #`((#%function-arity arity))
-                            #'())
+                            (list #'(#%function-arity arity))
+                            '())
                      (#%indirect-static-info indirect-function-static-info)))
-                #'()))
-          (define (gen-bounce ind-id+id key result-key)
-            (if (syntax-e ind-id+id)
-                (syntax-parse ind-id+id
-                  [(ind-id id)
-                   #`((define-static-info-syntax ind-id
+           '()))
+     (define (gen-bounce ind-id+id key result-key)
+       (if (syntax-e ind-id+id)
+           (syntax-parse ind-id+id
+             [(ind-id id)
+              (list #`(define-static-info-syntax ind-id
                         (#,key id)
                         #,@(if result-key
-                               #`((#,result-key all-static-infos))
-                               null)))])
-                #'()))
-          #`(begin
-              #,def
-              #,@(gen #'maybe-final-id)
-              #,@(gen #'maybe-call-statinfo-id)
-              #,@(gen-bounce #'maybe-ref-statinfo-id+id '#%index-get '#%index-result)
-              #,@(gen-bounce #'maybe-set-statinfo-id+id '#%index-set #f)
-              #,@(gen-bounce #'maybe-append-statinfo-id+id '#%append/checked #f))]
-         [else def])]))
-  (syntax-parse stx
-    #:datum-literals ()
-    [(_ _ () . _)
-     (parse #f #'#f #f #'() #t)]
-    [(_ _ (op::annotate-op ret ...) _ _ convert-ok? . _)
-     #:do [(define annot #`(#,group-tag ret ...))]
-     #:with c::annotation (respan annot)
-     #:do [(define annot-str (shrubbery-syntax->string annot))]
-     (syntax-parse #'c.parsed
-       [c-parsed::annotation-predicate-form
-        (parse (syntax-e #'op.check?) #'c-parsed.predicate annot-str #'c-parsed.static-infos #t)]
-       [c-parsed::annotation-binding-form
-        (unless (syntax-e #'convert-ok?)
-          (raise-syntax-error #f
-                              "declared result annotation must be a predicate annotation"
-                              #'id
-                              #'c))
-        (with-syntax-parse ([arg-parsed::binding-form #'c-parsed.binding]
-                            [arg-impl::binding-impl #'(arg-parsed.infoer-id () arg-parsed.data)]
-                            [arg-info::binding-info #'arg-impl.info]
-                            [((bind-id bind-use . bind-static-infos) ...) #'arg-info.bind-infos])
-          (define converter #`(lambda (tmp-id fail-k)
-                                (arg-info.matcher-id tmp-id
-                                                     arg-info.data
-                                                     if/blocked
-                                                     (begin
-                                                       (arg-info.committer-id tmp-id arg-info.data)
-                                                       (arg-info.binder-id tmp-id arg-info.data)
-                                                       (define-static-info-syntax/maybe bind-id . bind-static-infos)
-                                                       ...
-                                                       c-parsed.body)
-                                                     (fail-k))))
-          (parse (syntax-e #'op.check?) converter annot-str #'c-parsed.static-infos #f))])]))
+                               (list #`(#,result-key #,all-static-infos))
+                               '())))])
+           '()))
+     #`(begin
+         (~? (define handler-id handler))
+         (define-syntax id
+           (method-result (~? (quote-syntax handler-id) (~? (quote-syntax handler) #f))
+                          (quote #,predicate?)
+                          (quote #,all-count)
+                          (quote #,all-annot-str)
+                          (quote-syntax #,all-static-infos)
+                          (quote arity)))
+         #,@(gen #'maybe-final-id)
+         #,@(gen #'maybe-call-statinfo-id)
+         #,@(gen-bounce #'maybe-ref-statinfo-id+id #'#%index-get #'#%index-result)
+         #,@(gen-bounce #'maybe-set-statinfo-id+id #'#%index-set #f)
+         #,@(gen-bounce #'maybe-append-statinfo-id+id #'#%append/checked #f))]))

--- a/rhombus/private/class-method.rkt
+++ b/rhombus/private/class-method.rkt
@@ -851,20 +851,20 @@
                                               #`(begin #,body (void))]
                                              [(and result-desc
                                                    (method-result-handler-expr result-desc))
-                                              (if (method-result-predicate? result-desc)
-                                                  #`(let ([result #,body])
-                                                      (unless (#,(method-result-handler-expr result-desc) result)
-                                                        (raise-result-failure 'method-name
-                                                                              result
-                                                                              '#,(method-result-annot-str result-desc)))
-                                                      result)
-                                                  #`(let ([result #,body])
-                                                      (#,(method-result-handler-expr result-desc)
-                                                       result
-                                                       (lambda ()
-                                                         (raise-result-failure 'method-name
-                                                                               result
-                                                                               '#,(method-result-annot-str result-desc))))))]
+                                              => (lambda (proc)
+                                                   (wrap-annotation-check
+                                                    #'method-name body
+                                                    (method-result-count result-desc)
+                                                    (method-result-annot-str result-desc)
+                                                    (lambda (vs raise)
+                                                      (if (method-result-predicate? result-desc)
+                                                          #`(begin
+                                                              (unless (#,proc #,@vs) #,raise)
+                                                              (values #,@vs))
+                                                          #`(#,proc
+                                                             #,@vs
+                                                             (lambda (#,@vs) (values #,@vs))
+                                                             (lambda () #,raise))))))]
                                              [else body])))))
                                 #t)))
          #'e.parsed]))]))

--- a/rhombus/private/indexable.rkt
+++ b/rhombus/private/indexable.rkt
@@ -105,7 +105,7 @@
                   '(get set)))
 
 (define-syntax void-result
-  (method-result #'void? #t "Void" #'() 0))
+  (method-result #'void? #t 1 "Void" #'() 8))
 
 (define-for-syntax (parse-indexable-ref-or-set indexable-in stxes more-static?
                                                #:repetition? [repetition? #f])

--- a/rhombus/scribblings/ref-bind-macro.scrbl
+++ b/rhombus/scribblings/ref-bind-macro.scrbl
@@ -396,6 +396,7 @@
     kind: ~sequence
     fields:
       count
+      is_predicate
       maybe_converter
       static_info
       annotation_string
@@ -409,7 +410,12 @@
  @itemlist(
 
   @item{The @rhombus(count) field holds an integer for the number of
-  expected results.}
+  expected results, or @rhombus(#false) if no annotation is declared
+  (i.e., any number of results is expected).}
+
+  @item{The @rhombus(is_predicate) field is @rhombus(#true) if all
+  annotations are @tech{predicate annotations}, or @rhombus(#false)
+  if at least one of them is a @tech{converter annotation}.}
 
   @item{The @rhombus(maybe_converter) field is @rhombus(#false) if no
   annotation is declared or if it is unchecked, otherwise it is a syntax

--- a/rhombus/tests/class-method-result.rhm
+++ b/rhombus/tests/class-method-result.rhm
@@ -303,3 +303,92 @@ block:
       "result does not satisfy annotation",
       "Right",
     )
+
+// converter annotations
+block:
+  check:
+    ~eval
+    class A():
+      nonfinal
+      method m() :: converting(fun (_): #false):
+        #false
+    ~raises values(
+      "must be a predicate annotation",
+      "non-final",
+    )
+  check:
+    ~eval
+    interface A:
+      method m() :: converting(fun (_): #false)
+    ~raises values(
+      "must be a predicate annotation",
+      "non-final",
+    )
+  check:
+    class A():
+      method m() :: converting(fun (_): #true):
+        #false
+    A().m()
+    ~is #true
+
+// multiple-result annotations
+block:
+  check:
+    ~eval
+    class A():
+      nonfinal
+      method m() :: Any:
+        #false
+    class B():
+      extends A
+      override m() :: values(Any, Any):
+        values(#false, #false)
+    ~raises "incompatible result arities"
+  check:
+    ~eval
+    class A():
+      nonfinal
+      method m() :~ Any:
+        #false
+    class B():
+      extends A
+      override m() :~ values(Any, Any):
+        values(#false, #false)
+    ~raises "incompatible result arities"
+  check:
+    class A():
+      nonfinal
+      method m() :: (Real, Real):
+        values(1.0, 2.0)
+    class B():
+      extends A
+      override m() :: (Int, Int):
+        values(1, 2)
+    B().m()
+    ~is values(1, 2)
+  check:
+    class A():
+      nonfinal
+      method m() :: (Real, Int):
+        values(1.0, 2)
+    class B():
+      extends A
+      override m() :: (Int, Real):
+        values(1, 2.0)
+    B().m()
+    ~raises values(
+      "results do not satisfy annotation",
+      "(Int, Real)", "(Real, Int)",
+    )
+  check:
+    class A():
+      nonfinal
+      method m() :: (Any, String):
+        values(#false, "something")
+    class B():
+      extends A
+      override m() :: (String, String):
+        values("more", "really")
+    def (str1, str2) = B().m()
+    values(str1.length(), str2.length())
+    ~is values(4, 6)


### PR DESCRIPTION
This aligns the behavior with the documented grammar, which specifies that multiple-result annotations are allowed.