### PR TITLE
fix `#%literal` bindings when `case` expansion applies

### DIFF
--- a/rhombus/private/match.rkt
+++ b/rhombus/private/match.rkt
@@ -14,7 +14,13 @@
          "realm.rkt"
          "parens.rkt"
          (submod "quasiquote.rkt" for-match)
-         (only-in "literal.rkt" literal-infoer))
+         (only-in "literal.rkt" literal-infoer)
+         "version-case.rkt")
+;; TEMP approximate `case/equal-always`
+(meta-if-version-at-least
+ "8.11.1.8"
+ (require (only-in racket/case case/equal-always))
+ (require (only-in racket/base [case case/equal-always])))
 
 (provide match)
 
@@ -126,7 +132,7 @@
      (relocate+reraw
       (respan stx)
       #`(let ([val #,in-expr])
-          (case val
+          (case/equal-always val
             #,@(for/list ([parsed (in-list lit-parseds)]
                           [rhs (in-list lit-rhss)])
                  (syntax-parse parsed

--- a/rhombus/tests/match.rhm
+++ b/rhombus/tests/match.rhm
@@ -1,4 +1,6 @@
 #lang rhombus
+import:
+  "version_guard.rhm"
 
 check:
   match Pair.cons(7, 8)
@@ -19,7 +21,8 @@ check:
 block:
   let mutable cnt = 0
   fun f(x):
-    // literals for initial patterns should be converted to `case` internally
+    // literals for initial patterns should be converted to
+    // `case/equal-always` internally
     match (block:
              // check whether expression is repeatedly evaluated
              cnt := cnt + 1
@@ -45,4 +48,21 @@ check (match 1 | 1 || 2: "yes") ~is "yes"
 check (match 2 | 1 || 2: "yes") ~is "yes"
 check (match 3 | 1 || 2: "yes") ~throws "no matching case"
 
-check ( match 'ok (1)' | '«ok '$x'»': "ok") ~throws "expected quotes"
+check (match 'ok (1)' | '«ok '$x'»': "ok") ~throws "expected quotes"
+
+version_guard.at_least "8.11.1.8":
+  // check `==` semantics applies as opposed to `is_now`
+  // in other words, `case/equal-always` is really used
+  check:
+    match Bytes.copy(#"byte string"):
+    | #"byte string": "matched"
+    | ~else: "unmatched"
+    ~is "unmatched"
+
+  check:
+    import:
+      lib("racket/base.rkt").#{string-copy}
+    match #{string-copy}("string"):
+    | "string": "matched"
+    | ~else: "unmatched"
+    ~is "unmatched"


### PR DESCRIPTION
This uses the change in racket/racket#4856 for `case` expansion, which requires a very recent development version of Racket.

Fix #417.