### PR TITLE
remove wrapping of static infos in method dispatch

### DIFF
--- a/rhombus/private/class-primitive.rkt
+++ b/rhombus/private/class-primitive.rkt
@@ -68,8 +68,9 @@
                    (~optional property-si #:defaults ([property-si #'#f]))]
          ...)
         #:methods
-        ((~or* (~and [method mask name-method-proc method-proc (~optional method-si)]
-                     (~parse method-dispatch #'(nary mask #'name-method-proc #'method-proc (~? method-si))))
+        ((~or* (~and [method mask name-method-proc method-proc]
+                     (~parse method-dispatch
+                             #'(nary 'mask (quote-syntax name-method-proc) (quote-syntax method-proc))))
                (~and (~or* (~and [method name-method-proc])
                            (~and method
                                  (~parse name-method-proc

--- a/rhombus/private/define-arity.rkt
+++ b/rhombus/private/define-arity.rkt
@@ -92,28 +92,6 @@
   (define dispatch-id (format-id "~a/dispatch"))
   (define method-id (format-id "~a/method"))
   (define arity-mask (extract-arity-mask rhs))
-  (define method-static-infos
-    (or (and static-infos
-             (cond
-               [(static-info-lookup static-infos #'#%call-results-at-arities)
-                => (lambda (infos)
-                     #`(lambda (n)
-                         (case n
-                           #,@(for/list ([info (in-list (syntax->list infos))]
-                                         #:do [(define-values (n infos)
-                                                 (syntax-parse info
-                                                   [(n infos)
-                                                    (values (sub1 (syntax-e #'n)) #'infos)]))]
-                                         #:when (n . >= . 0))
-                                (with-syntax ([infos infos])
-                                  #`[(#,n) #`infos]))
-                           [else #f])))]
-               [(static-info-lookup static-infos #'#%call-result)
-                => (lambda (infos)
-                     (with-syntax ([infos infos])
-                       #`#`infos))]
-               [else #f]))
-        #'#f))
   (define-values (obj method)
     (syntax-parse rhs
       #:literals (lambda case-lambda)
@@ -131,7 +109,7 @@
                         #`[#,args #,(make-apply id #'obj args)])))]))
   (list* #`(define-for-syntax #,dispatch-id
              (lambda (nary)
-               (nary #,(arithmetic-shift arity-mask -1) #'#,id #'#,method-id #,method-static-infos)))
+               (nary '#,(arithmetic-shift arity-mask -1) (quote-syntax #,id) (quote-syntax #,method-id))))
          #`(define #,method-id
              (lambda (#,obj)
                ;; TODO what should we name the partially applied method?


### PR DESCRIPTION
Instead of doing the wrapping in method dispatch (which is now generated anyway), rely on the usual function-call mechanism.