### PR TITLE
improve documentation of `values` literals

### DIFF
--- a/rhombus/private/function-parse.rkt
+++ b/rhombus/private/function-parse.rkt
@@ -3,6 +3,7 @@
                      (only-in racket/function normalize-arity)
                      racket/keyword
                      syntax/parse/pre
+                     enforest/name-parse
                      shrubbery/print
                      "hash-set.rkt"
                      "srcloc.rkt"
@@ -40,7 +41,9 @@
          (submod "list.rkt" for-compound-repetition)
          (submod "map.rkt" for-info)
          "if-blocked.rkt"
-         "realm.rkt")
+         "realm.rkt"
+         (only-in "values.rkt"
+                  [values rhombus-values]))
 
 (module+ for-build
   (provide (for-syntax :kw-binding
@@ -202,9 +205,9 @@
                   annot-str)   ; the raw text of annotation, or `#f`
     #:description "return annotation"
     #:datum-literals (block group)
-    (pattern (~seq ann-op::annotate-op (~optional vls:identifier) (~and p (_::parens g ...)))
-             #:when (or (not (attribute vls))
-                        (free-identifier=? #'vls #'values))
+    (pattern (~seq ann-op::annotate-op (~optional op::name) (~and p (_::parens g ...)))
+             #:when (or (not (attribute op))
+                        (free-identifier=? (in-annotation-space #'op.name) (annot-quote rhombus-values)))
              #:do [(define gs #'(g ...))]
              #:with (c::annotation ...) gs
              #:with (arg ...) (generate-temporaries gs)
@@ -254,7 +257,7 @@
                                  cnt))]))]
              #:with static-infos sis
              #:attr converter cvtr
-             #:attr annot-str (shrubbery-syntax->string #`(#,group-tag (~? vls) p)))
+             #:attr annot-str (shrubbery-syntax->string #`(#,group-tag (~? op) p)))
     (pattern (~seq ann-op::annotate-op ctc0::not-block ctc::not-block ...)
              #:do [(define annot #`(#,group-tag ctc0 ctc ...))]
              #:with c::annotation (no-srcloc annot)

--- a/rhombus/private/values.rkt
+++ b/rhombus/private/values.rkt
@@ -4,6 +4,7 @@
                      "srcloc.rkt")
          "provide.rkt"
          "binding.rkt"
+         (submod "annotation.rkt" for-class)
          "reducer.rkt"
          "parse.rkt"
          "static-info.rkt"
@@ -14,6 +15,7 @@
 
 (provide (for-spaces (#f
                       rhombus/bind
+                      rhombus/annot
                       rhombus/reducer
                       rhombus/statinfo)
                      values)
@@ -24,7 +26,7 @@
 
 (define-binding-syntax values
   (binding-prefix-operator
-   #'values
+   (bind-quote values)
    '((default . stronger))
    'macro
    (lambda (stx)
@@ -33,6 +35,19 @@
         (raise-syntax-error #f
                             (string-append "not allowed as a pattern (except as a non-nested"
                                            " pattern by forms that specifically recognize it)")
+                            #'head)]))))
+
+(define-annotation-syntax values
+  (annotation-prefix-operator
+   (annot-quote values)
+   '((default . stronger))
+   'macro
+   (lambda (stx)
+     (syntax-parse stx
+       [(head . _)
+        (raise-syntax-error #f
+                            (string-append "not allowed as an annotation (except as a non-nested"
+                                           " annotation by forms that specifically recognize it)")
                             #'head)]))))
 
 (define-reducer-syntax values

--- a/rhombus/scribblings/ref-def.scrbl
+++ b/rhombus/scribblings/ref-def.scrbl
@@ -8,29 +8,34 @@
 @doc(
   ~nonterminal:
     rhs_expr: block expr
-  defn.macro 'def $bind = $rhs_expr'
-  defn.macro 'def $bind:
+  defn.macro 'def $lhs_bind = $rhs_expr'
+  defn.macro 'def $lhs_bind:
                 $body
                 ...'
+  grammar lhs_bind:
+    $bind
+    #,(@rhombus(values, ~bind))($bind, ...)
+    ($bind, ...)
 ){
 
- Binds the identifiers of @rhombus(bind) to the value of @rhombus(rhs_expr) or the
+ Binds the identifiers of @rhombus(bind)s to the values of @rhombus(rhs_expr) or the
  @rhombus(body) sequence. The @rhombus(body) itself can include
  definitions, and it normally ends with an expression to provide the
- result value.
+ result values.
 
  A @rhombus(bind) can be just an identifier or @nontermref(id_name), or it
  can be constructed with a binding operator, such as a pattern form or
- @rhombus(::) for annotations.
+ @rhombus(::) for annotations. The number of result values must match
+ the number of @rhombus(bind)s.
 
  An identifier is bound in the @rhombus(expr, ~space) @tech{space}, and most
  binding operators also create bindings in the @rhombus(expr, ~space) space.
 
- When @rhombus(def) is used with @rhombus(=), then @rhombus(expr) must
+ When @rhombus(def) is used with @rhombus(=), then @rhombus(rhs_expr) must
  not contain any immediate @rhombus(=) terms (although @rhombus(=) can
  appear nested in blocks, parentheses, etc.). When a @rhombus(def) group
  both contains a @rhombus(=) and ends in a block, the block is treated as
- part of an @rhombus(expr) after the @rhombus(=).
+ part of an @rhombus(rhs_expr) after the @rhombus(=).
 
 @examples(
   ~repl:
@@ -55,8 +60,9 @@
 @doc(
   ~nonterminal:
     rhs_expr: block expr
-  defn.macro 'let $bind = $rhs_expr'
-  defn.macro 'let $bind:
+    lhs_bind: def ~defn
+  defn.macro 'let $lhs_bind = $rhs_expr'
+  defn.macro 'let $lhs_bind:
                 $body
                 ...'
 ){

--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -160,8 +160,8 @@ normally bound to implement function calls.
   grammar maybe_res_annot:
     #,(@rhombus(::, ~bind)) $annot
     #,(@rhombus(:~, ~bind)) $annot
-    #,(@rhombus(::, ~bind)) values($annot, ...)
-    #,(@rhombus(:~, ~bind)) values($annot, ...)
+    #,(@rhombus(::, ~bind)) #,(@rhombus(values, ~annot))($annot, ...)
+    #,(@rhombus(:~, ~bind)) #,(@rhombus(values, ~annot))($annot, ...)
     #,(@rhombus(::, ~bind)) ($annot, ...)
     #,(@rhombus(:~, ~bind)) ($annot, ...)
     #,(epsilon)

--- a/rhombus/scribblings/ref-repetition.scrbl
+++ b/rhombus/scribblings/ref-repetition.scrbl
@@ -137,7 +137,7 @@ positions.
 @provided_also_meta()
 
  The @rhombus(&) expression operator and binding operator can only be
- used in places where its specifically recognized, normally either to
+ used in places where it's specifically recognized, normally either to
  reference or bind the ``rest'' of a data structure. The @rhombus(List)
  constructor, @rhombus(Map) constructor, @rhombus(fun) form, and the
  @rhombus(#%call) form are among the places that recognize
@@ -162,7 +162,7 @@ positions.
 @provided_also_meta()
 
  The @rhombus(~&) expression operator and binding operator can only be
- used in places where its specifically recognized, normally to bind the
+ used in places where it's specifically recognized, normally to bind the
  ``rest'' of a map with keywords as keys. The @rhombus(fun) and
  @rhombus(#%call) forms are among the places that recognize
  @rhombus(~&).

--- a/rhombus/scribblings/ref-values.scrbl
+++ b/rhombus/scribblings/ref-values.scrbl
@@ -18,12 +18,40 @@
 }
 
 @doc(
+  ~nonterminal:
+    lhs_bind: def ~defn
   bind.macro 'values($bind, ...)'
 ){
 
- Matches multiple result values corresponding to the number of
- @rhombus(bind)s, where each result matches the corresponing
- @rhombus(bind).
+ The @rhombus(values, ~bind) binding operator can only be used in
+ places where it's specifically recognized, normally to match multiple
+ result values. For example, the @rhombus(lhs_bind) position of
+ @rhombus(def) recognizes @rhombus(values, ~bind).
+
+@examples(
+  def values(x, y) = values(1, 2)
+  x+y
+)
+
+}
+
+@doc(
+  ~nonterminal:
+    maybe_res_annot: fun ~defn
+  annot.macro 'values($annot, ...)'
+){
+
+ The @rhombus(values, ~annot) annotation can only be used in places
+ where it's specifically recognized, normally to annotate multiple
+ result values. For example, the @rhombus(maybe_res_annot) position of
+ @rhombus(fun) recognizes @rhombus(values, ~annot).
+
+@examples(
+  fun two_numbers() :: values(Int, Int):
+    values(1, 2)
+  def (x, y) = two_numbers()
+  x+y
+)
 
 }
 

--- a/scribble/private/rhombus-spacer.rhm
+++ b/scribble/private/rhombus-spacer.rhm
@@ -119,7 +119,7 @@ meta:
            kind ~sequence
          | '$(tag && 'values') $(p && '($_)')'
          | '$(p && '($_)')': field tag = #false):
-          let new_tag = if tag | spacer.set(tag, #'~expr) | ''
+          let new_tag = if tag | spacer.set(tag, #'~annot) | ''
           let new_p = spacer.adjust_term(p, #'~annot, esc)
           '$new_tag $new_p'
       | ~else: spacer.adjust_sequence(res_ann, #'~annot, esc)


### PR DESCRIPTION
Clarify that the `values` binding operator can only be used where it’s recognized; also clarify that `($bind, ...)` acts as a shorthand for `values($bind, ...)` in `def`/`let`.

Add the `values` annotation literal and recognize it in result annotations.