### PR TITLE
rhombus/draw: fix `Printable` instance of `Color`

### DIFF
--- a/rhombus/draw/private/color.rhm
+++ b/rhombus/draw/private/color.rhm
@@ -38,13 +38,14 @@ class Color(handle):
   reconstructor(red, green, blue, alpha):
     Color(red, green, blue, alpha)
 
-  implements Printable
-  override describe(mode, recur):
-    "Color("
-      +& red +& ", "
-      +& green +& ", "
-      +& blue +& ", "
-      +& alpha +& ")"
+  private implements Printable
+  private override describe(mode, recur):
+    PrintDesc.list("Color(",
+                   [recur(red),
+                    recur(green),
+                    recur(blue),
+                    recur(alpha)],
+                   ")")
 
 fun
 | unwrap_color(c :: Color): c.handle

--- a/rhombus/private/print.rkt
+++ b/rhombus/private/print.rkt
@@ -188,7 +188,7 @@
           (fresh-ref
            v
            (lambda ()
-             (printer v mode (lambda (v [mode 'expr])
+             (printer v mode (lambda (v #:mode [mode 'expr])
                                (check-mode 'describe_recur mode)
                                (PrintDesc (pretty v mode ht)))))))]
     [(struct? v)

--- a/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/scribblings/ref-io.scrbl
@@ -111,9 +111,11 @@
   --- returns a @rhombus(PrintDesc, ~annot) given a
   @rhombus(mode, ~var), which is either @rhombus(#'text) or
   @rhombus(#'expr), and a @rhombus(recur, ~var) function, which accepts a
-  value and an optional @rhombus(~mode) like @rhombus(Printable.describe);
-  the @rhombus(recur) function is specific to a particular overall print
-  action so that it can handle cycles and graph references}
+  value and an optional @rhombus(~mode) like @rhombus(Printable.describe)
+  (unlike @rhombus(Printable.describe), the @rhombus(~mode) defaults to
+  @rhombus(#'expr), which is generally desirable when printing subcomponents);
+  the @rhombus(recur, ~var) function is specific to a particular overall print
+  action so that it can handle cycles and graph references.}
 
 )
 

--- a/rhombus/tests/printable.rhm
+++ b/rhombus/tests/printable.rhm
@@ -20,7 +20,7 @@ block:
     implements Printable
     override describe(mode, recur):
       import: .PrintDesc open
-      concat("(", align(concat(recur(x, mode), ",", newline(),
+      concat("(", align(concat(recur(x, ~mode: mode), ",", newline(),
                                recur(y), ")")))
   check "" +& Posn(1, 2) ~is "(1,\n 2)"
   check "" +& Posn("a", "b") ~is "(a,\n \"b\")"
@@ -31,7 +31,7 @@ block:
   class Posn(x, y):
     implements Printable
     override describe(mode, recur):
-      PrintDesc.list("(", [recur(x, mode), recur(y)], ")")
+      PrintDesc.list("(", [recur(x, ~mode: mode), recur(y)], ")")
   check "" +& Posn(1, 2) ~is "(1, 2)"
 
 block:
@@ -40,7 +40,7 @@ block:
     override describe(mode, recur):
       import .PrintDesc open
       // using newline() forces multi-line rendering of `Posn`
-      list("(", [concat(recur(x, mode), newline(), "!"), recur(y)], ")")
+      list("(", [concat(recur(x, ~mode: mode), newline(), "!"), recur(y)], ")")
   parameterize { Printable.current_pretty: #true }:
     check "" +& Posn(1, 2) ~is "(\n  1\n  !,\n  2\n)"
 


### PR DESCRIPTION
Also fix `recur` argument of the `describe` method, which should expect a keyword `~mode` argument defaulting to `#'expr`; clarify the intention in the documentation.