### PR TITLE
add `Array.of_length` annotation and reducer

### DIFF
--- a/rhombus/scribblings/ref-array.scrbl
+++ b/rhombus/scribblings/ref-array.scrbl
@@ -33,14 +33,18 @@ mutable and immutable arrays, while @rhombus(MutableArray, ~annot) and
 
 @doc(
   annot.macro 'Array'
+  annot.macro 'Array.of_length($expr)'
   annot.macro 'Array.now_of($annot)'
   annot.macro 'Array.later_of($annot)'
   annot.macro 'MutableArray'
   annot.macro 'ImmutableArray'
 ){
 
- The @rhombus(Array, ~annot) annotation (without @rhombus(now_of, ~datum) or
- @rhombus(later_of, ~datum)) matches any array.
+ The @rhombus(Array, ~annot) annotation (without
+ @rhombus(of_length, ~datum), @rhombus(now_of, ~datum), or
+ @rhombus(later_of, ~datum)) matches any array. The
+ @rhombus(Array.of_length, ~annot) annotation matches arrays of a
+ given length.
 
  The @rhombus(Array.now_of, ~annot) form constructs a @tech{predicate
   annotation} that matches an array whose elements all currently satisfy
@@ -71,6 +75,10 @@ mutable and immutable arrays, while @rhombus(MutableArray, ~annot) and
 
 @examples(
   ~repl:
+    Array(1, 2, 3) :: Array
+    Array(1, 2, 3) :: Array.of_length(3)
+    ~error:
+      Array(1, 2, 3) :: Array.of_length(5)
     Array(1, 2, 3) :: Array.now_of(Number)
     ~error:
       Array(1, "b", 3) :: Array.now_of(Number)
@@ -133,18 +141,27 @@ mutable and immutable arrays, while @rhombus(MutableArray, ~annot) and
 }
 
 @doc(
+  ~nonterminal:
+    len_expr: block expr
+    fill_expr: block expr
   reducer.macro 'Array'
-  reducer.macro 'Array ~length $expr'
+  reducer.macro 'Array.of_length($len_expr, $maybe_fill)'
+
+  grammar maybe_fill:
+    ~fill: $fill_expr
+    #,(@epsilon)
 ){
 
- A @tech{reducer} used with @rhombus(for), accumulates each result of a
+ @tech{Reducers} used with @rhombus(for), accumulates each result of a
  @rhombus(for) body into a result array.
 
- When a @rhombus(~length) clause is provided, an array of the specified
+ The @rhombus(Array.of_length, ~reducer) reducer, like the
+ corresponding annotation, produces an array of a given length.
+ Specifically, an array of the specified
  length is created and mutated by iterations of the @rhombus(for) body.
  Iterations more than the specified length will trigger an exception,
- while iterations fewer than the length will leave @rhombus(0) values in
- the array.
+ while iterations fewer than the length will leave the value of
+ @rhombus(fill_expr) (or @rhombus(0)) in the array.
 
 }
 

--- a/rhombus/scribblings/ref-reducer-macro.scrbl
+++ b/rhombus/scribblings/ref-reducer-macro.scrbl
@@ -20,6 +20,7 @@
 @doc(
   ~nonterminal:
     macro_patterns: expr.macro ~defn
+    maybe_each: for
 
   defn.macro 'reducer.macro $macro_patterns'
 ){
@@ -36,7 +37,7 @@
   ~eval: macro_eval
   ~defn:
     reducer.macro '(Array.len5)':
-      'Array ~length 5'
+      'Array.of_length(5)'
   ~repl:
     for Array.len5 (i: 0..3): i
 )
@@ -78,6 +79,10 @@
     for sum_pos_to_20 (a: [6, -4, 3]): a
     for sum_pos_to_20 (a: 3..): a
 )
+
+ @margin_note{It is recommended that a reducer macro only consume a
+  finite number of terms, as opposed to the whole tail, to account for
+  the @rhombus(maybe_each) position in @rhombus(for).}
 
  This example shows that reducers can be chained; specifically, it
  creates a @rhombus(counted) reducer, that chains onto an existing reducer

--- a/rhombus/tests/array.rhm
+++ b/rhombus/tests/array.rhm
@@ -31,7 +31,7 @@ block:
     arr.length()
     ~is 3
   check:
-    def arr :~ Array = dynamic(Array(1, 2, 3))
+    def arr :: Array.of_length(3) = dynamic(Array(1, 2, 3))
     arr.length()
     ~is 3
   check:
@@ -87,6 +87,10 @@ check:
   ~throws "does not satisfy annotation"
 
 check:
+  10 :: Array.of_length(1)
+  ~throws "does not satisfy annotation"
+
+check:
   10 :: Array.now_of(Any)
   ~throws "does not satisfy annotation"
 
@@ -96,6 +100,14 @@ check:
 
 check:
   10 :: Array.later_of(converting(fun (_): #false))
+  ~throws "does not satisfy annotation"
+
+check:
+  Array(1) :: Array.of_length(1)
+  ~completes
+
+check:
+  Array(1) :: Array.of_length(2)
   ~throws "does not satisfy annotation"
 
 check:

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -197,27 +197,32 @@ check:
   for Array:
     each i: 3..7
     i
-  ~prints_like Array(3, 4, 5, 6)
+  ~is_now Array(3, 4, 5, 6)
 
 check:
-  for Array ~length 6:
+  for Array.of_length(6):
     each i: 3..7
     i
-  ~prints_like Array(3, 4, 5, 6, 0, 0)
+  ~is_now Array(3, 4, 5, 6, 0, 0)
 
 check:
-  for Array ~length (1 + 5):
+  for Array.of_length(1 + 5):
     each i: 3..7
     i
-  ~prints_like Array(3, 4, 5, 6, 0, 0)
+  ~is_now Array(3, 4, 5, 6, 0, 0)
 
 check:
-  for Array ~length 6 (i: 3..7):
+  for Array.of_length(6) (i: 3..7):
     i
-  ~prints_like Array(3, 4, 5, 6, 0, 0)
+  ~is_now Array(3, 4, 5, 6, 0, 0)
 
 check:
-  for Array ~length 2:
+  for Array.of_length(6, ~fill: 42) (i: 3..7):
+    i
+  ~is_now Array(3, 4, 5, 6, 42, 42)
+
+check:
+  for Array.of_length(2):
     each i: 3..7
     i
   ~throws "index is out of range"

--- a/rhombus/tests/reducer-macro.rhm
+++ b/rhombus/tests/reducer-macro.rhm
@@ -2,7 +2,7 @@
 
 check:
   reducer.macro '(Array.len5)':
-    'Array ~length 5'
+    'Array.of_length(5)'
   for Array.len5 (i: 0..3): i
   ~is_now Array(0, 1, 2, 0, 0)
 


### PR DESCRIPTION
Mainly to replace the `~length` form of `Array`.  My rationale is that reducer macros should consume a finite number of terms in the presence of the `each` shorthand; the existing parsing hack makes me very uncomfortable.  Having a grouping in hand also makes it possible to add a `~fill` option, as in `for/vector`.