### PR TITLE
more consistent `{List,(Readable){Map,Set}}.empty`

### DIFF
--- a/rhombus/private/list.rkt
+++ b/rhombus/private/list.rkt
@@ -212,6 +212,9 @@
        (lambda (v) (cons v lst))
        (lambda () #f))))
 
+(define-static-info-syntax null
+  #:defined list-static-infos)
+
 (define-binding-syntax null
   (binding-transformer
    (lambda (stx)
@@ -221,10 +224,10 @@
 
 (define-syntax (empty-infoer stx)
   (syntax-parse stx
-    [(_ static-infos datum)
+    [(_ up-static-infos _)
      (binding-info "List.empty"
                    #'empty
-                   #'static-infos
+                   (static-infos-union list-static-infos #'up-static-infos)
                    #'()
                    #'empty-matcher
                    #'literal-bind-nothing
@@ -391,7 +394,7 @@
 
 (define-for-syntax (wrap-list-static-info expr)
   (wrap-static-info* expr list-static-infos))
-  
+
 ;; parses a list pattern that has already been checked for use with a
 ;; suitable `parens` or `brackets` form
 (define-for-syntax (parse-list-binding stx)

--- a/rhombus/private/static-info.rkt
+++ b/rhombus/private/static-info.rkt
@@ -180,6 +180,9 @@
 
 (define-syntax (define-static-info-syntax stx)
   (syntax-parse stx
+    [(_ id:identifier #:defined defined:id)
+     #`(define-syntax #,(in-static-info-space #'id)
+         (static-info (lambda () defined)))]
     [(_ id:identifier rhs ...)
      #`(define-syntax #,(in-static-info-space #'id)
          (static-info (lambda () (list (quasisyntax rhs) ...))))]))

--- a/rhombus/scribblings/ref-map.scrbl
+++ b/rhombus/scribblings/ref-map.scrbl
@@ -301,10 +301,10 @@ in an unspecified order.
 
 
 @doc(
+  def Map.empty :: Map = {}
   bind.macro 'Map.empty'
-  expr.macro 'Map.empty'
+  def ReadableMap.empty :: ReadableMap = {}
   bind.macro 'ReadableMap.empty'
-  expr.macro 'ReadableMap.empty'
 ){
 
  An empty map. The @rhombus(Map.empty, ~bind) binding form differs from
@@ -313,8 +313,11 @@ in an unspecified order.
  @rhombus(Map()) matches any immutable map.
 
  The @rhombus(ReadableMap.empty, ~bind) binding form matches an empty map
- whether it is mutable or immutable. The @rhombus(ReadableMap.empty)
- expression form is equivalent to @rhombus(Map.empty).
+ whether it is mutable or immutable.
+
+ Corresponding to the binding forms, @rhombus(Map.empty) and
+ @rhombus(ReadableMap.empty) are bound to @rhombus({}) with
+ approapriate static information.
 
 @examples(
   Map.empty

--- a/rhombus/scribblings/ref-set.scrbl
+++ b/rhombus/scribblings/ref-set.scrbl
@@ -189,10 +189,10 @@ it supplies its elements in an unspecified order.
 }
 
 @doc(
+  def Set.empty :: Set = Set{}
   bind.macro 'Set.empty'
-  expr.macro 'Set.empty'
+  def ReadableSet.empty :: ReadableSet = Set{}
   bind.macro 'ReadableSet.empty'
-  expr.macro 'ReadableSet.empty'
 ){
 
  An empty set. The @rhombus(Set.empty, ~bind) binding form differs from
@@ -200,11 +200,11 @@ it supplies its elements in an unspecified order.
  empty immutable set, while @rhombus(Set{}) matches any immutable set.
 
  The @rhombus(ReadableSet.empty, ~bind) binding form matches an empty set
- whether it is mutable or immutable. The @rhombus(ReadableSet.empty)
- expression form is equivalent to @rhombus(Set.empty).
+ whether it is mutable or immutable.
 
- An empty set, where the @rhombus(Set.empty, ~bind) binding matches
- only an empty set.
+ Corresponding to the binding forms, @rhombus(Set.empty) and
+ @rhombus(ReadableSet.empty) are bound to @rhombus(Set{}) with
+ approapriate static information.
 
 @examples(
   Set.empty

--- a/rhombus/tests/list.rhm
+++ b/rhombus/tests/list.rhm
@@ -183,3 +183,14 @@ check:
   use_static
   List.rest([1, 2, 3]).map(math.abs)
   ~is [2, 3]
+
+check:
+  use_static
+  List.empty.has_element("no such thing")
+  ~is #false
+
+check:
+  use_static
+  def List.empty && empty = dynamic([])
+  empty.has_element("no such thing")
+  ~is #false

--- a/rhombus/tests/map.rhm
+++ b/rhombus/tests/map.rhm
@@ -186,6 +186,54 @@ check:
   ~is [{"y", "z"}, {2, 3}]
 
 check:
+  match {}
+  | Map.empty: "empty"
+  | ~else: "other"
+  ~is "empty"
+
+check:
+  match MutableMap{}
+  | Map.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
+  match {1: 2}
+  | Map.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
+  match MutableMap{1: 2}
+  | Map.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
+  match {}
+  | ReadableMap.empty: "empty"
+  | ~else: "other"
+  ~is "empty"
+
+check:
+  match MutableMap{}
+  | ReadableMap.empty: "empty"
+  | ~else: "other"
+  ~is "empty"
+
+check:
+  match {1: 2}
+  | ReadableMap.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
+  match MutableMap{1: 2}
+  | ReadableMap.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
   {1: "a", 2: 2, 3: 3}.keys(#true) ~is [1, 2, 3]
 
 block:
@@ -202,7 +250,7 @@ block:
     check dynamic({1: "a", 2: "b"}).remove(3) ~is {1: "a", 2: "b"}
     check MutableMap{1: "a", 2: "b"}.remove ~throws "no such field or method"
     check MutableMap{1: "a", 2: "b"}.remove(1) ~throws "no such field or method"
-    
+
 block:
   use_static
   let m = MutableMap{1: "a", 2: "b"}
@@ -211,13 +259,13 @@ block:
   m.delete(3)
   check m ~is_now MutableMap{2: "b"}
   m[1] := "a"
-  check m ~is_now MutableMap{1: "a", 2: "b"}  
+  check m ~is_now MutableMap{1: "a", 2: "b"}
   check MutableMap.delete(m, 1) ~is #void
   check m ~is_now MutableMap{2: "b"}
   check MutableMap.delete(m, 3) ~is #void
   check m ~is_now MutableMap{2: "b"}
   m[1] := "a"
-  check m ~is_now MutableMap{1: "a", 2: "b"}  
+  check m ~is_now MutableMap{1: "a", 2: "b"}
   block:
     use_dynamic
     check dynamic(m).delete(1) ~is #void
@@ -255,7 +303,7 @@ check:
   for Set ((key, val): map):
     key.length() + val.y
   ~is {3, 5, 6}
-  
+
 check:
   ~eval
   use_static
@@ -264,4 +312,50 @@ check:
     {#'foo: "foo", 1: "1", Box(2): "Box(2)"}
   for ((key, val): map):
     println(key.length() + val.length())
+  ~throws "no such field or method (based on static information)"
+
+check:
+  use_static
+  Map.empty.get("no such thing", #false)
+  ~is #false
+
+check:
+  use_static
+  def Map.empty && empty = dynamic({})
+  empty.get("no such thing", #false)
+  ~is #false
+
+check:
+  use_static
+  Map.empty.remove("no such thing")
+  ~is {}
+
+check:
+  use_static
+  def Map.empty && empty = dynamic({})
+  empty.remove("no such thing")
+  ~is {}
+
+check:
+  use_static
+  ReadableMap.empty.get("no such thing", #false)
+  ~is #false
+
+check:
+  use_static
+  def ReadableMap.empty && empty = dynamic({})
+  empty.get("no such thing", #false)
+  ~is #false
+
+check:
+  ~eval
+  use_static
+  ReadableMap.empty.remove("no such thing")
+  ~throws "no such field or method (based on static information)"
+
+check:
+  ~eval
+  use_static
+  def ReadableMap.empty && empty = dynamic({})
+  empty.remove("no such thing")
   ~throws "no such field or method (based on static information)"

--- a/rhombus/tests/set.rhm
+++ b/rhombus/tests/set.rhm
@@ -159,6 +159,54 @@ check:
   ~is {"y", "z"}
 
 check:
+  match Set{}
+  | Set.empty: "empty"
+  | ~else: "other"
+  ~is "empty"
+
+check:
+  match MutableSet{}
+  | Set.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
+  match Set{1}
+  | Set.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
+  match MutableSet{1}
+  | Set.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
+  match Set{}
+  | ReadableSet.empty: "empty"
+  | ~else: "other"
+  ~is "empty"
+
+check:
+  match MutableSet{}
+  | ReadableSet.empty: "empty"
+  | ~else: "other"
+  ~is "empty"
+
+check:
+  match Set{1}
+  | ReadableSet.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
+  match MutableSet{1}
+  | ReadableSet.empty: "empty"
+  | ~else: "other"
+  ~is "other"
+
+check:
   {1, 2, 3}.append({4}, {5, 6}).remove(2) ~is {1, 3, 4, 5, 6}
   {1, 2, 3}.to_list().length() ~is 3
   {1, 2, 3}.to_list(#true) ~is [1, 2, 3]
@@ -196,7 +244,7 @@ block:
     check dynamic({1, 2}).remove(3) ~is {1, 2}
     check MutableSet{1, 2}.remove ~throws "no such field or method"
     check MutableSet{1, 2}.remove(1) ~throws "no such field or method"
-    
+
 block:
   use_static
   let m = MutableSet{1, 2}
@@ -205,13 +253,13 @@ block:
   m.delete(3)
   check m ~is_now MutableSet{2}
   m[1] := "a"
-  check m ~is_now MutableSet{1, 2}  
+  check m ~is_now MutableSet{1, 2}
   check MutableSet.delete(m, 1) ~is #void
   check m ~is_now MutableSet{2}
   check MutableSet.delete(m, 3) ~is #void
   check m ~is_now MutableSet{2}
   m[1] := "a"
-  check m ~is_now MutableSet{1, 2}  
+  check m ~is_now MutableSet{1, 2}
   block:
     use_dynamic
     check dynamic(m).delete(1) ~is #void
@@ -255,4 +303,50 @@ check:
   // make sure sequence element static info isn't confused for index
   def set :: Set.of(String) = {"foo", "1", "Box(2)"}
   set["foo"].length()
+  ~throws "no such field or method (based on static information)"
+
+check:
+  use_static
+  Set.empty["no such thing"]
+  ~is #false
+
+check:
+  use_static
+  def Set.empty && empty = dynamic(Set{})
+  empty["no such thing"]
+  ~is #false
+
+check:
+  use_static
+  Set.empty.remove("no such thing")
+  ~is Set{}
+
+check:
+  use_static
+  def Set.empty && empty = dynamic(Set{})
+  empty.remove("no such thing")
+  ~is Set{}
+
+check:
+  use_static
+  ReadableSet.empty["no such thing"]
+  ~is #false
+
+check:
+  use_static
+  def ReadableSet.empty && empty = dynamic(Set{})
+  empty["no such thing"]
+  ~is #false
+
+check:
+  ~eval
+  use_static
+  ReadableSet.empty.remove("no such thing")
+  ~throws "no such field or method (based on static information)"
+
+check:
+  ~eval
+  use_static
+  def ReadableSet.empty && empty = dynamic(Set{})
+  empty.remove("no such thing")
   ~throws "no such field or method (based on static information)"


### PR DESCRIPTION
Change the expression forms to simple variables with appropriate static information, and associate static information in binding forms. An idiosyncrasy of `Readable{Map,Set}.empty` is that the static information is *less* than directly using the constructor (and you can’t construct a “readable {map,set}”, apparently).