### PR TITLE
allow single-group body in `meta`

### DIFF
--- a/rhombus/private/meta.rkt
+++ b/rhombus/private/meta.rkt
@@ -25,20 +25,17 @@
   (declaration-transformer
    (lambda (stx)
      (syntax-parse stx
-       #:datum-literals (block bridge op |.|)
        [(form-id (_::block form ...))
         #'((begin-for-syntax
              (rhombus-top form ...)))]
-       ;; since definition contexts overlap declaration contexts,
-       ;; we have to handle `bridge` here, too:
-       [(form-id (op |.|) bridge . tail)
-        #'((rhombus-definition (group bridge . tail)))]))))
+       [(form-id . tail)
+        #'((begin-for-syntax
+             (rhombus-top (group . tail))))]))))
 
 (define-for-syntax (make-bridge-definer space-sym)
   (definition-transformer
    (lambda (stx)
      (syntax-parse stx
-       #:datum-literals (block)
        [(form-id name-seq::dotted-operator-or-identifier-sequence (tag::block form ...))
         #:with name::dotted-operator-or-identifier #'name-seq
         #`(#,(build-syntax-definition/maybe-extension

--- a/rhombus/scribblings/ref-meta.scrbl
+++ b/rhombus/scribblings/ref-meta.scrbl
@@ -12,39 +12,51 @@
   decl.macro 'meta:
                 $body
                 ...'
+  decl.macro 'meta $body'
 ){
 
  The same as the @rhombus(body) sequence, but shifted to one phase
  greater. Defintions inside a @rhombus(meta) block can be
  referenced in macro implementations, for example.
 
+ Alternatively, @rhombus(meta) can have a single @rhombus(body) in a
+ group, in which case it is equivalent to a block with the single
+ @rhombus(body).
+
  See also the @rhombus(meta, ~impo) import modifier.
 
 @examples(
   ~eval: macro.make_for_meta_eval()
-  meta:
-    syntax_class Arithmetic
-    | '$x + $y'
-    | '$x - $y'
-  expr.macro 'right_operand $(exp :: Arithmetic)':
-    exp.y
-  right_operand 1 + 2
+  ~repl:
+    meta:
+      syntax_class Arithmetic
+      | '$x + $y'
+      | '$x - $y'
+    expr.macro 'right_operand $(exp :: Arithmetic)':
+      exp.y
+    right_operand 1 + 2
+  ~repl:
+    meta fun add1(x):
+      x+1
+    expr.macro 'add1_statically $(n :: Int)':
+      '#%literal $(add1(Syntax.unwrap(n)))'
+    add1_statically 13
 )
 
 }
 
 @doc(
-  defn.macro 'meta.bridge $id:
+  defn.macro 'meta.bridge $op_or_id_name:
                 $body
                 ...'
 ){
 
- Binds @rhombus(id) at the enclosing phase, but like a macro,
+ Binds @rhombus(op_or_id_name) at the enclosing phase, but like a macro,
  where the @rhombus(body) side is a compile-time block at one phase
  greater than the enclosing phase.
 
  The result of the @rhombus(body) block might be a macro transformer
- that is triggered by a use of @rhombus(id), or it might be
+ that is triggered by a use of @rhombus(op_or_id_name), or it might be
  some other kind of value that is accessed with
  @rhombus(syntax_meta.value).
 
@@ -53,10 +65,10 @@
  those cases, the generated @rhombus(body) block produces an
  expression transformer, binding transformer, or annotation
  transformer. Some forms that expand to @rhombus(meta.bridge) enrich
- the @rhombus(id) with a scope for a @tech{space} of bindings, which
- enables overloading a @rhombus(id) for different contexts
+ the @rhombus(op_or_id_name) with a scope for a @tech{space} of bindings, which
+ enables overloading a @rhombus(op_or_id_name) for different contexts
  like expressions versus bindings. For example,
- @rhombus(annot.macro) enriches its @rhombus(id) with a
+ @rhombus(annot.macro) enriches its @rhombus(op_or_id_name) with a
  scope for annotation operators.
 
 }

--- a/rhombus/tests/meta.rhm
+++ b/rhombus/tests/meta.rhm
@@ -1,0 +1,41 @@
+#lang rhombus/and_meta
+
+meta def group = 1
+
+meta:
+  def block_1 = 2
+  def block_2 = 3
+
+check:
+  expr.macro 'show':
+    '[$group, $block_1, $block_2]'
+  show
+  ~is [1, 2, 3]
+
+meta.bridge outer:
+  '#'outer'
+
+check:
+  meta.bridge inner:
+    '#'inner'
+  expr.macro 'show':
+    '[$(syntax_meta.value('outer')),
+      $(syntax_meta.value('inner'))]'
+  show
+  ~is [#'outer, #'inner]
+
+check:
+  namespace direction:
+    export: left
+    meta.bridge left:
+      '#'left'
+  meta.bridge direction.right:
+    '#'right'
+  meta.bridge direction.(<>):
+    '#'both'
+  expr.macro 'show':
+    '[$(syntax_meta.value('direction.left')),
+      $(syntax_meta.value('direction.right')),
+      $(syntax_meta.value('direction.(<>)'))]'
+  show
+  ~is [#'left, #'right, #'both]


### PR DESCRIPTION
This form is similar to `define-for-syntax` in Racket, but more general.  In particular, it avoids the extra indentation as compared to the block form.