### PR TITLE
fix an innocent mistake in dot dispatch

### DIFF
--- a/rhombus/private/dot-parse.rkt
+++ b/rhombus/private/dot-parse.rkt
@@ -82,21 +82,20 @@
           [(mk mk-set)
            (syntax-parse tail
              [assign::assign-op-seq
-              (call-with-values
-               success-k
-               (lambda ()
-                 (build-assign
-                  (attribute assign.op)
-                  #'assign.name
-                  #`(lambda ()
-                      #,(mk lhs (lambda (e)
-                                  (relocate (respan #`(#,lhs #,field-stx)) e))))
-                  #`(lambda (v)
-                      #,(mk-set lhs #'v
-                                (lambda (e)
-                                  (relocate (respan #`(#,lhs #,field-stx)) e))))
-                  #'value
-                  #'assign.tail)))]
+              (define-values (assign-expr tail)
+                (build-assign
+                 (attribute assign.op)
+                 #'assign.name
+                 #`(lambda ()
+                     #,(mk lhs (lambda (e)
+                                 (relocate (respan #`(#,lhs #,field-stx)) e))))
+                 #`(lambda (v)
+                     #,(mk-set lhs #'v
+                               (lambda (e)
+                                 (relocate (respan #`(#,lhs #,field-stx)) e))))
+                 #'value
+                 #'assign.tail))
+              (success-k assign-expr tail)]
              [_ (just-access mk)])])))
 
     (k (syntax-e field-stx) field ary nary fail-k)))

--- a/rhombus/private/dot.rkt
+++ b/rhombus/private/dot.rkt
@@ -3,13 +3,10 @@
                      syntax/parse/pre
                      enforest/property
                      enforest/syntax-local
-                     enforest/operator
                      "operator-parse.rkt"
-                     "tag.rkt"
                      "statically-str.rkt"
                      "srcloc.rkt")
          "provide.rkt"
-         "definition.rkt"
          "expression.rkt"
          (submod "annotation.rkt" for-class)
          "static-info.rkt"
@@ -19,7 +16,6 @@
          "compound-repetition.rkt"
          "realm.rkt"
          "parse.rkt"
-         "assign.rkt"
          "is-static.rkt"
          (submod "assign.rkt" for-assign))
 
@@ -178,10 +174,11 @@
     [dp-id
      (define p (syntax-local-value* (in-dot-provider-space dp-id) dot-provider-ref))
      (unless p (raise-syntax-error #f "not bound as a dot provider" (in-dot-provider-space dp-id)))
+     (define (success-k expr tail) (values expr tail))
      ((dot-provider-handler p) form1 dot field-id
                                tail
                                more-static?
-                               values generic)]
+                               success-k generic)]
     [else (generic)]))
 
 (define-syntax (define-dot-provider-syntax stx)


### PR DESCRIPTION
The `call-with-values` in the assignment case appears to be wrong, because the values produced by `build-assign` should be received by `success-k`, not the other way around.  It *innocently* worked, however, because `success-k` was just `values`, which produced, well, no values, and then `build-assign` just returned the two values without going through `success-k`.  Fix this innocent mistake by using a `success-k` that does check for the correct arity, for future-proof sake.