### PR TITLE
say “throw” instead of “raise”

### DIFF
--- a/rhombus/private/check.rhm
+++ b/rhombus/private/check.rhm
@@ -18,9 +18,9 @@ meta:
   | '~is_a'
   | '~prints_like'
   | '~prints'
-  | '~raises'
+  | '$('~throws' || '~raises')' // TEMP remove the alias at some point
   | '~matches'
-      
+
   syntax_class Result:
     kind: ~sequence
   | '$(mode :: ResultMode): $body':
@@ -117,7 +117,7 @@ fun check_same(loc_where, thunk, expected_thunk, maybe_loc_mode):
         !exn_msg && (got == expected)
     | #'~is_now:
         !exn_msg && (got is_now expected)
-    | #'~raises:
+    | #'~throws || #'~raises:
         exn_msg && does_contain_each(expected, exn_msg)
     | #'~completes:
         !exn_msg
@@ -141,10 +141,10 @@ fun check_same(loc_where, thunk, expected_thunk, maybe_loc_mode):
         +& (exn_msg && ("exception " +& reindent_exn_msg(exn_msg, 17))
               || output && to_string(output, ~mode: #'expr)
               || values_str(got))
-        +&  "\n"
+        +& "\n"
         +& "  expected: " +& (match mode
                               | #'~completes: "completion"
-                              | #'~raises: "exception " +& values_str(expected)
+                              | #'~throws || #'~raises: "exception " +& values_str(expected)
                               | #'~matches: "matching " +& expected_thunk(#false)
                               | #'~is_a: "satisfying " +& expected_thunk(#false)
                               | #'~prints: "output " +& values_str(expected)

--- a/rhombus/private/control.rkt
+++ b/rhombus/private/control.rkt
@@ -67,7 +67,7 @@
               [_ #f]))]
       [else (raise-argument-error* e-who
                                    rhombus-realm
-                                   "ReadableString || Symbol || Identifier || Operator || False"
+                                   "maybe(ReadableString || Symbol || Identifier || Operator)"
                                    who)]))
   (unless (string? msg)
     (raise-argument-error* e-who rhombus-realm "ReadableString" msg))

--- a/rhombus/scribblings/annotation-macro-protocol.scrbl
+++ b/rhombus/scribblings/annotation-macro-protocol.scrbl
@@ -15,7 +15,7 @@ Unless otherwise specified, an @tech{annotation} is a @deftech{predicate
  annotation}. For example, @rhombus(String, ~annot) and @rhombus(ReadableString, ~annot) are
 predicate annotations. When a predicate annotation is applied to a value
 with the @rhombus(::) expression operator, the result of the expression
-is the operator's left-hand argument (or an exception is raised).
+is the operator's left-hand argument (or an exception is thrown).
 Similarly, using the @rhombus(::, ~bind) binding operator with a
 predicate annotation has no effect on the binding other than checking
 whether a corresponding value satisfies the annotation's predicate.

--- a/rhombus/scribblings/annotation.scrbl
+++ b/rhombus/scribblings/annotation.scrbl
@@ -25,7 +25,7 @@ The @rhombus(:~) and @rhombus(::) operators also work in expression
 positions. In that case, the assertion or check is about the expression
 on the left-hand side of @rhombus(:~) or @rhombus(::). For @rhombus(::),
 the left-hand expression must produce a value that satisfies the
-right-hand annotation, otherwise a run-time exception is raised. The
+right-hand annotation, otherwise a run-time exception is thrown. The
 @rhombus(is_a) operator takes an annotation like @rhombus(::), but it
 produces a boolean result indicating whether the result of the left-hand
 expression matches the annotation.

--- a/rhombus/scribblings/ref-annotation-macro.scrbl
+++ b/rhombus/scribblings/ref-annotation-macro.scrbl
@@ -160,7 +160,7 @@
  If a value is tested against a delayed annotation @rhombus(id) before
  it is completed via @rhombus(annot.delayed_complete) at run time, then
  an exception is reported. At compile time, attempting to use the static information
- associated @rhombus(id) raises a syntax error until it is completed via
+ associated @rhombus(id) throws a syntax error until it is completed via
  @rhombus(annot.delayed_complete).
 
  These forms should be used as last resort, because they inherently

--- a/rhombus/scribblings/ref-bytes.scrbl
+++ b/rhombus/scribblings/ref-bytes.scrbl
@@ -127,7 +127,7 @@ and @rhombus(ImmutableBytes, ~annot) require one or the other.
  Converts a byte string to a string, decoding as UTF-8, Latin-1, or the
  current locale's encoding. The @rhombus(err_char) argument provides a
  @tech{character} to use in place of an encoding error, where
- @rhombus(#false) means that an exception is raised.
+ @rhombus(#false) means that an exception is thrown.
 
 @examples(
   #"hello".utf8_string()

--- a/rhombus/scribblings/ref-check.scrbl
+++ b/rhombus/scribblings/ref-check.scrbl
@@ -33,7 +33,7 @@
     ~eval
     ~eval: $evaluator_expr
     #,(epsilon)
-  
+
   grammar expected_result:
     ~is $expected_expr
     ~is: $expected_body; ...
@@ -47,13 +47,13 @@
     ~matches: $expected_bind; ...
     ~prints $expected_expr
     ~prints: $expected_body; ...
-    ~raises $expected_expr
-    ~raises: $expected_body; ...
+    ~throws $expected_expr
+    ~throws: $expected_body; ...
     ~completes
 ){
 
  Evaluates the @rhombus(body) or @rhombus(expr) form, catching any
- exception that is raised, then determines whether the result or
+ exception that is thrown, then determines whether the result or
  exception matches @rhombus(expected_result):
 
 @itemlist(
@@ -83,10 +83,10 @@
   @rhombus(Port.current_output()) to a string, then checks that there is
   no exception and the output string is the same as the expected result.}
 
- @item{In @rhombus(~raises) mode, obtains one or more strings (as
+ @item{In @rhombus(~throws) mode, obtains one or more strings (as
   multiple values) by evaluating @rhombus(expected_body) or
   @rhombus(expected_expr), then checks that original @rhombus(body) or
-  @rhombus(expr) raised an exception and that each string is contained in
+  @rhombus(expr) threw an exception and that each string is contained in
   the exception message.}
 
  @item{In @rhombus(~completes) mode, checks merely that the original
@@ -140,19 +140,19 @@
     ~prints_like '2'
   check:
     1+"a"
-    ~raises "expected: Number"
+    ~throws "expected: Number"
   ~error:
     check:
       + // oops: causes syntax error for overall `check` form
-      ~raises "infix operator without preceding argument"    
+      ~throws "infix operator without preceding argument"
   check:
     ~eval // lets `check` confirm the expected syntax error
     +
-    ~raises "infix operator without preceding argument"    
+    ~throws "infix operator without preceding argument"
   check:
     ~eval
     +
-    ~raises values("+", "infix operator without preceding argument")
+    ~throws values("+", "infix operator without preceding argument")
 )
 
 }

--- a/rhombus/scribblings/ref-class.scrbl
+++ b/rhombus/scribblings/ref-class.scrbl
@@ -702,7 +702,7 @@
 
  When a class has an abstract method or property,
  either declared directly or inherited, the underlying constructor for the class
- raises an exception. The method or property must be overridden with a
+ throws an exception. The method or property must be overridden with a
  @rhombus(override, ~class_clause) class in a subclass, and then the
  subclass can be instantiated (as long as it has no other abstract
  methods). A @tech{final} class cannot have an abstract method or property.

--- a/rhombus/scribblings/ref-cond.scrbl
+++ b/rhombus/scribblings/ref-cond.scrbl
@@ -67,7 +67,7 @@
  clause.
 
  If no @rhombus(clause_test_expr) produces a true value and there is no
- @rhombus(~else) clause, a run-time exception is raised.
+ @rhombus(~else) clause, a run-time exception is thrown.
 
 }
 

--- a/rhombus/scribblings/ref-exn.scrbl
+++ b/rhombus/scribblings/ref-exn.scrbl
@@ -97,16 +97,17 @@
 
  Throws the value of @rhombus(expr) as an exception. Any value can be
  thrown, but typically thrown values are instances of a subclass of
- @rhombus(Exn).
+ @rhombus(Exn, ~class).
 
 }
 
 @doc(
   fun error(message :: ReadableString)
     :: None
-  fun error(who :: ReadableString || Symbol || Identifier || Operator || False,
-            message :: ReadableString)
-    :: None
+  fun error(
+    who :: maybe(ReadableString || Symbol || Identifier || Operator),
+    message :: ReadableString
+  ) :: None
 ){
 
  Throws the @rhombus(Exn.Fail, ~class) exception with @rhombus(message) as the

--- a/rhombus/scribblings/ref-list.scrbl
+++ b/rhombus/scribblings/ref-list.scrbl
@@ -197,7 +197,7 @@ it supplies its elements in order.
 
 
 @doc(
-  def List.empty :: []
+  def List.empty :: List = []
   bind.macro 'List.empty'
 ){
 
@@ -232,7 +232,9 @@ it supplies its elements in order.
 
 
 @doc(
-  repet.macro 'List.repet($lst)'
+  ~nonterminal:
+    list_expr: block expr
+  repet.macro 'List.repet($list_expr)'
 ){
 
  Creates a repetition from a list. This is a shorthand for using
@@ -302,7 +304,7 @@ it supplies its elements in order.
  elements in the case of @rhombus(List.drop_left), or without the last
  @rhombus(n) elements in the case of @rhombus(List.drop_right). The given
  @rhombus(lst) must have at least @rhombus(n) elements, otherwise an
- @rhombus(Exn.Fail.Contract, ~class) exception is raised.
+ @rhombus(Exn.Fail.Contract, ~class) exception is thrown.
 
 @examples(
   [1, 2, 3, 4, 5].drop_left(2)
@@ -315,7 +317,7 @@ it supplies its elements in order.
 
 
 @doc(
-  fun List.has_element(lst :: List, v) :: List
+  fun List.has_element(lst :: List, v :: Any) :: Boolean
 ){
 
  Returns @rhombus(#true) if @rhombus(lst) has an element equal to
@@ -330,7 +332,7 @@ it supplies its elements in order.
 
 
 @doc(
-  fun List.remove(lst :: List, v) :: List
+  fun List.remove(lst :: List, v :: Any) :: List
 ){
 
  Returns a list like @rhombus(lst), but with the first element equal to
@@ -360,10 +362,12 @@ it supplies its elements in order.
 
 
 @doc(
-  fun List.sort(lst :: List, less :: Function.of_arity(2) = math.less) :: List,
+  fun List.sort(lst :: List,
+                is_less :: Function.of_arity(2) = math.less)
+    :: List,
 ){
 
- Sorts @rhombus(lst) using @rhombus(less) to compare elements.
+ Sorts @rhombus(lst) using @rhombus(is_less) to compare elements.
 
 @examples(
   List.sort([1, 3, 2])

--- a/rhombus/scribblings/ref-map.scrbl
+++ b/rhombus/scribblings/ref-map.scrbl
@@ -279,7 +279,7 @@ in an unspecified order.
     key_expr: block expr
     val_expr: block expr
   expr.macro 'MutableMap{key_expr: val_expr, ...}'
-  fun MutableMap(key :: Any, value:: Any, ...) :: MutableMap
+  fun MutableMap(key :: Any, value :: Any, ...) :: MutableMap
 ){
 
  Similar to @rhombus(Map) as a constructor, but creates a mutable map
@@ -355,7 +355,9 @@ in an unspecified order.
 
 
 @doc(
-  fun Map.keys(map :: ReadableMap, try_sort = #false) :: List
+  fun Map.keys(map :: ReadableMap,
+               try_sort :: Any = #false)
+    :: List
 ){
 
  Returns the keys of @rhombus(map) in a list.  If @rhombus(try_order)
@@ -383,7 +385,11 @@ in an unspecified order.
 
 
 @doc(
-  fun Map.get(map :: ReadableMap, key, default = #,(@rhombus(raise_error, ~var)))
+  fun Map.get(map :: ReadableMap,
+              key :: Any,
+              default :: Any:
+                fun (): throw Exn.Fail.Contract(....))
+    :: Any
 ){
 
  Equivalent to @rhombus(map[key]) when @rhombus(default) is not
@@ -404,7 +410,7 @@ in an unspecified order.
 
 
 @doc(
-  fun Map.remove(map :: Map, key) :: Map
+  fun Map.remove(map :: Map, key :: Any) :: Map
 ){
 
  Returns a map like @rhombus(map), but without a mapping for
@@ -419,7 +425,7 @@ in an unspecified order.
 
 
 @doc(
-  fun MutableMap.delete(map :: MutableMap, key) :: Void
+  fun MutableMap.delete(map :: MutableMap, key :: Any) :: Void
 ){
 
  Changes @rhombus(map) to remove a mapping for @rhombus(key), if any.
@@ -436,7 +442,7 @@ in an unspecified order.
 
 
 @doc(
-  fun Map.has_key(map :: ReadableMap, key) :: Boolean
+  fun Map.has_key(map :: ReadableMap, key :: Any) :: Boolean
 ){
 
  Returns @rhombus(#true) if @rhombus(key) is mapped to a value in

--- a/rhombus/scribblings/ref-match.scrbl
+++ b/rhombus/scribblings/ref-match.scrbl
@@ -51,7 +51,7 @@
  completely enumerated here.
 
  If no @rhombus(target_expr) produces a true value and there is no
- @rhombus(~else) clause, a run-time exception is raised. In that case,
+ @rhombus(~else) clause, a run-time exception is thrown. In that case,
  when all of the @rhombus(bind) forms are syntax-object patterns, the
  generated exception's message may be specialized to report the expected
  pattern, instead of just reporting that no cases matched.

--- a/rhombus/scribblings/ref-string.scrbl
+++ b/rhombus/scribblings/ref-string.scrbl
@@ -156,7 +156,7 @@ immutable strings.
  Converts a string to a byte string, encoding by UTF-8, Latin-1, or the
  current locale's encoding. The @rhombus(err_byte) argument provides a
  byte to use in place of an encoding error, where @rhombus(#false) means
- that an exception is raised. (No encoding error is possible with
+ that an exception is thrown. (No encoding error is possible with
  @rhombus(String.utf8_bytes), but @rhombus(err_byte) is accepted for
  consistency.)
 

--- a/rhombus/scribblings/ref-stxobj-meta.scrbl
+++ b/rhombus/scribblings/ref-stxobj-meta.scrbl
@@ -41,7 +41,7 @@
  available, then @rhombus(fail) is called if it is a procedure of 0
  arguments, otherwise @rhombus(fail) is returned.
 
- The default @rhombus(fail) is a procedure that raises an exception.
+ The default @rhombus(fail) is a procedure that throws an exception.
 
 }
 

--- a/rhombus/tests/alt-fun.rhm
+++ b/rhombus/tests/alt-fun.rhm
@@ -28,17 +28,17 @@ block:
   | f([]): 0
   | f(): 2
   check:
-    f([1]) ~raises "f: no matching case for arguments"
+    f([1]) ~throws "f: no matching case for arguments"
 
 block:
   fun f([] = [1]): 0
   check:
-    f() ~raises "f: argument does not satisfy annotation"
+    f() ~throws "f: argument does not satisfy annotation"
 
 block:
   fun f([] = [], & rst): rst
   check:
-    f("a") ~raises "f: argument does not satisfy annotation"
+    f("a") ~throws "f: argument does not satisfy annotation"
 
 block:
   /*

--- a/rhombus/tests/annot-convert.rhm
+++ b/rhombus/tests/annot-convert.rhm
@@ -10,7 +10,7 @@ check:
 
 check:
   [[1, 2]] :: List.of(converting(fun ([_, y :: String]): y))
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 class Posn(x, y)
 class PosnKW(x, ~y: y)
@@ -51,7 +51,7 @@ check:
 
 check:
   [2, 2] :: (converting(fun ([1, x]): x) || converting(fun ([x, 1]): x))
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   [12, 1] :: (Int || converting(fun ([x, 1]): x))
@@ -99,7 +99,7 @@ check:
     override method m() :: converting(fun (_ :: String): 0):
       "100"
   Hello().m()
-  ~raises values(
+  ~throws values(
     "result does not satisfy annotation",
     "converting(fun (_ :: String): 0)",
   )
@@ -108,7 +108,7 @@ check:
   ~eval
   interface Greeter:
     method m() :: converting(fun (_::String): 0)
-  ~raises "declared result annotation must be a predicate annotation"
+  ~throws "declared result annotation must be a predicate annotation"
 
 check:
   ~eval
@@ -116,7 +116,7 @@ check:
     nonfinal
     method m() :: converting(fun (_::String): 0):
       "hi"
-  ~raises "declared result annotation must be a predicate annotation"
+  ~throws "declared result annotation must be a predicate annotation"
 
 check:
   class Hello():
@@ -148,32 +148,32 @@ check:
 
 check:
   [1, "oops"] is_a matching((_ :: List) :: converting(fun ([x, ...]): [x+1, ...]))
-  ~raises "+: contract violation"
+  ~throws "+: contract violation"
 
 check:
   ~eval
   "apple" :~ ReadableString.to_string
-  ~raises "converter annotation not allowed in a non-checked position"
+  ~throws "converter annotation not allowed in a non-checked position"
 
 check:
   ~eval
   def x :~ ReadableString.to_string = 0
-  ~raises "converter annotation not allowed in a non-checked position"
+  ~throws "converter annotation not allowed in a non-checked position"
 
 check:
   ~eval
   fun (x :~ ReadableString.to_string): 0
-  ~raises "converter annotation not allowed in a non-checked position"
+  ~throws "converter annotation not allowed in a non-checked position"
 
 check:
   ~eval
   fun () :~ ReadableString.to_string: 0
-  ~raises "converter annotation not allowed in a non-checked position"
+  ~throws "converter annotation not allowed in a non-checked position"
 
 check:
   ~eval
   fun () :~ values(Int, ReadableString.to_string): 0
-  ~raises "converter annotation not allowed in a non-checked position"
+  ~throws "converter annotation not allowed in a non-checked position"
 
 block:
   annot.macro 'UTF8Bytes_oops':
@@ -182,7 +182,7 @@ block:
 
   check:
     #"\316\273" :: UTF8Bytes_oops ~is "λ"
-    #"\316" :: UTF8Bytes_oops ~raises "byte string is not a well-formed UTF-8 encoding"
+    #"\316" :: UTF8Bytes_oops ~throws "byte string is not a well-formed UTF-8 encoding"
     #"\316" is_a UTF8Bytes_oops ~is #true
 
   fun try_utf8(s):
@@ -202,4 +202,4 @@ block:
   check:
     #"\316\273" :: UTF8Bytes ~is "λ"
     #"\316" is_a UTF8Bytes ~is #false
-    #"\316" :: UTF8Bytes ~raises "value does not satisfy annotation"
+    #"\316" :: UTF8Bytes ~throws "value does not satisfy annotation"

--- a/rhombus/tests/annot-macro.rhm
+++ b/rhombus/tests/annot-macro.rhm
@@ -11,7 +11,7 @@ check:
 
 check:
   "no" :: AlsoPosn
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 bind.macro 'AlsoPosn ($x, $y)':
   'Posn($x, $y)'
@@ -25,7 +25,7 @@ block:
   annot.delayed_declare Forward
   check:
     10 :: Forward
-    ~raises "delayed annoation is not yet completed"
+    ~throws "delayed annoation is not yet completed"
   annot.delayed_complete Forward: Int
   check:
     10 :: Forward
@@ -39,7 +39,7 @@ block:
     fun f(v): v :: Forward
   check:
     f.f(10)
-    ~raises "delayed annoation is not yet completed"
+    ~throws "delayed annoation is not yet completed"
   annot.delayed_complete f.Forward: Int
   check:
     f.f(10)
@@ -51,7 +51,7 @@ check:
   import: rhombus/meta open
   annot.delayed_declare Forward
   fun (): (10 :: Forward).x
-  ~raises "static information needed before completed"
+  ~throws "static information needed before completed"
 
 check:
   ~eval

--- a/rhombus/tests/annotation.rhm
+++ b/rhombus/tests/annotation.rhm
@@ -8,7 +8,7 @@ check:
 check:
   ~eval
   "a" :: PosInt . count()
-  ~raises "operator precedence"
+  ~throws "operator precedence"
 
 check:
   1 is_a Function ~is #false

--- a/rhombus/tests/appendable.rhm
+++ b/rhombus/tests/appendable.rhm
@@ -43,13 +43,13 @@ check:
   (A3() ++ A3()).v ~is 3
   (A3() :: I3) ++ A3() ~is O(3)
   (A4() ++ A4()).v ~is 4
-  A() ++ B() ~raises "cannot append an appendable object and other value"
-  B() ++ A() ~raises "cannot append an appendable object and other value"
+  A() ++ B() ~throws "cannot append an appendable object and other value"
+  B() ++ A() ~throws "cannot append an appendable object and other value"
 
 block:
   use_dynamic
   check:
-    dynamic(A()) ++ B() ~raises "cannot append an appendable object and other value"
+    dynamic(A()) ++ B() ~throws "cannot append an appendable object and other value"
 
 check:
   A() is_a Appendable ~is #true
@@ -77,7 +77,7 @@ block:
         0
     A()    
   check:
-    gen() ++ gen() ~raises "cannot append an appendable object and other value"
+    gen() ++ gen() ~throws "cannot append an appendable object and other value"
     dynamic("a") ++ "b" ~is "ab"
     dynamic([]) ++ ["a"] ~is ["a"]
 

--- a/rhombus/tests/arithmetic.rhm
+++ b/rhombus/tests/arithmetic.rhm
@@ -15,7 +15,7 @@ check:
 check:
   ~eval
   10 / 2 * 4
-  ~raises "combination of expression operators at same precedence, but only in the other order"
+  ~throws "combination of expression operators at same precedence, but only in the other order"
 
 check:
   fun five(x):

--- a/rhombus/tests/array.rhm
+++ b/rhombus/tests/array.rhm
@@ -6,7 +6,7 @@ check:
 
 check:
   Array.length([1, 2, 3])
-  ~raises values("contract violation", "expected: Array")
+  ~throws values("contract violation", "expected: Array")
 
 block:
   use_static
@@ -84,23 +84,23 @@ block:
 
 check:
   10 :: Array
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   10 :: Array.now_of(Any)
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   10 :: Array.later_of(Any)
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   10 :: Array.later_of(converting(fun (_): #false))
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   Array(1) :: Array.now_of(String)
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   Array(1) :: Array.later_of(String)
@@ -120,7 +120,7 @@ check:
 check:
   def a :: Array.later_of(String) = Array(1)
   a[0]
-  ~raises values(
+  ~throws values(
     "current element does not satisfy the array's annotation",
     "0",
     "String",
@@ -135,7 +135,7 @@ check:
   def a :: Array.later_of(String) = Array("apple")
   a[0]
   a[0] := #'oops
-  ~raises values(
+  ~throws values(
     "new element does not satisfy the array's annotation",
     "0",
     "String",
@@ -144,7 +144,7 @@ check:
 check:
   ~eval
   Array(Array("apple")) :: Array.now_of(Array.later_of(String))
-  ~raises "converter annotation not supported for element"
+  ~throws "converter annotation not supported for element"
 
 check:
   use_static
@@ -157,4 +157,4 @@ check:
   use_static
   def a :: Array.now_of(String) = Array("apple")
   a[0] ++ "jack"
-  ~raises "specialization not known"
+  ~throws "specialization not known"

--- a/rhombus/tests/boolean-pattern.rhm
+++ b/rhombus/tests/boolean-pattern.rhm
@@ -21,7 +21,7 @@ check:
   class Posn(x, y)
   def z && Posn(x, y) = dynamic(Posn(1, 2))
   z.x
-  ~raises values("no such field or method", "static")
+  ~throws values("no such field or method", "static")
 
 block:
   fun try(v):

--- a/rhombus/tests/box.rhm
+++ b/rhombus/tests/box.rhm
@@ -54,23 +54,23 @@ check:
 
 check:
   10 :: Box
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   10 :: Box.now_of(Any)
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   10 :: Box.later_of(Any)
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   10 :: Box.later_of(converting(fun (_): #false))
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   Box(1) :: Box.now_of(String)
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   Box(1) :: Box.later_of(String)
@@ -90,7 +90,7 @@ check:
 check:
   def bx :: Box.later_of(String) = Box(1)
   bx.value
-  ~raises values(
+  ~throws values(
     "current value does not satisfy the box's annotation",
     "String",
   )
@@ -99,7 +99,7 @@ check:
   def bx :: Box.later_of(String) = Box("apple")
   bx.value
   bx.value := #'oops
-  ~raises values(
+  ~throws values(
     "new value does not satisfy the box's annotation",
     "String",
   )
@@ -107,7 +107,7 @@ check:
 check:
   ~eval
   Box(Box("apple")) :: Box.now_of(Box.later_of(String))
-  ~raises "converter annotation not supported for value"
+  ~throws "converter annotation not supported for value"
 
 check:
   use_static
@@ -120,7 +120,7 @@ check:
   use_static
   def bx :: Box.now_of(String) = Box("apple")
   bx.value ++ "jack"
-  ~raises "specialization not known"
+  ~throws "specialization not known"
 
 check:
   def b = Box(0)

--- a/rhombus/tests/class-constructor-macro.rhm
+++ b/rhombus/tests/class-constructor-macro.rhm
@@ -37,14 +37,14 @@ check:
   class Posn(x, y):
     constructor (x): 0
     expression 'Posn': '0'
-  ~raises "unnamed constructor inaccessible due to expression macro"
+  ~throws "unnamed constructor inaccessible due to expression macro"
   
 check:
   ~eval
   class Posn(x, y):
     constructor Posn(x): 0
     expression 'Posn': '0'
-  ~raises "constructor name conflicts with expression macro"
+  ~throws "constructor name conflicts with expression macro"
 
 check:
   interface Shape:
@@ -68,7 +68,7 @@ block:
     ~is "hello"
   check:
     5 :: Stringish
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
   block:
     class S():
       implements Stringish

--- a/rhombus/tests/class-method-result.rhm
+++ b/rhombus/tests/class-method-result.rhm
@@ -20,13 +20,13 @@ block:
     ~is 3
   check:
     Posn(1, 2).n()
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "String",
     )
   check:
     Posn(1, 2).n_f()
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "String",
     )
@@ -45,7 +45,7 @@ block:
         0
     check:
       Posn3D(1, 2, 3).m()
-      ~raises values(
+      ~throws values(
         "result does not satisfy annotation",
         "Int",
       )
@@ -98,26 +98,26 @@ block:
     ~is Magenta()
   check:
     Bottom().m(Magenta())
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Green",
     )
 
   check:
     Top().m(Cyan())
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Red",
     )
   check:
     Middle().m(Cyan())
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Blue",
     )
   check:
     Bottom().m(Cyan())
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Green",
     )
@@ -174,13 +174,13 @@ block:
     ~is #true
   check:
     Point(1, 2).visible()
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Boolean",
     )
   check:
     Point(1, 2).invisible()
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Boolean",
     )
@@ -217,7 +217,7 @@ block:
     ~is RacketLogo()
   check:
     RacketLogo().example(#false)
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Red", "Blue",
     )
@@ -243,7 +243,7 @@ block:
     ~is [1, 2]
   check:
     Top().m("apple")
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Int",
     )
@@ -252,7 +252,7 @@ block:
     ~is "apple"
   check:
     Bottom().m2("apple")
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Int",
     )
@@ -287,19 +287,19 @@ block:
     ~is Both()
   check:
     C(#false).m()
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Right",
     )
   check:
     C(LeftC()).m()
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Right",
     )
   check:
     C(RightC()).m()
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Right",
     )
@@ -312,7 +312,7 @@ block:
       nonfinal
       method m() :: converting(fun (_): #false):
         #false
-    ~raises values(
+    ~throws values(
       "must be a predicate annotation",
       "non-final",
     )
@@ -320,7 +320,7 @@ block:
     ~eval
     interface A:
       method m() :: converting(fun (_): #false)
-    ~raises values(
+    ~throws values(
       "must be a predicate annotation",
       "non-final",
     )
@@ -343,7 +343,7 @@ block:
       extends A
       override m() :: values(Any, Any):
         values(#false, #false)
-    ~raises "incompatible result arities"
+    ~throws "incompatible result arities"
   check:
     ~eval
     class A():
@@ -354,7 +354,7 @@ block:
       extends A
       override m() :~ values(Any, Any):
         values(#false, #false)
-    ~raises "incompatible result arities"
+    ~throws "incompatible result arities"
   check:
     class A():
       nonfinal
@@ -376,7 +376,7 @@ block:
       override m() :: (Int, Real):
         values(1, 2.0)
     B().m()
-    ~raises values(
+    ~throws values(
       "results do not satisfy annotation",
       "(Int, Real)", "(Real, Int)",
     )

--- a/rhombus/tests/class-method.rhm
+++ b/rhombus/tests/class-method.rhm
@@ -7,40 +7,40 @@ check:
   class Posn(x, y):
     method x(): 0
     method x(): 1
-  ~raises "duplicate method name"
+  ~throws "duplicate method name"
 
 check:
   ~eval
   class Posn(x, y):
     method x(): 0
     abstract x
-  ~raises "duplicate method name"
+  ~throws "duplicate method name"
 
 check:
   ~eval
   class Posn(x, y):
     method x(): 0
-  ~raises "identifier used as both a field name and method name"
+  ~throws "identifier used as both a field name and method name"
 
 check:
   ~eval
   class Posn(x, y):
     private method x(): 0
-  ~raises "identifier used as both a field name and method name"
+  ~throws "identifier used as both a field name and method name"
 
 check:
   ~eval
   class Posn(x, y):
     field q: 1
     method q(): 0
-  ~raises "identifier used as both a field name and method name"
+  ~throws "identifier used as both a field name and method name"
 
 check:
   ~eval
   class Posn(x, y):
     private field q: 1
     method q(): 0
-  ~raises "identifier used as both a field name and method name"
+  ~throws "identifier used as both a field name and method name"
 
 check:
   ~eval
@@ -49,7 +49,7 @@ check:
   class Posn3D(z):
     extends Posn
     method x(): 0
-  ~raises "identifier used as both a field name and method name"    
+  ~throws "identifier used as both a field name and method name"    
 
 check:
   ~eval
@@ -58,7 +58,7 @@ check:
   class Posn3D(z):
     extends Posn
     private method x(): 0
-  ~raises "identifier used as both a field name and method name"    
+  ~throws "identifier used as both a field name and method name"    
 
 check:
   ~eval
@@ -68,7 +68,7 @@ check:
   class Posn3D(z):
     extends Posn
     method q(): 0
-  ~raises "identifier used as both a field name and method name"    
+  ~throws "identifier used as both a field name and method name"    
 
 check:
   ~eval
@@ -77,7 +77,7 @@ check:
     method z(): 0
   class Posn3D(z):
     extends Posn
-  ~raises "identifier used as both a field name and method name"    
+  ~throws "identifier used as both a field name and method name"    
 
 check:
   ~eval
@@ -87,7 +87,7 @@ check:
   class Posn3D(z):
     extends Posn
     field q: 1
-  ~raises "identifier used as both a field name and method name"    
+  ~throws "identifier used as both a field name and method name"    
 
 check:
   ~eval
@@ -97,7 +97,7 @@ check:
   class Posn3D(z):
     extends Posn
     private field q: 1
-  ~raises "identifier used as both a field name and method name"    
+  ~throws "identifier used as both a field name and method name"    
 
 check:
   ~eval
@@ -107,7 +107,7 @@ check:
   class Posn3D(z):
     extends Posn
     method m(): 0
-  ~raises "method is already in superclass"
+  ~throws "method is already in superclass"
 
 check:
   ~eval
@@ -116,7 +116,7 @@ check:
   class Posn3D(z):
     extends Posn
     override m(): 0
-  ~raises "method is not in superclass"
+  ~throws "method is not in superclass"
 
 check:
   ~eval
@@ -126,13 +126,13 @@ check:
   class Posn3D(z):
     extends Posn
     override m(): 0
-  ~raises "cannot override superclass's final method"
+  ~throws "cannot override superclass's final method"
 
 check:
   ~eval
   class Posn(x, y):
     abstract m
-  ~raises "final class cannot have abstract methods"
+  ~throws "final class cannot have abstract methods"
 
 check:
   class Posn(x, y):
@@ -147,7 +147,7 @@ check:
     nonfinal
     abstract m
   Posn(1, 2)
-  ~raises "cannot instantiate class with abstract"
+  ~throws "cannot instantiate class with abstract"
 
 check:
   ~eval
@@ -158,7 +158,7 @@ check:
     extends Posn
     nonfinal
   Posn3D(1, 2, 3)
-  ~raises "cannot instantiate class with abstract"
+  ~throws "cannot instantiate class with abstract"
 
 check:
   class Posn(x, y):
@@ -207,7 +207,7 @@ check:
       method m0(): [y, x]
     def p = Posn(1, 2)
     p.m0
-  ~raises values("method must be called", "static")
+  ~throws values("method must be called", "static")
 
 check:
   ~eval
@@ -216,7 +216,7 @@ check:
     class Posn(x, y):
       method m0(): m0
     "ok"
-  ~raises "method must be called"
+  ~throws "method must be called"
 
 check:
   use_dynamic
@@ -244,7 +244,7 @@ check:
   class Posn(x, y):
     private field q = 1
   (Posn(1, 2)).q
-  ~raises values("no such field or method", "static")
+  ~throws values("no such field or method", "static")
 
 check:
   ~eval
@@ -252,14 +252,14 @@ check:
   class Posn(x, y):
     private field q: 1
   Posn.q
-  ~raises "identifier not provided"
+  ~throws "identifier not provided"
 
 check:
   use_dynamic
   class Posn(x, y):
     private field q: 1
   (Posn(1, 2)).q
-  ~raises "no such field"
+  ~throws "no such field"
 
 check:
   use_static
@@ -305,7 +305,7 @@ check:
     class Posn3D(z):
       extends Posn
     "ok"
-  ~raises values("no such field or method", "static")
+  ~throws values("no such field or method", "static")
 
 check:
   class Posn(x, y):
@@ -353,7 +353,7 @@ check:
   class Posn3D(z):
     extends Posn
     override m(): super.m()
-  ~raises "method is abstract in superclass"
+  ~throws "method is abstract in superclass"
 
 check:
   class Posn(x, y):
@@ -381,7 +381,7 @@ check:
   class Posn(x, y):
     method a(): 1
   Posn.a(0)
-  ~raises "not an instance"
+  ~throws "not an instance"
 
 check:
   class A():
@@ -411,7 +411,7 @@ check:
     abstract override m()
   class C():
     extends B
-  ~raises "final class cannot have abstract methods"
+  ~throws "final class cannot have abstract methods"
 
 check:
   ~eval
@@ -422,7 +422,7 @@ check:
   class B():
     extends A
     abstract override m()
-  ~raises "final class cannot have abstract methods"
+  ~throws "final class cannot have abstract methods"
 
 block:
   interface C:
@@ -495,28 +495,28 @@ block:
     A.k(~arg: 0, B()) ~is O("k")
     A.kw(B(), ~arg: 0).v ~is "kw"
     A.kw(~arg: 0, B()) ~is O("kw")
-    B.m(A()) ~raises "not an instance for method call"
-    B.f(A()) ~raises "not an instance for method call"
-    B.k(A(), ~arg: 0) ~raises "not an instance for method call"
-    B.k(~arg: 0, A()) ~raises "not an instance for method call"
-    B.kw(A(), ~arg: 0) ~raises "not an instance for method call"
-    B.kw(~arg: 0, A()) ~raises "not an instance for method call"
+    B.m(A()) ~throws "not an instance for method call"
+    B.f(A()) ~throws "not an instance for method call"
+    B.k(A(), ~arg: 0) ~throws "not an instance for method call"
+    B.k(~arg: 0, A()) ~throws "not an instance for method call"
+    B.kw(A(), ~arg: 0) ~throws "not an instance for method call"
+    B.kw(~arg: 0, A()) ~throws "not an instance for method call"
     B.m(B()).v ~is "m"
     B.f(B()).v ~is "f"
     B.k(B(), ~arg: 0).v ~is "k"
     B.k(~arg: 0, B()) ~is O("k")
     B.kw(B(), ~arg: 0).v ~is "kw"
     B.kw(~arg: 0, B()) ~is O("kw")
-    ("oops" :~ A).m() ~raises "not an instance for method call"
-    ("oops" :~ A).f() ~raises "not an instance for method call"
-    ("oops" :~ B).m() ~raises "not an instance for method call"
-    ("oops" :~ B).f() ~raises "not an instance for method call"
-    ("oops" :~ B).k(~arg: 0) ~raises "not an instance for method call"
-    ("oops" :~ B).kw(~arg: 0) ~raises "not an instance for method call"
-    dynamic(B.m)(A()) ~raises "not an instance for method call"
-    dynamic(B.f)(A()) ~raises "not an instance for method call"
-    dynamic(B.k)(A(), ~arg: 0) ~raises "not an instance for method call"
-    dynamic(B.kw)(A(), ~arg: 0) ~raises "not an instance for method call"
+    ("oops" :~ A).m() ~throws "not an instance for method call"
+    ("oops" :~ A).f() ~throws "not an instance for method call"
+    ("oops" :~ B).m() ~throws "not an instance for method call"
+    ("oops" :~ B).f() ~throws "not an instance for method call"
+    ("oops" :~ B).k(~arg: 0) ~throws "not an instance for method call"
+    ("oops" :~ B).kw(~arg: 0) ~throws "not an instance for method call"
+    dynamic(B.m)(A()) ~throws "not an instance for method call"
+    dynamic(B.f)(A()) ~throws "not an instance for method call"
+    dynamic(B.k)(A(), ~arg: 0) ~throws "not an instance for method call"
+    dynamic(B.kw)(A(), ~arg: 0) ~throws "not an instance for method call"
     dynamic(B.m)(B()) ~is O("m")
     dynamic(B.f)(B()) ~is O("f")
     dynamic(B.k)(B(), ~arg: 0) ~is O("k")
@@ -561,12 +561,12 @@ block:
     B.k(~arg: 0, B()) ~is O("k")
     B.kw(B(), ~arg: 0).v ~is "kw"
     B.kw(~arg: 0, B()) ~is O("kw")
-    I.m(C()) ~raises "not an instance for method call"
-    I.f(C()) ~raises "not an instance for method call"
-    I.k(C(), ~arg: 0) ~raises "not an instance for method call"
-    I.k(~arg: 0, C()) ~raises "not an instance for method call"
-    I.kw(C(), ~arg: 0) ~raises "not an instance for method call"
-    I.kw(~arg: 0, C()) ~raises "not an instance for method call"
+    I.m(C()) ~throws "not an instance for method call"
+    I.f(C()) ~throws "not an instance for method call"
+    I.k(C(), ~arg: 0) ~throws "not an instance for method call"
+    I.k(~arg: 0, C()) ~throws "not an instance for method call"
+    I.kw(C(), ~arg: 0) ~throws "not an instance for method call"
+    I.kw(~arg: 0, C()) ~throws "not an instance for method call"
     I.m(D()).v ~is "m"
     I.f(D()).v ~is "f"
     I.k(D(), ~arg: 0).v ~is "k"
@@ -575,8 +575,8 @@ block:
     I.kw(~arg: 0, D()) ~is O("kw")
     J.m(D()).v ~is "m"
     J.f(D()).v ~is "f"
-    J.m(B()) ~raises "not an instance for method call"
-    J.f(B()) ~raises "not an instance for method call"
+    J.m(B()) ~throws "not an instance for method call"
+    J.f(B()) ~throws "not an instance for method call"
     J.k(D(), ~arg: 0).v ~is "k"
     J.k(~arg: 0, D()) ~is O("k")
     J.kw(D(), ~arg: 0).v ~is "kw"
@@ -585,30 +585,30 @@ block:
     (C() :: _C).f().v ~is "f"
     (C() :: _C).k(~arg: 0).v ~is "k"
     (C() :: _C).kw(~arg: 0).v ~is "kw"
-    ("oops" :~ I).m() ~raises "not an instance for method call"
-    ("oops" :~ I).f() ~raises "not an instance for method call"
-    ("oops" :~ I).k(~arg: 0) ~raises "not an instance for method call"
-    ("oops" :~ I).kw(~arg: 0) ~raises "not an instance for method call"
-    ("oops" :~ B).m() ~raises "not an instance for method call"
-    ("oops" :~ B).f() ~raises "not an instance for method call"
-    ("oops" :~ B).k(~arg: 0) ~raises "not an instance for method call"
-    ("oops" :~ B).kw(~arg: 0) ~raises "not an instance for method call"
-    ("oops" :~ _C).m() ~raises "not an instance for method call"
-    ("oops" :~ _C).f() ~raises "not an instance for method call"
-    ("oops" :~ _C).k(~arg: 0) ~raises "not an instance for method call"
-    ("oops" :~ _C).kw(~arg: 0) ~raises "not an instance for method call"
-    ("oops" :~ J).m() ~raises "not an instance for method call"
-    ("oops" :~ J).f() ~raises "not an instance for method call"
-    ("oops" :~ J).k(~arg: 0) ~raises "not an instance for method call"
-    ("oops" :~ J).kw(~arg: 0) ~raises "not an instance for method call"
-    (C() :~ I).m() ~raises "not an instance for method call"
-    (C() :~ I).f() ~raises "not an instance for method call"
-    (C() :~ I).k(~arg: 0) ~raises "not an instance for method call"
-    (C() :~ I).kw(~arg: 0) ~raises "not an instance for method call"
-    (C() :~ J).m() ~raises "not an instance for method call"
-    (C() :~ J).f() ~raises "not an instance for method call"
-    (C() :~ J).k(~arg: 0) ~raises "not an instance for method call"
-    (C() :~ J).kw(~arg: 0) ~raises "not an instance for method call"
+    ("oops" :~ I).m() ~throws "not an instance for method call"
+    ("oops" :~ I).f() ~throws "not an instance for method call"
+    ("oops" :~ I).k(~arg: 0) ~throws "not an instance for method call"
+    ("oops" :~ I).kw(~arg: 0) ~throws "not an instance for method call"
+    ("oops" :~ B).m() ~throws "not an instance for method call"
+    ("oops" :~ B).f() ~throws "not an instance for method call"
+    ("oops" :~ B).k(~arg: 0) ~throws "not an instance for method call"
+    ("oops" :~ B).kw(~arg: 0) ~throws "not an instance for method call"
+    ("oops" :~ _C).m() ~throws "not an instance for method call"
+    ("oops" :~ _C).f() ~throws "not an instance for method call"
+    ("oops" :~ _C).k(~arg: 0) ~throws "not an instance for method call"
+    ("oops" :~ _C).kw(~arg: 0) ~throws "not an instance for method call"
+    ("oops" :~ J).m() ~throws "not an instance for method call"
+    ("oops" :~ J).f() ~throws "not an instance for method call"
+    ("oops" :~ J).k(~arg: 0) ~throws "not an instance for method call"
+    ("oops" :~ J).kw(~arg: 0) ~throws "not an instance for method call"
+    (C() :~ I).m() ~throws "not an instance for method call"
+    (C() :~ I).f() ~throws "not an instance for method call"
+    (C() :~ I).k(~arg: 0) ~throws "not an instance for method call"
+    (C() :~ I).kw(~arg: 0) ~throws "not an instance for method call"
+    (C() :~ J).m() ~throws "not an instance for method call"
+    (C() :~ J).f() ~throws "not an instance for method call"
+    (C() :~ J).k(~arg: 0) ~throws "not an instance for method call"
+    (C() :~ J).kw(~arg: 0) ~throws "not an instance for method call"
 
 check:
   ~eval
@@ -620,7 +620,7 @@ check:
     implements: A B
     override method m():
       super.m()
-  ~raises "inherited method is ambiguous"
+  ~throws "inherited method is ambiguous"
 
 check:
   // make sure static info works calling a final-ish method

--- a/rhombus/tests/class-namespace.rhm
+++ b/rhombus/tests/class-namespace.rhm
@@ -22,7 +22,7 @@ check:
   class Posn(x, y):
     def x = 10
     export: x
-  ~raises "conflicts with field name"
+  ~throws "conflicts with field name"
 
 check:
   ~eval
@@ -30,7 +30,7 @@ check:
     method dist(): x+y
     def dist = 10
     export: dist
-  ~raises "conflicts with method name"
+  ~throws "conflicts with method name"
 
 check:
   ~eval
@@ -38,4 +38,4 @@ check:
     method zero(): 0
     def zero = 0
     export: zero
-  ~raises "conflicts with method name"
+  ~throws "conflicts with method name"

--- a/rhombus/tests/class-prefab.rhm
+++ b/rhombus/tests/class-prefab.rhm
@@ -22,47 +22,47 @@ block:
     Posn.x(p) ~is 10
     Posn.y(p) ~is 20
     Posn.dist(p) ~is 30
-    Posn.x(p3) ~raises "contract violation"
+    Posn.x(p3) ~throws "contract violation"
     (p :: Posn).x ~is 10
     (p :: Posn).y ~is 20
     Posn(1, 2).m() ~is [1, 2]
     Posn.m(p) ~is [10, 20]
-    Posn.m(p3) ~raises "not an instance for method call"
+    Posn.m(p3) ~throws "not an instance for method call"
     (p :: Posn).m() ~is [10, 20]
-    (p3 :: Posn).m() ~raises "does not satisfy annotation"
+    (p3 :: Posn).m() ~throws "does not satisfy annotation"
     Posn(1, 2) is_a Posn ~is #true
     p is_a Posn ~is #true
     p3 is_a Posn ~is #false
-    (block: use_dynamic; dynamic(Posn(1, 2)).x) ~raises "no such field or method"
-    (block: use_dynamic; dynamic(Posn(1, 2)).m()) ~raises "no such field or method"
+    (block: use_dynamic; dynamic(Posn(1, 2)).x) ~throws "no such field or method"
+    (block: use_dynamic; dynamic(Posn(1, 2)).m()) ~throws "no such field or method"
 
 check:
   ~eval
   class Posn(x, y):
     prefab
     opaque
-  ~raises "prefab class cannot be opaque"
+  ~throws "prefab class cannot be opaque"
 
 check:
   ~eval
   class Posn(x, y):
     opaque
     prefab
-  ~raises "opaque class cannot be prefab"
+  ~throws "opaque class cannot be prefab"
 
 check:
   ~eval
   class Posn(x, y):
     prefab
     method m(): "ok"
-  ~raises "methods in a prefab class must be final"
+  ~throws "methods in a prefab class must be final"
 
 check:
   ~eval
   class Posn(x, y):
     prefab
     property dist: x + y
-  ~raises "methods in a prefab class must be final"
+  ~throws "methods in a prefab class must be final"
 
 check:
   class Posn(x, y):
@@ -79,7 +79,7 @@ check:
   class Posn3D(z):
     extends Posn
     prefab
-  ~raises "superclass must be prefab"
+  ~throws "superclass must be prefab"
 
 
 block:
@@ -114,7 +114,7 @@ block:
   check:
     Posn(1, 2) ~is Posn(1, 2)
     Posn(1, "2") ~is Posn(1, "2")
-    Posn("1", 2) ~raises "value does not satisfy annotation"
+    Posn("1", 2) ~throws "value does not satisfy annotation"
 
   block:
     class Posn3D(z):
@@ -125,7 +125,7 @@ block:
       Posn3D(1, 2, 3) ~is Posn3D(1, 2, 3)
       Posn3D(1, "2", 3) ~is Posn3D(1, "2", 3)
       Posn3D(1, 2, "3") ~is Posn3D(1, 2, "3")
-      Posn3D("1", 2, 3) ~raises "value does not satisfy annotation"
+      Posn3D("1", 2, 3) ~throws "value does not satisfy annotation"
 
   block:
     class Posn3D(z :: Int):
@@ -135,8 +135,8 @@ block:
     check:
       Posn3D(1, 2, 3) ~is Posn3D(1, 2, 3)
       Posn3D(1, "2", 3) ~is Posn3D(1, "2", 3)
-      Posn3D(1, 2, "3") ~raises "value does not satisfy annotation"
-      Posn3D("1", 2, 3) ~raises "value does not satisfy annotation"
+      Posn3D(1, 2, "3") ~throws "value does not satisfy annotation"
+      Posn3D("1", 2, 3) ~throws "value does not satisfy annotation"
 
 block:
   class Posn(x, y):
@@ -151,7 +151,7 @@ block:
       Posn3D(1, 2, 3) ~is Posn3D(1, 2, 3)
       Posn3D("1", 2, 3) ~is Posn3D("1", 2, 3)
       Posn3D(1, "2", 3) ~is Posn3D(1, "2", 3)
-      Posn3D(1, 2, "3") ~raises "value does not satisfy annotation"
+      Posn3D(1, 2, "3") ~throws "value does not satisfy annotation"
 
 check:
   class Posn(x :: Int, y):
@@ -171,5 +171,5 @@ block:
     p ~is_now Posn(1, 2)
     p.x := 10 ~completes
     p ~is_now Posn(10, 2)
-    p.x := "oops" ~raises "does not satisfy annotation"
+    p.x := "oops" ~throws "does not satisfy annotation"
     p ~is_now Posn(10, 2)

--- a/rhombus/tests/class-private-field.rhm
+++ b/rhombus/tests/class-private-field.rhm
@@ -13,7 +13,7 @@ check:
       method get_color():
         color
     Posn(1, 2).color
-  ~raises values("no such field or method", "static")
+  ~throws values("no such field or method", "static")
 
 check:
   ~eval
@@ -22,7 +22,7 @@ check:
       method get_color():
         color
     Posn(1, 2).color
-  ~raises "no such field"
+  ~throws "no such field"
 
 check:
   class Posn(x, y, private color = "blue"):

--- a/rhombus/tests/class-property.rhm
+++ b/rhombus/tests/class-property.rhm
@@ -89,7 +89,7 @@ check:
   class Posn3D(z):
     extends Posn
     override is_origin: #false
-  ~raises "cannot override superclass's property with a non-property method"
+  ~throws "cannot override superclass's property with a non-property method"
 
 check:
   ~eval
@@ -99,7 +99,7 @@ check:
   class Posn3D(z):
     extends Posn
     override is_origin(): #false
-  ~raises "cannot override superclass's property with a non-property method"
+  ~throws "cannot override superclass's property with a non-property method"
 
 check:
   ~eval
@@ -109,7 +109,7 @@ check:
   class Posn3D(z):
     extends Posn
     final override is_origin: #false
-  ~raises "cannot override superclass's property with a non-property method"
+  ~throws "cannot override superclass's property with a non-property method"
 
 check:
   ~eval
@@ -119,7 +119,7 @@ check:
   class Posn3D(z):
     extends Posn
     override property is_origin: #false
-  ~raises "cannot override superclass's non-property method with a property"
+  ~throws "cannot override superclass's non-property method with a property"
 
 block:
   class Posn(x, y):
@@ -154,7 +154,7 @@ check:
     implements Pointy
     override is_origin():
       x == 0 && y == 0
-  ~raises "cannot override interface's property with a non-property method"
+  ~throws "cannot override interface's property with a non-property method"
 
 check:
   ~eval
@@ -164,7 +164,7 @@ check:
     implements Pointy
     override property is_origin:
       x == 0 && y == 0
-  ~raises "cannot override interface's non-property method with a property"
+  ~throws "cannot override interface's non-property method with a property"
 
 check:
   class A():
@@ -194,7 +194,7 @@ check:
     abstract override property m
   class C():
     extends B
-  ~raises "final class cannot have abstract methods"
+  ~throws "final class cannot have abstract methods"
 
 check:
   ~eval
@@ -205,4 +205,4 @@ check:
   class B():
     extends A
     abstract override property m
-  ~raises "final class cannot have abstract methods"
+  ~throws "final class cannot have abstract methods"

--- a/rhombus/tests/class-reconstructor.rhm
+++ b/rhombus/tests/class-reconstructor.rhm
@@ -10,7 +10,7 @@ check:
     constructor (z):
       super(z+1, z-1)
   Posn(0) with (x = 1)
-  ~raises "value does not support functional update"
+  ~throws "value does not support functional update"
 
 block:
   import rhombus/static/meta open
@@ -38,7 +38,7 @@ block:
   check (Posn3D(1, 2, 3) :: Posn) with (x = 10) ~is Posn3D(10, 2, 4)
   block:
     use_dynamic
-    check dynamic(Posn3D(1, 2, 3)) with (w = -1) ~raises "no such reconstructor argument in class"
+    check dynamic(Posn3D(1, 2, 3)) with (w = -1) ~throws "no such reconstructor argument in class"
     check (Posn3D(1, 2, 3) :: Posn) with (z = 30) ~is Posn3D(1, 2, 31)
 
 block:
@@ -60,7 +60,7 @@ check:
   class Posn(x, y):
     nonfinal
   fun (): Posn(1, 2) with (z = 3)
-  ~raises "no such reconstructor argument in class"
+  ~throws "no such reconstructor argument in class"
 
 check:
   ~eval
@@ -106,7 +106,7 @@ check:
   class Posn(x, y):
     reconstructor_fields:
       delta: 0
-  ~raises "reconstructor fields supplied without a reconstructor"
+  ~throws "reconstructor fields supplied without a reconstructor"
 
 check:
   ~eval
@@ -118,7 +118,7 @@ check:
       "oops"
   class Posn3D():
     extends Posn
-  ~raises "superclass requires custom reconstructor"
+  ~throws "superclass requires custom reconstructor"
 
 block:
   class Posn(x, y):

--- a/rhombus/tests/class-together.rhm
+++ b/rhombus/tests/class-together.rhm
@@ -20,15 +20,15 @@ check:
 
 check:
   Foo([1])
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   Bar(1)
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   Foo([Foo([])])
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   class.together:

--- a/rhombus/tests/class.rhm
+++ b/rhombus/tests/class.rhm
@@ -22,18 +22,18 @@ check:
   class Posn(x, y)
   class Posn3D(z):
     extends Posn
-  ~raises "superclass is final"
+  ~throws "superclass is final"
 
 check:
   ~eval
   class Posn(x, x)
-  ~raises "duplicate field name"
+  ~throws "duplicate field name"
 
 check:
   ~eval
   class Posn(x, y):
     field x = 0
-  ~raises "duplicate field name"
+  ~throws "duplicate field name"
 
 check:
   ~eval
@@ -41,7 +41,7 @@ check:
     nonfinal
   class Posn3D(x):
     extends Posn
-  ~raises "field name already exists in superclass"
+  ~throws "field name already exists in superclass"
 
 block:
   class Posn(~x, y)
@@ -385,7 +385,7 @@ check:
 check:
   ~eval
   class Posn(x = 0, y)
-  ~raises "without default after"
+  ~throws "without default after"
 
 check:
   ~eval
@@ -393,13 +393,13 @@ check:
     nonfinal
   class Posn3D(z):
     extends Posn
-  ~raises "field needs a default"
+  ~throws "field needs a default"
 
 check:
   ~eval
   class Posn(x, y = no_such_variable)
   Posn(1)
-  ~raises "no_such_variable: undefined"
+  ~throws "no_such_variable: undefined"
 
 check:
   ~eval
@@ -408,17 +408,17 @@ check:
   class Posn3D(z = the_y):
     extends Posn
   Posn3D(0)
-  ~raises "the_y: undefined"
+  ~throws "the_y: undefined"
 
 check:
   class Posn(x :: Int, y :: Int)
   Posn("x", 0)
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 block:
   class Posn(mutable x :: Int, y :: Int)
   check:
-    Posn("x", 0) ~raises "value does not satisfy annotation"
+    Posn("x", 0) ~throws "value does not satisfy annotation"
     Posn(1, 2) == Posn(1, 2) ~is #false
     Posn(1, 2) != Posn(1, 2) ~is #true
     Posn(1, 2) is_now Posn(1, 2) ~is #true
@@ -443,7 +443,7 @@ check:
 check:
   class Posn(mutable x :: Int, y :: Int)
   Posn("x", 0).x := "oops"
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   import rhombus/meta open
@@ -671,7 +671,7 @@ block:
     extends Posn
   check:
     Posn3D(1, 2, "x")
-    ~raises "annotation"
+    ~throws "annotation"
   check:
     Posn3D("1", "2", 3)
     ~is Posn3D("1", "2", 3)
@@ -729,21 +729,21 @@ check:
     property | me2 :: CPosn: this
              | me2 := other: "no"
   (CPosn(1, 2).me2 := 10).x
-  ~raises values("no such field or method", "static")
+  ~throws values("no such field or method", "static")
 
 check:
   ~eval
   class Posn(x, y):
     annotation 'Posn':
       1
-  ~raises "result must be a template expression"
+  ~throws "result must be a template expression"
 
 check:
   ~eval
   class Posn(x, y):
     dot '$left . sevens':
       '77'
-  ~raises "dot: unbound"
+  ~throws "dot: unbound"
 
 check:
   import rhombus/meta open
@@ -776,19 +776,19 @@ block:
     Posn.a(Posn(1, 2)) + 10 ~is 13
     Posn.w(Posn(1, 2)) + 10 ~is 24
     Posn.a(8) + 100 ~is 103
-    Posn.aa(8) ~raises "not an instance"
+    Posn.aa(8) ~throws "not an instance"
   check:
     use_dynamic
     Posn(1, 2).bananas + 10
-    ~raises "no such field or method"
+    ~throws "no such field or method"
   check:
     use_dynamic
     dynamic(Posn(1, 2)).a + 10
-    ~raises "dynamic use of dot syntax"
+    ~throws "dynamic use of dot syntax"
   check:
     use_dynamic
     dynamic(Posn3D(1, 2, 3)).w + 10
-    ~raises "dynamic use of dot syntax"
+    ~throws "dynamic use of dot syntax"
 
 block:
   import rhombus/meta open
@@ -813,7 +813,7 @@ check:
   class Posn(x, y):
     dot '$left . x':
       '77'
-  ~raises "identifier used as both a field name and dot-syntax name"
+  ~throws "identifier used as both a field name and dot-syntax name"
 
 check:
   ~eval
@@ -822,7 +822,7 @@ check:
     method sevens(): 777
     dot '$left . sevens':
       '77'
-  ~raises "identifier used as both a dot-syntax name and method name"
+  ~throws "identifier used as both a dot-syntax name and method name"
 
 check:
   ~eval
@@ -834,7 +834,7 @@ check:
   class Posn3D(z):
     extends Posn
     method sevens(): 777
-  ~raises "method name is supplied as dot syntax by superclass"
+  ~throws "method name is supplied as dot syntax by superclass"
 
 check:
   ~eval
@@ -845,7 +845,7 @@ check:
       '77'
   class Posn3D(sevens):
     extends Posn
-  ~raises "field name already in superclass as dot syntax"
+  ~throws "field name already in superclass as dot syntax"
 
 block:
   import lib("racket/base.rkt")
@@ -917,4 +917,4 @@ check:
   use_static
   class Pack(mutable vs :: List.of(Int))
   Pack.vs(1, 2, 3)
-  ~raises "wrong number of arguments in function call (based on static information)"
+  ~throws "wrong number of arguments in function call (based on static information)"

--- a/rhombus/tests/def.rhm
+++ b/rhombus/tests/def.rhm
@@ -30,9 +30,9 @@ check:
 check:
   ~eval
   def x where x = 1 = 2
-  ~raises "multiple immediate equals not allowed in this group"
+  ~throws "multiple immediate equals not allowed in this group"
 
 check:
   ~eval
   def | x = 2
-  ~raises "alternatives are not supported here"
+  ~throws "alternatives are not supported here"

--- a/rhombus/tests/defn-macro.rhm
+++ b/rhombus/tests/defn-macro.rhm
@@ -43,7 +43,7 @@ check:
   block:
     empty_import
     "ok"
-  ~raises "misuse as an expression"
+  ~throws "misuse as an expression"
 
 // definition-sequence macros
 defn.sequence_macro 'reverse_defns; $defn1 ...; $defn2 ...; $tail; ...':

--- a/rhombus/tests/equality-map-set.rhm
+++ b/rhombus/tests/equality-map-set.rhm
@@ -62,7 +62,7 @@ check:
 
 check:
   {mcons(1, 2): 3}[mcons(1, 2)]
-  ~raises "Map.get: no value found for key"
+  ~throws "Map.get: no value found for key"
 
 block:
   def a = mcons(1, 2)

--- a/rhombus/tests/equatable.rhm
+++ b/rhombus/tests/equatable.rhm
@@ -21,11 +21,11 @@ check AnythingGoes() == AnythingGoes() ~is #true
 check:
   use_dynamic
   AnythingGoes().equals(AnythingGoes(), fun (& _): #true)
-  ~raises "equals: no such field or method"
+  ~throws "equals: no such field or method"
 check:
   use_dynamic
   AnythingGoes().hash_code(fun (_): 0)
-  ~raises "hash_code: no such field or method"
+  ~throws "hash_code: no such field or method"
 
 check AnythingGoes() == NoGo() ~is #false
 check NoGo() == AnythingGoes()  ~is #false
@@ -39,7 +39,7 @@ check AnythingGoes() == Fail() ~is #false
 check Fail() == AnythingGoes() ~is #false
 check NoGo() == Fail() ~is #false
 check Fail() == NoGo() ~is #false
-check Fail() == Fail() ~raises "failure"
+check Fail() == Fail() ~throws "failure"
 block:
   let f: Fail()
   check f == f ~is #true

--- a/rhombus/tests/exn.rhm
+++ b/rhombus/tests/exn.rhm
@@ -48,18 +48,18 @@ block:
 
 check:
   error(#'example, "~a oops")
-  ~raises "~a oops"
+  ~throws "~a oops"
 
 block:
   check:
     error("who-str", "message")
-    ~raises values("who-str: ", "message")
+    ~throws values("who-str: ", "message")
   check:
     error(#'who_sym, "message")
-    ~raises values("who_sym: ", "message")
+    ~throws values("who_sym: ", "message")
   check:
     error(Syntax.make(#'who_id), "message")
-    ~raises values("who_id: ", "message")
+    ~throws values("who_id: ", "message")
   check:
     error(Syntax.make_op(#'who_op), "message")
-    ~raises values("who_op: ", "message")
+    ~throws values("who_op: ", "message")

--- a/rhombus/tests/export-module.rhm
+++ b/rhombus/tests/export-module.rhm
@@ -30,13 +30,13 @@ check:
   ~eval
   import lib("rhombus/tests/export-module.rhm")!annot
   annot.exint
-  ~raises "no such imported identifier"
+  ~throws "no such imported identifier"
 
 check:
   ~eval
   import lib("rhombus/tests/export-module.rhm")!expr
   1 :: expr.exint
-  ~raises "not bound as an annotation"
+  ~throws "not bound as an annotation"
 
 module ~early both ~lang rhombus/and_meta:
   namespace n:
@@ -77,4 +77,4 @@ check:
   ~eval
   import lib("rhombus/tests/export-module.rhm")!expr_via_reexport
   1 :: expr_via_reexport.exint
-  ~raises "not bound as an annotation"
+  ~throws "not bound as an annotation"

--- a/rhombus/tests/export-namespace.rhm
+++ b/rhombus/tests/export-namespace.rhm
@@ -51,7 +51,7 @@ check:
       only_space annot:
         exint
   n.exint
-  ~raises "identifier not provided"
+  ~throws "identifier not provided"
 
 check:
   ~eval
@@ -62,7 +62,7 @@ check:
       only_space expr:
         exint
   1 :: n.exint
-  ~raises "identifier not provided"
+  ~throws "identifier not provided"
 
 check:
   ~eval
@@ -73,7 +73,7 @@ check:
       only_space expr:
         except_space expr:
           exint
-  ~raises "space excluded in nested modification"
+  ~throws "space excluded in nested modification"
 
 check:
   ~eval
@@ -84,7 +84,7 @@ check:
       except_space expr:
         only_space annot:
           exint
-  ~raises "space not included in nested modification"
+  ~throws "space not included in nested modification"
 
 check:
   namespace ns:
@@ -109,7 +109,7 @@ check:
     def z = 200
     export all_defined
   ns.x
-  ~raises "identifier not provided by ns"
+  ~throws "identifier not provided by ns"
 
 block:
   import "example-d.rhm" as d
@@ -123,7 +123,7 @@ check:
   ~eval
   import lib("rhombus/tests/example-d.rhm") as d
   d.two
-  ~raises "no such imported identifier"
+  ~throws "no such imported identifier"
 
 block:
   def thing = 1
@@ -206,4 +206,4 @@ check:
         except_space annot:
           thing
     "ok"
-  ~raises "duplicate export name with different bindings"
+  ~throws "duplicate export name with different bindings"

--- a/rhombus/tests/expr-macro.rhm
+++ b/rhombus/tests/expr-macro.rhm
@@ -228,21 +228,21 @@ check:
   macro
   | 'prefix': 'ok'
   | 'preeefix': 'oops'
-  ~raises "case operator does not match the initial case operator"
+  ~throws "case operator does not match the initial case operator"
 
 check:
   ~eval
   macro prefix
   | 'prefix': 'ok'
   | 'preeefix': 'oops'
-  ~raises "case operator does not match the declared operator"
+  ~throws "case operator does not match the declared operator"
 
 check:
   ~eval
   macro prefix:
     ~associativity: ~left
   | 'prefix': 'ok'
-  ~raises "associativity specified without infix cases"
+  ~throws "associativity specified without infix cases"
 
 check:
   def f = (macro '() $x':
@@ -257,7 +257,7 @@ check:
   (macro '() $x':
      ~weaker_than: +
      '$x')
-  ~raises "unexpected term"
+  ~throws "unexpected term"
 
 check:
   expr.macro 'two_of $(n :: Name)':

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -220,7 +220,7 @@ check:
   for Array ~length 2:
     each i: 3..7
     i
-  ~raises "index is out of range"
+  ~throws "index is out of range"
 
 check:
   def mutable accum = []
@@ -274,7 +274,7 @@ check:
   for:
     each x: dynamic([1])
     x
-  ~raises "no specific iteration implementation available"
+  ~throws "no specific iteration implementation available"
 
 check:
   for Set:
@@ -337,42 +337,42 @@ check:
   use_static
   for ((key, val): ([Box(1), Box(2), Box(3)] :: List.of(Box))):
     key.value
-  ~raises "no such field or method (based on static information)"
+  ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
   for ((key, val): ([Box(1), Box(2), Box(3)] :: List.of(Box))):
     val.value
-  ~raises "no such field or method (based on static information)"
+  ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
   for ((key, val): ({Box(1), Box(2), Box(3)} :: Set.of(Box))):
     key.value
-  ~raises "no such field or method (based on static information)"
+  ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
   for ((key, val): ({Box(1), Box(2), Box(3)} :: Set.of(Box))):
     val.value
-  ~raises "no such field or method (based on static information)"
+  ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
   for (val: ({Box(1): "1", Box(2): "2", Box(3): "3"} :: Map.of(Box, String))):
     val.value
-  ~raises "no such field or method (based on static information)"
+  ~throws "no such field or method (based on static information)"
 
 check:
   ~eval
   use_static
   for (val: ({Box(1): "1", Box(2): "2", Box(3): "3"} :: Map.of(Box, String))):
     val.length()
-  ~raises "no such field or method (based on static information)"
+  ~throws "no such field or method (based on static information)"
 
 // check `let` across clause boundary
 check:

--- a/rhombus/tests/fun.rhm
+++ b/rhombus/tests/fun.rhm
@@ -44,7 +44,7 @@ block:
     ~is 101
   check:
     add1("oops")
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "Int",
     )
@@ -98,7 +98,7 @@ fun size2 :: Int:
 check:
   size2(10) ~is 10
   size2(Posn(1, 2)) ~is 3
-  size2("wrong") ~raises "does not satisfy annotation"
+  size2("wrong") ~throws "does not satisfy annotation"
 
 block:
   use_static
@@ -154,7 +154,7 @@ block:
       values(0, "oops")
     def (x, y) = f()
     10
-    ~raises values(
+    ~throws values(
       "results do not satisfy annotation",
       "(Int, Int)"
     )
@@ -162,7 +162,7 @@ block:
     fun f() :: (Int, Int):
       0
     f()
-    ~raises values(
+    ~throws values(
       "result does not satisfy annotation",
       "(Int, Int)"
     )
@@ -170,7 +170,7 @@ block:
     fun f() :: Int:
       values(0, "oops")
     f()
-    ~raises values(
+    ~throws values(
       "results do not satisfy annotation",
       "Int"
     )
@@ -186,13 +186,13 @@ block:
       def x = f()
       def (a, b) = x
       b[0]
-    ~raises "specialization not known"
+    ~throws "specialization not known"
 
 check:
   ~eval
   fun f(x = "hello" :: String):
     "ok"
-  ~raises "immediate annotation operator not allowed in default-value expression"
+  ~throws "immediate annotation operator not allowed in default-value expression"
 
 check:
   use_static
@@ -207,7 +207,7 @@ check:
 check:
   ~eval
   fun (x where x = 1 = 2): 10
-  ~raises "multiple immediate equals not allowed in this group"
+  ~throws "multiple immediate equals not allowed in this group"
 
 // check generation of function calls
 block:

--- a/rhombus/tests/function-arity.rhm
+++ b/rhombus/tests/function-arity.rhm
@@ -14,71 +14,71 @@ defn.macro 'static $check: $form; ...; $raises $msg':
 static check:
   fun f(x): x
   fun (): f()
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   fun f(x): x
   fun (): f(1, 2)
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   fun f(x): x
   fun (): f(1, ~flavor: "vanilla")
-  ~raises "keyword argument not recognized"
+  ~throws "keyword argument not recognized"
 
 static check:
   fun f(x, ~flavor): x
   fun (): f(1)
-  ~raises "missing keyword argument in function call"
+  ~throws "missing keyword argument in function call"
 
 static check:
   fun f(x, & y): x
   fun (): f()
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   fun f(x, ~flavor, ~& kws): x
   fun (): f(1, ~color: "red")
-  ~raises "missing keyword argument in function call"
+  ~throws "missing keyword argument in function call"
 
 static check:
   class Posn(x, y):
     method m(): x
   fun (): Posn.m()
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   class Posn(x, y):
     nonfinal
     method m(): x
   fun (): Posn.m()
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   class Posn(x, y):
     nonfinal
     method m(): x
   fun (): Posn.m(1, 2)
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   class Posn(x, y):
     method m(): x
   fun (): Posn(1, 2).m(0)
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   class Posn(x, y):
     method m(): x
     method n(): m(1)
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
   
 static check:
   class Posn(x, y):
     nonfinal
     method m(): x
   fun (): Posn(1, 2).m(0)
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   class Posn(x, y):
@@ -87,13 +87,13 @@ static check:
   class Posn3D(z):
     extends Posn
   fun (): Posn3D(1, 2, 3).m(0)
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   interface Pointy:
     method m(): 0
     method n(): m(1)
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   interface Pointy:
@@ -101,40 +101,40 @@ static check:
   class Posn(x, y):
     implements Pointy
   fun (): Posn(1, 2).m(0)
-  ~raises "wrong number of arguments"
+  ~throws "wrong number of arguments"
 
 static check:
   class Posn(x, y):
     property | p: 10
   fun (): Posn(1, 2).p := 11
-  ~raises "property does not support assignment"
+  ~throws "property does not support assignment"
   
 static check:
   class Posn(x, y):
     property | p: 10
   fun (): Posn.p(Posn(1, 2), 11)
-  ~raises "wrong number of arguments in function call"
+  ~throws "wrong number of arguments in function call"
 
 check:
   ~eval
   class Posn(x, y):
     property | p: 10
     method m(): p := 11
-  ~raises "property does not support assignment"
+  ~throws "property does not support assignment"
   
 static check:
   class Posn(x, y):
     nonfinal
     property | p: 10
   fun (): Posn(1, 2).p := 11
-  ~raises "property does not support assignment"
+  ~throws "property does not support assignment"
   
 static check:
   class Posn(x, y):
     nonfinal
     property | p: 10
   fun (): Posn.p(Posn(1, 2), 11)
-  ~raises "wrong number of arguments in function call"
+  ~throws "wrong number of arguments in function call"
 
 static check:
   class Posn(x, y):
@@ -143,7 +143,7 @@ static check:
   class Posn3D(z):
     extends Posn
     method n(): super.m(1)
-  ~raises "wrong number of arguments in method call"
+  ~throws "wrong number of arguments in method call"
 
 static check:
   class Posn(x, y):
@@ -152,7 +152,7 @@ static check:
   class Posn3D(z):
     extends Posn
     method n(): super.p := 1
-  ~raises "property does not support assignment"
+  ~throws "property does not support assignment"
 
 static check:
   class Posn(x, y):
@@ -162,11 +162,11 @@ static check:
     extends Posn
     nonfinal
     method n(): this.p := 1
-  ~raises "property does not support assignment"
+  ~throws "property does not support assignment"
 
 static check:
   class Posn(x, y):
     constructor (z):
       super(z+1, z-1)
   fun (): Posn(1, 2)
-  ~raises "wrong number of arguments in function call"
+  ~throws "wrong number of arguments in function call"

--- a/rhombus/tests/import-local.rhm
+++ b/rhombus/tests/import-local.rhm
@@ -24,7 +24,7 @@ block:
     ~is [1, 2, 3]
   check:
     ([1, 2, 3] :: ex_a.ExList.of(String))
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
 
 block:
   import:
@@ -50,7 +50,7 @@ block:
     ~is [1, 2, 3]
   check:
     ([1, 2, 3] :: ExList.of(String))
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
 
 block:
   import:
@@ -70,7 +70,7 @@ block:
     ~is [1, 2, 3]
   check:
     ([1, 2, 3] :: ExList.of(String))
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
 
 block:
   import:
@@ -87,7 +87,7 @@ block:
     ~is [1, 2, 3]
   check:
     ([1, 2, 3] :: ExList.of(String))
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
 
 block:
   import:
@@ -97,7 +97,7 @@ block:
     ~is [1, 2, 3]
   check:
     ([1, 2, 3] :: of(String))
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
 
 block:
   import:
@@ -114,5 +114,5 @@ block:
     ~is [1, 2, 3]
   check:
     ([1, 2, 3] :: XList.of(String))
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
 

--- a/rhombus/tests/import-module.rhm
+++ b/rhombus/tests/import-module.rhm
@@ -23,12 +23,12 @@ check:
 check:
   import: lib("rhombus/tests/example-c.rhm") as ex_c
   def ex_c.exint = "10"
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   import: lib("rhombus/tests/example-c.rhm") as ex_c
   "10" :: ex_c.exint
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   import: lib("rhombus/tests/example-c.rhm") open
@@ -101,7 +101,7 @@ check:
         open
         only_space: expr
     10 :: exint
-  ~raises "not bound as an annotation"
+  ~throws "not bound as an annotation"
 
 check:
   ~eval
@@ -111,7 +111,7 @@ check:
       lib("rhombus/tests/example-c.rhm") as ex_c:
         only_space: expr
     10 :: ex_c.exint
-  ~raises "not bound as an annotation"
+  ~throws "not bound as an annotation"
 
 check:
   import:

--- a/rhombus/tests/import-namespace.rhm
+++ b/rhombus/tests/import-namespace.rhm
@@ -27,12 +27,12 @@ check:
 check:
   import: .n as ex_c
   def ex_c.exint = "10"
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   import: .n as ex_c
   "10" :: ex_c.exint
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   import: .n open
@@ -99,7 +99,7 @@ check:
         open
         only_space: expr
     10 :: exint
-  ~raises "not bound as an annotation"
+  ~throws "not bound as an annotation"
 
 check:
   ~eval
@@ -114,7 +114,7 @@ check:
       .n as ex_c:
         only_space: expr
     10 :: ex_c.exint
-  ~raises "identifier not provided"
+  ~throws "identifier not provided"
 
 check:
   import:
@@ -160,11 +160,11 @@ block:
   check:
     import .n2 as ex_c
     def ex_c.exint = -10
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
   check:
     import .n2 open
     def exint = -10
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
 
 check:
   namespace ns:

--- a/rhombus/tests/import-singleton.rhm
+++ b/rhombus/tests/import-singleton.rhm
@@ -13,7 +13,7 @@ check:
       export: exint
       def exint = 10  
     import: .n.exint meta
-  ~raises "cannot shift phase of namespace content"
+  ~throws "cannot shift phase of namespace content"
 
 check:
   ~eval
@@ -23,7 +23,7 @@ check:
       def exint = 10  
     import: .n.exint:
               except: exint
-  ~raises "identifier to exclude is not nested within the imported name"
+  ~throws "identifier to exclude is not nested within the imported name"
 
 check:
   import: .n.exint
@@ -42,12 +42,12 @@ check:
 check:
   import: .n.exint
   def exint = "10"
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   import: .n.exint
   "10" :: exint
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   import: .n:
@@ -92,7 +92,7 @@ check:
       .n.exint:
         only_space: expr
     10 :: exint
-  ~raises "not bound as an annotation"
+  ~throws "not bound as an annotation"
 
 check:
   import:

--- a/rhombus/tests/import.rhm
+++ b/rhombus/tests/import.rhm
@@ -18,7 +18,7 @@ check:
   import: lib("rhombus/tests/example-a.rhm") as ex_a:
             expose: beta
   alpha
-  ~raises "alpha: undefined"
+  ~throws "alpha: undefined"
 
 check:
   ~eval
@@ -39,7 +39,7 @@ check:
   ~eval
   import: lib("rhombus/tests/example-a.rhm").ExList open
   for ExList: "oops, no ExList"
-  ~raises "expected reducer"
+  ~throws "expected reducer"
 
 check:
   ~eval
@@ -51,7 +51,7 @@ check:
   ~eval
   import: lib("rhombus/tests/example-a.rhm") open
   ex_a.alpha
-  ~raises "ex_a: undefined"
+  ~throws "ex_a: undefined"
 
 check:
   ~eval
@@ -121,20 +121,20 @@ check:
   ~eval
   import: lib("rhombus/tests/example-a.rhm").alpha open
   alpha
-  ~raises"cannot open binding"
+  ~throws"cannot open binding"
 
 check:
   ~eval
   import: lib("rhombus/tests/example-a.rhm").alpha:
            except: other
   "does not get here"
-  ~raises "identifier to exclude is not nested within the imported name"
+  ~throws "identifier to exclude is not nested within the imported name"
 
 check:
   ~eval
   import: lib("rhombus/tests/example-a.rhm").alpha
   beta
-  ~raises "beta: undefined"
+  ~throws "beta: undefined"
 
 // This test assumes too much about the implementation of `Pair`
 #//

--- a/rhombus/tests/indexable.rhm
+++ b/rhombus/tests/indexable.rhm
@@ -62,7 +62,7 @@ check:
   C()[4].v ~is 4
   A2()[3].v ~is 3
   A2()["good"] := #'ok ~is #void
-  A2()["bad"] := #'no ~raises values(
+  A2()["bad"] := #'no ~throws values(
     "result does not satisfy annotation",
     "Void",
   )

--- a/rhombus/tests/interface.rhm
+++ b/rhombus/tests/interface.rhm
@@ -56,7 +56,7 @@ check:
   class LoneRanger():
     implements Shape
     implements Cowboy
-  ~raises "method supplied by multiple superinterfaces"
+  ~throws "method supplied by multiple superinterfaces"
 
 // conflict resolved
 check:
@@ -148,7 +148,7 @@ check:
       private implements Adder
       private override total(): x
     Sum(20).total
-  ~raises "no such field"
+  ~throws "no such field"
 
 check:
   ~eval
@@ -160,7 +160,7 @@ check:
       private implements Adder
       private override total(): x
     Sum(20).total
-  ~raises values("no such field or method", "static")
+  ~throws values("no such field or method", "static")
 
 // implement an interface both privately and publicly => public
 check:
@@ -192,7 +192,7 @@ check:
   def m = MilkShed()
   check:
     (m :~ Stool).seat()
-    ~raises "Stool"
+    ~throws "Stool"
   [m is_a Stool,
    m is_a _Stool,
    m is_a Cow,
@@ -267,7 +267,7 @@ check:
     extends A
   class C1():
     implements: A B
-  ~raises "method supplied by multiple superinterfaces and not overridden"
+  ~throws "method supplied by multiple superinterfaces and not overridden"
 check:
   ~eval
   interface A:
@@ -276,7 +276,7 @@ check:
     method m(): 1    
   class C1():
     implements: B A
-  ~raises "method supplied by multiple superinterfaces and not overridden"
+  ~throws "method supplied by multiple superinterfaces and not overridden"
 check:
   ~eval
   interface A:
@@ -287,7 +287,7 @@ check:
   class C2():
     extends C1
     implements: A
-  ~raises "method supplied by multiple classes or superinterfaces and not overridden"
+  ~throws "method supplied by multiple classes or superinterfaces and not overridden"
 check:
   ~eval
   interface A:
@@ -298,7 +298,7 @@ check:
   class C2():
     extends C1
     implements: A
-  ~raises "method supplied by multiple classes or superinterfaces and not overridden"
+  ~throws "method supplied by multiple classes or superinterfaces and not overridden"
 
 block:
   import rhombus/meta open
@@ -313,7 +313,7 @@ block:
   check:
     use_dynamic
     dynamic(Posn(1, 2)).sevens
-    ~raises "dynamic use of dot syntax"
+    ~throws "dynamic use of dot syntax"
 
 check:
   ~eval
@@ -323,7 +323,7 @@ check:
       '77'
   class Posn(sevens):
     implements Point
-  ~raises "field name already in interface as dot syntax"
+  ~throws "field name already in interface as dot syntax"
 
 check:
   ~eval
@@ -336,7 +336,7 @@ check:
       '#false'
   class O():
     implements: A B
-  ~raises "dot syntax supplied by multiple superinterfaces"
+  ~throws "dot syntax supplied by multiple superinterfaces"
 
 check:
   ~eval
@@ -351,7 +351,7 @@ check:
   class O():
     implements A
     extends B
-  ~raises "dot syntax supplied by multiple classes or superinterfaces"
+  ~throws "dot syntax supplied by multiple classes or superinterfaces"
 
 check:
   ~eval
@@ -364,7 +364,7 @@ check:
       #false
   class O():
     implements: A B
-  ~raises "name supplied as both method and dot syntax by superinterfaces"
+  ~throws "name supplied as both method and dot syntax by superinterfaces"
 
 check:
   ~eval
@@ -379,4 +379,4 @@ check:
   class O():
     implements A
     extends B
-  ~raises "name supplied as both method and dot syntax by classes or superinterfaces"
+  ~throws "name supplied as both method and dot syntax by classes or superinterfaces"

--- a/rhombus/tests/list.rhm
+++ b/rhombus/tests/list.rhm
@@ -19,7 +19,7 @@ check:
 
 check:
   List.length({1, 2, 3})
-  ~raises values("contract violation", "expected: List")
+  ~throws values("contract violation", "expected: List")
 
 check:
   [1] :: NonemptyList
@@ -27,7 +27,7 @@ check:
 
 check:
   [] :: NonemptyList
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 block:
   use_static
@@ -88,25 +88,25 @@ block:
 block:
   check:
     1 :: List
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: List.of(Any)
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: List.of(converting(fun (_): #false))
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     [1, 2, 3] :: List.of(converting(fun (n :: Int): n+1))
     ~is [2, 3, 4]
   check:
     1 :: NonemptyList
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: NonemptyList.of(Any)
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: NonemptyList.of(converting(fun (_): #false))
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     [1, 2, 3] :: NonemptyList.of(converting(fun (n :: Int): n+1))
     ~is [2, 3, 4]
@@ -154,7 +154,7 @@ check:
   [1, 2].append() ~is [1, 2]
   [1, 2].append([3]) ~is [1, 2, 3]
   [1, 2].append([3], [4, 5]) ~is [1, 2, 3, 4, 5]
-  [1, 2].append(3) ~raises "contract violation"
+  [1, 2].append(3) ~throws "contract violation"
 
 check:
   match []

--- a/rhombus/tests/map.rhm
+++ b/rhombus/tests/map.rhm
@@ -22,7 +22,7 @@ check:
 
 check:
   Map.length({1, 2, 3})
-  ~raises values("contract violation", "expected: ReadableMap")
+  ~throws values("contract violation", "expected: ReadableMap")
 
 block:
   use_static
@@ -66,16 +66,16 @@ block:
 block:
   check:
     1 :: Map
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: Map.of(Any, Any)
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: Map.of(
       converting(fun (_): #false),
       converting(fun (_): #false)
     )
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     {1: 2, 2: 3, 3: 4} :: Map.of(
       converting(fun (n :: Int): n+1),
@@ -121,7 +121,7 @@ block:
          [3, [2, [1, []]]]]
   check:
     {&"oops"}
-    ~raises "not an immutable map"
+    ~throws "not an immutable map"
 
 block:
   def [x, ...] = [1, 2, 3]
@@ -200,8 +200,8 @@ block:
     use_dynamic
     check dynamic({1: "a", 2: "b"}).remove(1) ~is {2: "b"}
     check dynamic({1: "a", 2: "b"}).remove(3) ~is {1: "a", 2: "b"}
-    check MutableMap{1: "a", 2: "b"}.remove ~raises "no such field or method"
-    check MutableMap{1: "a", 2: "b"}.remove(1) ~raises "no such field or method"
+    check MutableMap{1: "a", 2: "b"}.remove ~throws "no such field or method"
+    check MutableMap{1: "a", 2: "b"}.remove(1) ~throws "no such field or method"
     
 block:
   use_static
@@ -222,8 +222,8 @@ block:
     use_dynamic
     check dynamic(m).delete(1) ~is #void
     check m ~is_now MutableMap{2: "b"}
-    check {1: "a", 2: "b"}.delete ~raises "no such field or method"
-    check {1: "a", 2: "b"}.delete(1) ~raises "no such field or method"
+    check {1: "a", 2: "b"}.delete ~throws "no such field or method"
+    check {1: "a", 2: "b"}.delete(1) ~throws "no such field or method"
 
 block:
   let m = MutableMap{1: "a", 2: "b"}
@@ -264,4 +264,4 @@ check:
     {#'foo: "foo", 1: "1", Box(2): "Box(2)"}
   for ((key, val): map):
     println(key.length() + val.length())
-  ~raises "no such field or method (based on static information)"
+  ~throws "no such field or method (based on static information)"

--- a/rhombus/tests/match.rhm
+++ b/rhombus/tests/match.rhm
@@ -43,6 +43,6 @@ block:
 
 check (match 1 | 1 || 2: "yes") ~is "yes"
 check (match 2 | 1 || 2: "yes") ~is "yes"
-check (match 3 | 1 || 2: "yes") ~raises "no matching case"
+check (match 3 | 1 || 2: "yes") ~throws "no matching case"
 
-check ( match 'ok (1)' | '«ok '$x'»': "ok") ~raises "expected quotes"
+check ( match 'ok (1)' | '«ok '$x'»': "ok") ~throws "expected quotes"

--- a/rhombus/tests/module-path-error.rhm
+++ b/rhombus/tests/module-path-error.rhm
@@ -13,7 +13,7 @@ parameterize { racket.#{error-print-source-location}: #true }:
       import:
         self!nested1 open
         self!nested2 open
-    ~raises values("identifier already required",
+    ~throws values("identifier already required",
                    "self!nested1",
                    "self!nested2")
 
@@ -28,7 +28,7 @@ parameterize { racket.#{error-print-source-location}: #true }:
         import:
           parent!nested1 open
           parent!nested2 open
-    ~raises values("identifier already required",
+    ~throws values("identifier already required",
                    "parent!nested1",
                    "parent!nested2")
 
@@ -44,7 +44,7 @@ parameterize { racket.#{error-print-source-location}: #true }:
           import:
             parent ! ! nested1 open
             parent ! ! nested2 open
-    ~raises values("identifier already required",
+    ~throws values("identifier already required",
                    "parent ! ! nested1",
                    "parent ! ! nested2")
 
@@ -55,6 +55,6 @@ parameterize { racket.#{error-print-source-location}: #true }:
       import:
         "example-e.rhm"!nested open
         file("example-e.rhm") open
-    ~raises values("identifier already required",
+    ~throws values("identifier already required",
                    "\"example-e.rhm\"!nested",
                    "file(\"example-e.rhm\")")

--- a/rhombus/tests/mutable.rhm
+++ b/rhombus/tests/mutable.rhm
@@ -35,7 +35,7 @@ block:
   def mutable p :: Posn = Posn(1, 2)
   check:
     p.x ~is 1
-    p := 100 ~raises "value does not satisfy annotation"
+    p := 100 ~throws "value does not satisfy annotation"
     p.x ~is 1
     p := Posn(4, 5) ~completes
     p.x ~is 4
@@ -48,12 +48,12 @@ block:
     p.x ~is 1
     p := 100 ~completes
     p ~is 100
-    p.x ~raises "contract violation"
+    p.x ~throws "contract violation"
 
 block:
   def mutable i :: Int = 10
   check:
-    i := "no" ~raises "value does not satisfy annotation"
+    i := "no" ~throws "value does not satisfy annotation"
     i ~is 10
     i := 11 ~completes
     i ~is 11
@@ -62,7 +62,7 @@ block:
   import lib("racket/base.rkt")
   def mutable str :: ReadableString.to_string = "apple"
   check:
-    str := 10 ~raises "value does not satisfy annotation"
+    str := 10 ~throws "value does not satisfy annotation"
     str ~is "apple"
     str := base.#{string-copy}("banana") ~completes
     str ~is "banana"

--- a/rhombus/tests/namespace-extend.rhm
+++ b/rhombus/tests/namespace-extend.rhm
@@ -182,7 +182,7 @@ check:
     namespace N
     import: .N as n
     n.y
-  ~raises "identifier not provided"
+  ~throws "identifier not provided"
 
 // Same, for macro
 check:
@@ -194,7 +194,7 @@ check:
     namespace N
     import: .N as n
     n.z 0
-  ~raises "identifier not provided"
+  ~throws "identifier not provided"
 
 //No shadowing => extension is visible
 check:

--- a/rhombus/tests/namespace.rhm
+++ b/rhombus/tests/namespace.rhm
@@ -103,7 +103,7 @@ check:
     export:
       nonesuch
   nonesuch
-  ~raises "undefined"
+  ~throws "undefined"
 
 check:
   import rhombus/meta open

--- a/rhombus/tests/operator.rhm
+++ b/rhombus/tests/operator.rhm
@@ -109,7 +109,7 @@ block:
   check:
     ** 10 ~is "10"
     ** "apple" ~is "apple"
-    ** #'sym ~raises "no matching case for arguments"
+    ** #'sym ~throws "no matching case for arguments"
 
 // multi-case infix operator
 block:
@@ -120,7 +120,7 @@ block:
   check:
     1 ** 10 ~is 10
     0 ** "apple" ~is 0
-    2 ** 10 ~raises "no matching case for arguments"
+    2 ** 10 ~throws "no matching case for arguments"
 
 // multi-case prefix and infix
 block:
@@ -133,10 +133,10 @@ block:
   check:
     ** 10 ~is "10"
     ** "apple" ~is "apple"
-    ** #'sym ~raises "no matching case for arguments"
+    ** #'sym ~throws "no matching case for arguments"
     1 ** 10 ~is 10
     0 ** "apple" ~is 0
-    2 ** 10 ~raises "no matching case for arguments"
+    2 ** 10 ~throws "no matching case for arguments"
 
 
 // multi-case postfix
@@ -154,7 +154,7 @@ check:
   operator
   | 0 ** a: 0
   | 1 **: 1
-  ~raises "combination of infix and postfix cases not allowed"
+  ~throws "combination of infix and postfix cases not allowed"
 
 check:
   ~eval
@@ -162,7 +162,7 @@ check:
   | (0 ** a): 0
   | (** a): 0
   | (1 **): 1
-  ~raises "combination of infix and postfix cases not allowed"
+  ~throws "combination of infix and postfix cases not allowed"
 
 check:
   ~eval
@@ -170,27 +170,27 @@ check:
   | 0 ** a: 0
   | ** a: 0
   | 1 **: 1
-  ~raises "combination of infix and postfix cases not allowed"
+  ~throws "combination of infix and postfix cases not allowed"
 
 check:
   ~eval
   operator
   | ** **: 0
-  ~raises "expected non-operator"
+  ~throws "expected non-operator"
 
 check:
   ~eval
   operator
   | (0 ** a): 0
   | (1 ??): 1
-  ~raises "case operator does not match the initial case operator"
+  ~throws "case operator does not match the initial case operator"
 
 check:
   ~eval
   operator **:
   | (0 ** a): 0
   | (1 ??): 1
-  ~raises "case operator does not match the declared operator"
+  ~throws "case operator does not match the declared operator"
 
 check:
   ~eval
@@ -199,7 +199,7 @@ check:
   | (1 ** b):
       ~weaker_than: +
       1
-  ~raises "precedence option not allowed after first infix case"
+  ~throws "precedence option not allowed after first infix case"
 
 check:
   ~eval
@@ -208,7 +208,7 @@ check:
   | (1 **):
       ~weaker_than: +
       1
-  ~raises "precedence option not allowed after first postfix case"
+  ~throws "precedence option not allowed after first postfix case"
 
 check:
   ~eval
@@ -217,7 +217,7 @@ check:
   | (** 1):
       ~weaker_than: +
       1
-  ~raises "precedence option not allowed after first prefix case"
+  ~throws "precedence option not allowed after first prefix case"
 
 check:
   ~eval
@@ -225,7 +225,7 @@ check:
     ~associativity: ~none
   | (** 0): 0
   | (** 1): 1
-  ~raises "associativity specified without infix cases"
+  ~throws "associativity specified without infix cases"
 
 check:
   ~eval
@@ -234,7 +234,7 @@ check:
   | (1 ** b):
       ~associativity: ~left
       1
-  ~raises "associativity option not allowed after first infix case"
+  ~throws "associativity option not allowed after first infix case"
 
 // check postfix operator as repetition
 check:

--- a/rhombus/tests/pair.rhm
+++ b/rhombus/tests/pair.rhm
@@ -19,15 +19,15 @@ check:
 
 check:
   Pair.first(1)
-  ~raises values("contract violation", "expected: Pair")
+  ~throws values("contract violation", "expected: Pair")
 
 check:
   Pair("ok", "oops") :: Pair.of(String, Number)
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   ["ok", "oops"] :: Pair.of(String, Number)
-  ~raises "does not satisfy annotation"
+  ~throws "does not satisfy annotation"
 
 check:
   ["ok", "fine"] :: Pair.of(String, List)
@@ -87,16 +87,16 @@ block:
     ~is Pair(2, 1)
   check:
     1 :: Pair
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: Pair.of(Any, Any)
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: Pair.of(
       converting(fun (_): #false),
       converting(fun (_): #false)
     )
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
 
 block:
   check:

--- a/rhombus/tests/pattern-template-escape.rhm
+++ b/rhombus/tests/pattern-template-escape.rhm
@@ -66,13 +66,13 @@ check:
   ~eval
   import: rhombus/meta open
   expr.macro '$1 + $2': '0'
-  ~raises "expected operator-macro pattern"
+  ~throws "expected operator-macro pattern"
 
 check:
   ~eval
   import: rhombus/meta open
   expr.macro '$x $ $x': '0'
-  ~raises "expected operator-macro pattern"
+  ~throws "expected operator-macro pattern"
 
 check:
   //  macro that acts as a template form

--- a/rhombus/tests/quasiquote.rhm
+++ b/rhombus/tests/quasiquote.rhm
@@ -92,39 +92,39 @@ check:
 check:
   ~eval
   'x $'
-  ~raises "misplaced escape"
+  ~throws "misplaced escape"
 
 check:
   ~eval
   'x
    $'
-  ~raises "misplaced escape"
+  ~throws "misplaced escape"
 
 check:
   ~eval
   '... x'
-  ~raises "misplaced repetition"
+  ~throws "misplaced repetition"
 
 check:
   ~eval
   '...
    x'
-  ~raises "misplaced repetition"
+  ~throws "misplaced repetition"
 
 check:
   ~eval
   def '0 $('1; 2') 3' = '0 1; 2'
-  ~raises "multi-group pattern incompatible with term context"
+  ~throws "multi-group pattern incompatible with term context"
 
 check:
   ~eval
   def '0 $('1; 2')' = '0 1; 2'
-  ~raises "multi-group pattern incompatible with group context"
+  ~throws "multi-group pattern incompatible with group context"
 
 check:
   ~eval
   def '(0, $('1; 2'))' = '(0, 1, 2)'
-  ~raises "multi-group pattern incompatible with group context"
+  ~throws "multi-group pattern incompatible with group context"
 
 check:
   '1 $('')'
@@ -133,7 +133,7 @@ check:
 check:
   def g = ''
   '3 + (1, $g $g)'
-  ~raises "generated an empty group"
+  ~throws "generated an empty group"
 
 check:
   def ['(($b_var_id), ...)', ...]: ['((1), (2 2), (3))', '((4))']
@@ -171,40 +171,40 @@ block:
   check:
     '$b $a' ~prints_like ':« 1 » | 12 | 13'
     'head $b $a' ~prints_like 'head:« 1 » | 12 | 13'
-    'apple $[a, '8']' ~raises "alternatives not allowed in non-tail position of a group"
-    'apple $[b, '8']' ~raises "block not allowed in non-tail position of a group"
-    '$b $b' ~raises "block not allowed in non-tail position of a group"
-    'head $b $b' ~raises "block not allowed in non-tail position of a group"
-    '$a $a' ~raises "alternatives not allowed in non-tail position of a group"
-    'head $a $a' ~raises "alternatives not allowed in non-tail position of a group"
-    '$[b, b]' ~raises "block not allowed in non-tail"
-    'head $[b, b]' ~raises "block not allowed in non-tail"
-    'head $[a, a]' ~raises "alternatives not allowed in non-tail position of a group"
-    '$ts ...' ~raises "block not allowed in non-tail position of a group"
-    'head $ts ...' ~raises "block not allowed in non-tail position of a group"
-    '$[ts] ...' ~raises "block not allowed in non-tail position of a group"
+    'apple $[a, '8']' ~throws "alternatives not allowed in non-tail position of a group"
+    'apple $[b, '8']' ~throws "block not allowed in non-tail position of a group"
+    '$b $b' ~throws "block not allowed in non-tail position of a group"
+    'head $b $b' ~throws "block not allowed in non-tail position of a group"
+    '$a $a' ~throws "alternatives not allowed in non-tail position of a group"
+    'head $a $a' ~throws "alternatives not allowed in non-tail position of a group"
+    '$[b, b]' ~throws "block not allowed in non-tail"
+    'head $[b, b]' ~throws "block not allowed in non-tail"
+    'head $[a, a]' ~throws "alternatives not allowed in non-tail position of a group"
+    '$ts ...' ~throws "block not allowed in non-tail position of a group"
+    'head $ts ...' ~throws "block not allowed in non-tail position of a group"
+    '$[ts] ...' ~throws "block not allowed in non-tail position of a group"
 
 
 check:
   match '1 2: a b'
   | '$_ ...: a': "ok"
-  ~raises "unexpected term" // not "expected more terms"
+  ~throws "unexpected term" // not "expected more terms"
 check:
   match '1 2: a b'
   | '$_ ... $_ ...: a': "ok"
-  ~raises "unexpected term" // not "expected more terms"
+  ~throws "unexpected term" // not "expected more terms"
 check:
   match '1 2: a b'
   | '$_ ... 1 ...: a': "ok"
-  ~raises "unexpected term" // not "expected more terms"
+  ~throws "unexpected term" // not "expected more terms"
 check:
   match '1 2 | a b'
   | '$_ ... | a': "ok"
-  ~raises "unexpected term" // not "expected more terms"
+  ~throws "unexpected term" // not "expected more terms"
 check:
   match '1 2 | a b'
   | '$_ ...: a': "ok"
-  ~raises "expected a `:` block"
+  ~throws "expected a `:` block"
 
 check:
   match '(1)':

--- a/rhombus/tests/recur.rhm
+++ b/rhombus/tests/recur.rhm
@@ -56,12 +56,12 @@ check:
 check:
   ~eval
   recur f(x): x
-  ~raises "missing initial-value expression"
+  ~throws "missing initial-value expression"
 
 check:
   ~eval
   recur f(~x: x): x
-  ~raises "missing initial-value expression"
+  ~throws "missing initial-value expression"
 
 check:
   recur loop(x :: String = "a"):
@@ -71,7 +71,7 @@ check:
 check:
   recur loop(x :: String = 10):
     x.length()
-  ~raises "value does not match annotation"
+  ~throws "value does not match annotation"
 
 check:
   (recur loop(x :: String = "abs") :: String:
@@ -88,12 +88,12 @@ check:
 check:
   recur loop(x :: String = "abs") :: String:
     0
-  ~raises "result does not match annotation"
+  ~throws "result does not match annotation"
 
 check:
   recur loop(x :: String = "abs") :: (String, Int):
     0
-  ~raises "result does not match annotation"
+  ~throws "result does not match annotation"
 
 check:
   def mutable count = 0

--- a/rhombus/tests/rest-args.rhm
+++ b/rhombus/tests/rest-args.rhm
@@ -393,19 +393,19 @@ check:
 
 check:
   anyargs(~x: 10, ~&{#'~x: 10})
-  ~raises "duplicate keyword"
+  ~throws "duplicate keyword"
 
 check:
   anyargs(~&{#'~x: 10}, ~x: 10)
-  ~raises "duplicate keyword"
+  ~throws "duplicate keyword"
 
 check:
   anyargs(~&{#'~x: 10}, ~&{#'~x: 10})
-  ~raises "duplicate keyword"
+  ~throws "duplicate keyword"
 
 check:
   anyargs(~&{#'~x: 10}, ~&{#'~y: 10}, ~&{#'~x: 10})
-  ~raises "duplicate keyword"
+  ~throws "duplicate keyword"
 
 // ---------------------------
 // Combinations of Positional and Keyword Rest
@@ -517,7 +517,7 @@ block:
 check:
   ~eval
   def {2: two, x: y, ...} = {1: "a"}
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 block:
   def {x, ...} = {1, 2}
@@ -546,4 +546,4 @@ block:
 check:
   ~eval
   def {2, x, ...} = {1}
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"

--- a/rhombus/tests/set.rhm
+++ b/rhombus/tests/set.rhm
@@ -12,7 +12,7 @@ check:
 
 check:
   Set.length([1, 2, 3])
-  ~raises values("contract violation", "expected: ReadableSet")
+  ~throws values("contract violation", "expected: ReadableSet")
 
 block:
   use_static
@@ -48,13 +48,13 @@ block:
 block:
   check:
     1 :: Set
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: Set.of(Any)
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     1 :: Set.of(converting(fun (_): #false))
-    ~raises "does not satisfy annotation"
+    ~throws "does not satisfy annotation"
   check:
     {1, 2, 3} :: Set.of(converting(fun (n :: Int): n+1))
     ~is {2, 3, 4}
@@ -95,7 +95,7 @@ block:
          [3, [2, [1, []]]]]
   check:
     Set{&"oops"}
-    ~raises "not a set"
+    ~throws "not a set"
 
 block:
   def [x, ...] = [1, 2, 3]
@@ -163,7 +163,7 @@ check:
   {1, 2, 3}.to_list().length() ~is 3
   {1, 2, 3}.to_list(#true) ~is [1, 2, 3]
   Set.append({1}, {3, 5}, {2, 4, 6}) ~is {1, 2, 3, 4, 5, 6}
-  {1}.copy().remove(2) ~raises "no such field or method"
+  {1}.copy().remove(2) ~throws "no such field or method"
   {1, 3}.intersect() ~is {1, 3}
   {1, 3}.intersect({2, 3}) ~is {3}
   {1, 3}.intersect({2, 3}, {3, 4}) ~is {3}
@@ -174,13 +174,13 @@ check:
 block:
   check:
     Set.append(MutableSet{1, 2, 3}, {4}, {5, 6})
-    ~raises values("contract violation", "expected: Set")
+    ~throws values("contract violation", "expected: Set")
   check:
     Set.intersect(MutableSet{1, 3}, {2, 3}, {3, 4})
-    ~raises values("contract violation", "expected: Set")
+    ~throws values("contract violation", "expected: Set")
   check:
     Set.union(MutableSet{1, 3}, {2, 3}, {3, 4})
-    ~raises values("contract violation", "expected: Set")
+    ~throws values("contract violation", "expected: Set")
 
 block:
   use_static
@@ -194,8 +194,8 @@ block:
     use_dynamic
     check dynamic({1, 2}).remove(1) ~is {2}
     check dynamic({1, 2}).remove(3) ~is {1, 2}
-    check MutableSet{1, 2}.remove ~raises "no such field or method"
-    check MutableSet{1, 2}.remove(1) ~raises "no such field or method"
+    check MutableSet{1, 2}.remove ~throws "no such field or method"
+    check MutableSet{1, 2}.remove(1) ~throws "no such field or method"
     
 block:
   use_static
@@ -216,8 +216,8 @@ block:
     use_dynamic
     check dynamic(m).delete(1) ~is #void
     check m ~is_now MutableSet{2}
-    check {1, 2}.delete ~raises "no such field or method"
-    check {1, 2}.delete(1) ~raises "no such field or method"
+    check {1, 2}.delete ~throws "no such field or method"
+    check {1, 2}.delete(1) ~throws "no such field or method"
 
 block:
   let m = MutableSet{1, 2}
@@ -255,4 +255,4 @@ check:
   // make sure sequence element static info isn't confused for index
   def set :: Set.of(String) = {"foo", "1", "Box(2)"}
   set["foo"].length()
-  ~raises "no such field or method (based on static information)"
+  ~throws "no such field or method (based on static information)"

--- a/rhombus/tests/static_arity.rhm
+++ b/rhombus/tests/static_arity.rhm
@@ -24,7 +24,7 @@ expr.macro 'one_check:
        ~eval
        use_static
        $dotted_id ... (~bad_keyword: 10, '$arg', ...)
-       ~raises values("keyword argument not recognized by called function", "static")
+       ~throws values("keyword argument not recognized by called function", "static")
      $(match '$arg; ...'
        | '$arg; ...; $last; $(bound_as expr_meta.space: '...')':
            'check_wrong_fewer:
@@ -54,4 +54,4 @@ expr.macro 'check_wrong_count:
      ~eval
      use_static
      $dotted_id ... ('$arg', ...)
-     ~raises "wrong number of arguments in function call"'
+     ~throws "wrong number of arguments in function call"'

--- a/rhombus/tests/syntax-class.rhm
+++ b/rhombus/tests/syntax-class.rhm
@@ -69,7 +69,7 @@ check:
   | '$x $op $y'
   match '1+2'
   | '$(exp :: Arithmetic)': exp.op
-  ~raises "no such field"
+  ~throws "no such field"
 
 check:
   ~eval
@@ -78,7 +78,7 @@ check:
   | '$x $op $y'
   match '1+2'
   | '$(exp :: Arithmetic)': exp.op
-  ~raises "no such field"
+  ~throws "no such field"
 
 check:
   ~eval
@@ -87,7 +87,7 @@ check:
   | '$x'
   match '1'
   | '$(any :: Any)': any.x
-  ~raises "no such field"
+  ~throws "no such field"
 
 check:
   ~eval
@@ -96,7 +96,7 @@ check:
   | '$x $op $y'
   match '1+2'
   | '$(exp :: Arithmetic)': exp.op
-  ~raises "field implementation does not match declared depth"
+  ~throws "field implementation does not match declared depth"
 
 check:
   ~eval
@@ -105,7 +105,7 @@ check:
   | '$x $op $y'
   match '1+2'
   | '$(exp :: Arithmetic)': exp.op
-  ~raises "field implementation does not match declared kind"
+  ~throws "field implementation does not match declared kind"
 
 check:
   syntax_class Arithmetic:
@@ -183,7 +183,7 @@ block:
     expr.macro 'right_operand $(e :: Arithmetic)':
       values(e.y, '')
     right_operand 1 +
-    ~raises "expression with addition or subtraction"
+    ~throws "expression with addition or subtraction"
 
 block:
   syntax_class Foo
@@ -207,7 +207,7 @@ check:
   | '$x + $y + $z'
   match '10 + 20 + 30'
   | '$(f :: Foo)': f.z
-  ~raises "no such field or method"
+  ~throws "no such field or method"
 
 block:
   syntax_class Foo:
@@ -232,7 +232,7 @@ check:
   syntax_class Foo:
     kind: ~term
   | '$x + $y'
-  ~raises "not a single-term pattern"
+  ~throws "not a single-term pattern"
 
 block:
   syntax_class Foo:
@@ -269,7 +269,7 @@ block:
     | '$x + $y'
     match '0 + 1 + 2 + 3'
     | '0 + $(f :: Foo) + 3': [f.x, f.y]
-    ~raises "syntax class incompatible with this context"
+    ~throws "syntax class incompatible with this context"
 
 block:
   syntax_class Foo:
@@ -304,7 +304,7 @@ check:
     kind: ~block
   | '($x + $y,
       $z - $w)'
-  ~raises "not a block pattern"
+  ~throws "not a block pattern"
 
 block:
   syntax_class Foo:
@@ -413,7 +413,7 @@ check:
       field form: '~lang'
   match '(~lang, ~lang)'
   | '($(o :: Option), ...)': [o.form]
-  ~raises "field is a repetition"
+  ~throws "field is a repetition"
 
 check:
   ~eval
@@ -422,7 +422,7 @@ check:
       field form: '~lang'
   match '(~lang, ~lang)'
   | '($(o :: Option), ...)': [o.form]
-  ~raises "field is a repetition"
+  ~throws "field is a repetition"
 
 block:
   syntax_class NTerms
@@ -503,13 +503,13 @@ check:
   ~eval
   syntax_class House(material) | '< < > >'
   def '$(x :: House)' = #false
-  ~raises "syntax class expects arguments"
+  ~throws "syntax class expects arguments"
 
 check:
   ~eval
   syntax_class Horse | '!!!'
   def '$(x :: Horse(1))' = #false
-  ~raises "syntax class does not expect arguments"
+  ~throws "syntax class does not expect arguments"
 
 // field value does not have to be syntax
 check:
@@ -574,7 +574,7 @@ block:
     ~prints_like ['1', '2']
   check:
     m('9 1')
-    ~raises "value does not satisfy annotation"
+    ~throws "value does not satisfy annotation"
 
 // opening an inline syntax class
 block:
@@ -794,13 +794,13 @@ check:
   ~eval
   match '1'
   | '$(pattern any | '$x')': x
-  ~raises "cannot reference an identifier before its definition"
+  ~throws "cannot reference an identifier before its definition"
 
 check:
   ~eval
   match '1'
   | (pattern any | '$x'): x
-  ~raises "cannot reference an identifier before its definition"
+  ~throws "cannot reference an identifier before its definition"
 
 // check generated attributes in inline `pattern`s
 block:
@@ -933,14 +933,14 @@ check:
   syntax_class C:
     root_swap: unknown terms
   | '$_ $second'
-  ~raises "field to swap as root not found"
+  ~throws "field to swap as root not found"
 
 check:
   ~eval
   syntax_class C:
     root_swap: second first
   | '$first $second'
-  ~raises "field for root already exists"
+  ~throws "field for root already exists"
 
 
 check:

--- a/rhombus/tests/syntax-kind-interchange.rhm
+++ b/rhombus/tests/syntax-kind-interchange.rhm
@@ -43,7 +43,7 @@ check:
 check:
   match '1; 2 4; 3'
   | '$a': '1 + $a'
-  ~raises "multi-group syntax not allowed in group context"
+  ~throws "multi-group syntax not allowed in group context"
 
 check:
   match '(1) (2 + 7, 14) (3)'
@@ -58,12 +58,12 @@ check:
 check:
   def [none, ...] = []
   'x; $none ...; y'
-  ~raises "generated an empty group"
+  ~throws "generated an empty group"
   
 check:
   def none = []
   'x; $none; y'
-  ~raises "cannot coerce empty list to group syntax"
+  ~throws "cannot coerce empty list to group syntax"
 
 check:
   def none = '1; 2'
@@ -78,12 +78,12 @@ check:
 check:
   def none = ['1', '2 3']
   'x; $none; y'
-  ~raises "multi-term syntax not allowed in term context"
+  ~throws "multi-term syntax not allowed in term context"
 
 check:
   def none = []
   'x; $none; y'
-  ~raises "cannot coerce empty list to group syntax"
+  ~throws "cannot coerce empty list to group syntax"
 
 check:
   def none = ''

--- a/rhombus/tests/syntax-object.rhm
+++ b/rhombus/tests/syntax-object.rhm
@@ -13,7 +13,7 @@ block:
 
 check:
   Syntax.make(1) ~prints_like '1'
-  Syntax.make([1, 2]) ~raises "invalid as a shrubbery term"
+  Syntax.make([1, 2]) ~throws "invalid as a shrubbery term"
   Syntax.make([#'parens, [#'group, 1, "a", #'z]]) ~prints_like '(1 "a" z)'
   Syntax.make([#'parens,
                [#'group, 1],
@@ -27,14 +27,14 @@ check:
 check:
   Syntax.make_group([1, 2]) ~prints_like '1 2'
   Syntax.make_group(['block', ['block', '1 2', '3']]) ~prints_like 'block: 1 2; 3'
-  Syntax.make_group([': a', ': b']) ~raises "invalid as a shrubbery non-tail term representation"
-  Syntax.make_group(['any', ['block', '1 2', '3'], 'more']) ~raises "invalid as a shrubbery non-tail term"
-  Syntax.make_group(['any', ['alts', ['block', '1 2', '3']], 'more']) ~raises "invalid as a shrubbery non-tail term"
+  Syntax.make_group([': a', ': b']) ~throws "invalid as a shrubbery non-tail term representation"
+  Syntax.make_group(['any', ['block', '1 2', '3'], 'more']) ~throws "invalid as a shrubbery non-tail term"
+  Syntax.make_group(['any', ['alts', ['block', '1 2', '3']], 'more']) ~throws "invalid as a shrubbery non-tail term"
   Syntax.make_group([': a', '| b']) ~prints_like ':« a » | b'
   Syntax.make_group([['block', 'a'], ['alts', ['block', '1 2', '3']]]) ~prints_like ':« a » | 1 2 ; 3'
 
 check:
-  Syntax.make_group([]) ~raises "NonemptyList"
+  Syntax.make_group([]) ~throws "NonemptyList"
 
 check:
   Syntax.make_temp_id("hello", ~keep_name: #true) ~prints_like 'hello'
@@ -49,11 +49,11 @@ check:
 
 check:
   Syntax.unwrap('x') ~is #'x
-  Syntax.unwrap('1 1') ~raises "multi-term syntax not allowed in term context"
+  Syntax.unwrap('1 1') ~throws "multi-term syntax not allowed in term context"
   Syntax.unwrap('(1 2 3)') ~prints_like ['parens', '1 2 3']
   Syntax.unwrap('(1, 2, 3)') ~prints_like ['parens', '1', '2', '3']
   Syntax.unwrap_group('1 2 3') ~prints_like ['1', '2', '3']
-  Syntax.unwrap_group('1 2; 3 4') ~raises "multi-group syntax not allowed in group context"
+  Syntax.unwrap_group('1 2; 3 4') ~throws "multi-group syntax not allowed in group context"
   Syntax.unwrap_sequence('1 2; 3 4 5') ~prints_like ['1 2', '3 4 5']
   Syntax.unwrap_sequence('1 2') ~prints_like ['1 2']
   Syntax.unwrap_sequence('1') ~prints_like ['1']

--- a/rhombus/tests/unquote-binding.rhm
+++ b/rhombus/tests/unquote-binding.rhm
@@ -44,7 +44,7 @@ check:
   def '$('1' || '2')' = '1' ~completes
   def '$('1' || '2')' = '2' ~completes
   def '$('1' || '2') ...' = '1 2 1' ~completes
-  def '$('1' || '2') ...' = '1 2 1 3' ~raises "does not satisfy annotation"
+  def '$('1' || '2') ...' = '1 2 1 3' ~throws "does not satisfy annotation"
 
 block:
   def a = "top a"
@@ -131,7 +131,7 @@ block:
     ~prints_like '801'
   check:
     get_area_code('+ 65 (801) 555 - 1212')
-    ~raises "argument does not satisfy annotation"
+    ~throws "argument does not satisfy annotation"
 
 check:
   expr.macro 'm':

--- a/rhombus/tests/when_unless.rhm
+++ b/rhombus/tests/when_unless.rhm
@@ -26,16 +26,16 @@ block:
 check:
   ~eval
   def x when x.length() > 10 = "Hello"
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   ~eval
   def x unless x.length() < 10 = "Hello"
-  ~raises "value does not satisfy annotation"
+  ~throws "value does not satisfy annotation"
 
 check:
   ~eval
   block:
     let x when #true = 1
     x
-  ~raises "pattern requires early binding of its names"
+  ~throws "pattern requires early binding of its names"


### PR DESCRIPTION
Rhombus uses `throw` instead of `raise`, so we should consistenly refer to “throw”.  This commit updates relevant sections in the docs and changes the `check` directive to `~throws`.  Tests are batch-edited to use `~throws`.