### PR TITLE
add `satisfying` annotation

### DIFF
--- a/rhombus/scribblings/ref-annotation.scrbl
+++ b/rhombus/scribblings/ref-annotation.scrbl
@@ -136,7 +136,7 @@
 ){
 
  Converts @rhombus(bind) into an annotation. Variables bound in
- @rhombus($bind) are not made visible, but the annotation corresponds to
+ @rhombus(bind) are not made visible, but the annotation corresponds to
  the set of values for which @rhombus(bind) would match. Since no results
  are made visible, @rhombus(bind) is used only in matching mode, and
  implied conversions might be skipped.
@@ -145,6 +145,37 @@
   def x :: matching([_, 10]) = [9, 10]
   ~error:
     def y :: matching([_, 10]) = [9, 11]
+)
+
+}
+
+@doc(
+  ~nonterminal:
+    pred_expr: block expr
+  annot.macro 'satisfying(pred_expr)'
+){
+
+ Produces a @tech{predicate annotation} using the resulting function
+ from @rhombus(pred_expr).
+
+@examples(
+  ~defn:
+    fun is_multiple_of(n):
+      fun (v):
+        v is_a Int && v mod n == 0
+  ~repl:
+    15 :: (satisfying(is_multiple_of(3))
+             && satisfying(is_multiple_of(5)))
+  ~defn:
+    fun
+    | is_list_with_one(lst :: List):
+        lst.has_element(1)
+    | is_list_with_one(_):
+        #false
+  ~repl:
+    [1, 2, 3] :: satisfying(is_list_with_one)
+    ~error:
+      Array(1, 2, 3) :: satisfying(is_list_with_one)
 )
 
 }
@@ -164,8 +195,8 @@
  the value produced by the annotation is determined by the @rhombus(body)
  sequence, which can refer to variables bound by @rhombus(bind).
 
- When @rhombus(annot) is provided, then it's static information is
- propoagted to the new converter annotation. If @rhombus(annot) is
+ When @rhombus(annot) is provided, then its static information is
+ propagated to the new converter annotation. If @rhombus(annot) is
  supplied with @rhombus(::, ~bind), then the result of the @rhombus(body)
  sequence is checked against @rhombus(annot).
 

--- a/rhombus/tests/annotation.rhm
+++ b/rhombus/tests/annotation.rhm
@@ -35,3 +35,20 @@ check:
   1 is_a converting(fun (i :: Int unless i mod 3 == 0): i)
   [1, 2, 3] is_a converting(fun ([x, ...] when math.sum(x, ...) == 6): #true)
   ~completes
+
+block:
+  fun is_multiple_of(n):
+    fun (v):
+      v is_a Int && v mod n == 0
+  check:
+    0 ~is_a satisfying(is_multiple_of(1))
+    1 ~is_a satisfying(is_multiple_of(1))
+    15 ~is_a satisfying(is_multiple_of(3)) && satisfying(is_multiple_of(5))
+
+check:
+  #false is_a satisfying("not a function")
+  ~throws values("contract violation", "expected: Function.of_arity(1)")
+
+check:
+  #false is_a satisfying(fun (): #false)
+  ~throws values("contract violation", "expected: Function.of_arity(1)")

--- a/scribble/private/rhombus-spacer.rhm
+++ b/scribble/private/rhombus-spacer.rhm
@@ -33,6 +33,7 @@ export:
     Any
     described_as
     matching
+    satisfying
     converting
     maybe
     syntax_class
@@ -685,6 +686,14 @@ spacer.bridge matching(self, tail, context, esc):
   fun adjust(t):
     match t
     | '($(_ :: Group))': spacer.adjust_term(t, #'~bind, esc)
+    | ~else: t
+  '$self $(adjust_one(tail, context, esc, adjust))'
+
+spacer.bridge satisfying(self, tail, context, esc):
+  ~in: ~annot
+  fun adjust(t):
+    match t
+    | '($(_ :: Group))': spacer.adjust_term(t, #'~expr, esc)
     | ~else: t
   '$self $(adjust_one(tail, context, esc, adjust))'
 


### PR DESCRIPTION
This form can be useful for turning an existing predicate into annotation without using `annot.macro` and friends, especially when defining new annotation isn’t worth it.  I also think that it can be used to document Racket interops, because Racket modules generally export many predicates as flat contracts.