### PR TITLE
add support for annotations in `values` reducer

### DIFF
--- a/gui_demo.rhm
+++ b/gui_demo.rhm
@@ -46,7 +46,8 @@ fun draw_face(dc :: draw.DC, config :: Map):
 
     // draw ghost dots (showing recent mouse movements)
     let dot_size = [4, 4]
-    for values(brush = draw.Brush(~color: draw.Color(0, 0, 0, 0.25))):
+    for values(brush :~ draw.Brush:
+                 draw.Brush(~color: draw.Color(0, 0, 0, 0.25))):
       each [x, y]: (config["ghosts"] :: List).reverse()
       dc.brush := brush
       let x = x/scale

--- a/rhombus/private/boolean-reducer.rkt
+++ b/rhombus/private/boolean-reducer.rkt
@@ -1,10 +1,7 @@
 #lang racket/base
 (require (for-syntax racket/base
-                     syntax/parse/pre
-                     "annotation-string.rkt")
-         "reducer.rkt"
-         "parse.rkt"
-         "static-info.rkt")
+                     syntax/parse/pre)
+         "reducer.rkt")
 
 (provide (for-space rhombus/reducer
                     all
@@ -18,6 +15,7 @@
         (values (reducer
                  #'build-result
                  #'([result #true])
+                 #f
                  #'build-accum
                  #f
                  #'build-stop-false
@@ -34,6 +32,7 @@
         (values (reducer
                  #'build-result
                  #'([result #f])
+                 #f
                  #'build-accum
                  #f
                  #'build-stop-true

--- a/rhombus/private/reducer-macro.rkt
+++ b/rhombus/private/reducer-macro.rkt
@@ -125,6 +125,7 @@
 (begin-for-syntax
   (define/arity (reducer_meta.pack wrapper-id-in
                                    binds
+                                   maybe-pre-clause-id-in
                                    step-id-in
                                    maybe-break-id-in
                                    maybe-final-id-in
@@ -134,6 +135,7 @@
     #:static-infos ((#%call-result #,syntax-static-infos))
     (define wrapper-id (unpack-identifier who wrapper-id-in))
     (check-syntax who binds)
+    (define maybe-pre-clause-id (unpack-maybe-identifier who maybe-pre-clause-id-in))
     (define step-id (unpack-identifier who step-id-in))
     (define maybe-break-id (unpack-maybe-identifier who maybe-break-id-in))
     (define maybe-final-id (unpack-maybe-identifier who maybe-final-id-in))
@@ -153,36 +155,45 @@
                          #,(reducer
                             #'chain-to-wrapper
                             packed-binds
+                            (and maybe-pre-clause-id #'chain-to-pre-clause-former)
                             #'chain-to-body-wrapper
                             (and maybe-break-id #'chain-to-breaker)
                             (and maybe-final-id #'chain-to-finaler)
                             #'chain-to-finisher
                             si
-                            #`[#,wrapper-id #,step-id #,maybe-break-id #,maybe-final-id #,finish-id #,data])))))
+                            #`[#,wrapper-id
+                               #,maybe-pre-clause-id
+                               #,step-id #,maybe-break-id #,maybe-final-id #,finish-id
+                               #,data])))))
 
 (define-syntax (chain-to-wrapper stx)
   (syntax-parse stx
-    [(_ [wrapper-id step-id break-id final-id finish-id data] e)
+    [(_ [wrapper-id pre-clause-id step-id break-id final-id finish-id data] e)
      #'(rhombus-expression (group wrapper-id data (parsed #:rhombus/expr e)))]))
+
+(define-syntax (chain-to-pre-clause-former stx)
+  (syntax-parse stx
+    [(_ [wrapper-id pre-clause-id step-id break-id final-id finish-id data])
+     #'(rhombus-definition (group pre-clause-id data))]))
 
 (define-syntax (chain-to-body-wrapper stx)
   (syntax-parse stx
-    [(_ [wrapper-id step-id break-id final-id finish-id data] e)
+    [(_ [wrapper-id pre-clause-id step-id break-id final-id finish-id data] e)
      #'(rhombus-definition (group step-id data (parsed #:rhombus/expr e)))]))
 
 (define-syntax (chain-to-breaker stx)
   (syntax-parse stx
-    [(_ [wrapper-id step-id break-id final-id finish-id data])
+    [(_ [wrapper-id pre-clause-id step-id break-id final-id finish-id data])
      #'(rhombus-expression (group break-id data))]))
 
 (define-syntax (chain-to-finaler stx)
   (syntax-parse stx
-    [(_ [wrapper-id step-id break-id final-id finish-id data])
+    [(_ [wrapper-id pre-clause-id step-id break-id final-id finish-id data])
      #'(rhombus-expression (group final-id data))]))
 
 (define-syntax (chain-to-finisher stx)
   (syntax-parse stx
-    [(_ [wrapper-id step-id break-id final-id finish-id data])
+    [(_ [wrapper-id pre-clause-id step-id break-id final-id finish-id data])
      #'(rhombus-expression (group finish-id data))]))
 
 (begin-for-syntax
@@ -194,13 +205,17 @@
        #`(parens (group chain-back-to-wrapper)
                  (group (parens (group r.id rhombus= (parsed #:rhombus/expr r.init-expr))
                                 ...))
+                 (group #,(and (syntax-e #'r.pre-clause-former) #'chain-back-to-pre-clauser))
                  (group chain-back-to-body-wrapper)
                  (group #,(and (syntax-e #'r.break-whener) #'chain-back-to-breaker))
                  (group #,(and (syntax-e #'r.final-whener) #'chain-back-to-finaler))
                  (group chain-back-to-finisher)
                  (group #,(unpack-static-infos who #'r.static-infos))
                  (group (parsed #:rhombus/reducer/chain
-                                (r.wrapper r.body-wrapper r.break-whener r.final-whener r.finisher r.data))))]
+                                (r.wrapper
+                                 r.pre-clause-former
+                                 r.body-wrapper r.break-whener r.final-whener r.finisher
+                                 r.data))))]
       [_ (raise-arguments-error* who rhombus-realm
                                  "not a parsed reducer form"
                                  "syntax object" stx)])))
@@ -211,8 +226,18 @@
      (syntax-parse stx
        #:datum-literals (parsed group)
        [(_ (parsed #:rhombus/reducer/chain
-                   (wrapper body-wrapper breaker finaler finisher data)) e)
+                   (wrapper pre-clause-former body-wrapper breaker finaler finisher data))
+           e)
         (values #'(wrapper data (rhombus-expression (group e))) #'())]))))
+
+(define-syntax chain-back-to-pre-clauser
+  (definition-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       #:datum-literals (parsed group)
+       [(_ (parsed #:rhombus/reducer/chain
+                   (wrapper pre-clause-former body-wrapper breaker finaler finisher data)))
+        (list #'(pre-clause-former data))]))))
 
 (define-syntax chain-back-to-body-wrapper
   (definition-transformer
@@ -220,7 +245,8 @@
      (syntax-parse stx
        #:datum-literals (parsed group)
        [(_ (parsed #:rhombus/reducer/chain
-                   (wrapper body-wrapper breaker finaler finisher data)) e)
+                   (wrapper pre-clause-former body-wrapper breaker finaler finisher data))
+           e)
         (list #'(body-wrapper data (rhombus-expression (group e))))]))))
 
 (define-syntax chain-back-to-breaker
@@ -229,7 +255,7 @@
      (syntax-parse stx
        #:datum-literals (parsed group)
        [(_ (parsed #:rhombus/reducer/chain
-                   (wrapper body-wrapper breaker finaler finisher data)))
+                   (wrapper pre-clause-former body-wrapper breaker finaler finisher data)))
         (values #'(finisher data) #'())]))))
 
 (define-syntax chain-back-to-finaler
@@ -238,7 +264,7 @@
      (syntax-parse stx
        #:datum-literals (parsed group)
        [(_ (parsed #:rhombus/reducer/chain
-                   (wrapper body-wrapper breaker finaler finisher data)))
+                   (wrapper pre-clause-former body-wrapper breaker finaler finisher data)))
         (values #'(finaler data) #'())]))))
 
 (define-syntax chain-back-to-finisher
@@ -247,5 +273,5 @@
      (syntax-parse stx
        #:datum-literals (parsed group)
        [(_ (parsed #:rhombus/reducer/chain
-                   (wrapper body-wrapper breaker finaler finisher data)))
+                   (wrapper pre-clause-former body-wrapper breaker finaler finisher data)))
         (values #'(finisher data) #'())]))))

--- a/rhombus/scribblings/ref-reducer-macro.scrbl
+++ b/rhombus/scribblings/ref-reducer-macro.scrbl
@@ -54,6 +54,7 @@
       reducer_meta.pack(
         'sptt_return',
         '(accum = 0)',
+        #false,
         'sptt_step_defs',
         #false,
         'sptt_final',
@@ -91,7 +92,7 @@
   ~defn:
     reducer.macro 'counted($(r :: reducer_meta.Parsed))':
       let '($wrap, ($(bind && '$id $_'), ...),
-            $step, $break, $final, $finish,
+            $pre, $step, $break, $final, $finish,
             $si, $data)':
         reducer_meta.unpack(r)
       let [si, ...]:
@@ -102,6 +103,7 @@
       reducer_meta.pack(
         'build_return',
         '(count = 0, $bind, ...)',
+        pre.unwrap() && 'build_pre',
         'build_inc',
         break.unwrap() && 'build_break',
         final.unwrap() && 'build_final',
@@ -109,10 +111,10 @@
         '(($statinfo_meta.values_key,
            $(statinfo_meta.pack_group('$si ... ()'))))',
         '[[count, $id, ...],
-          $wrap, $step, $break, $final, $finish,
+          $wrap, $pre, $step, $break, $final, $finish,
           $data]'
       )
-    expr.macro 'build_return [$_, $wrap, $_, $_, $_, $_, $data] $e':
+    expr.macro 'build_return [$_, $wrap, $_, $_, $_, $_, $_, $data] $e':
       'call_with_values(
          fun (): $e,
          fun
@@ -124,14 +126,16 @@
                fun (): $wrap $data (values(r, $('...'))),
                fun (r, $('...')): values(r, $('...'), c)
              ))'
-    defn.macro 'build_inc [$_, $_, $step, $_, $_, $_, $data] $e':
+    defn.macro 'build_pre [$_, $_, $pre, $_, $_, $_, $_, $data]':
+      '$pre $data'
+    defn.macro 'build_inc [$_, $_, $_, $step, $_, $_, $_, $data] $e':
       '$step $data $e'
-    expr.macro 'build_break [$_, $_, $_, $break, $_, $_, $data]':
+    expr.macro 'build_break [$_, $_, $_, $_, $break, $_, $_, $data]':
       '$break $data'
-    expr.macro 'build_final [$_, $_, $_, $_, $final, $_, $data]':
+    expr.macro 'build_final [$_, $_, $_, $_, $_, $final, $_, $data]':
       '$final $data'
     expr.macro 'build_finish [[$count, $id, ...],
-                              $_, $_, $_, $_, $finish,
+                              $_, $_, $_, $_, $_, $finish,
                               $data]':
       'block:
          def ($id, ...) = $finish $data
@@ -163,6 +167,7 @@
 @doc(
   fun reducer_meta.pack(complete_id :: Identifier,
                         binds :: Syntax,
+                        pre_clause_id :: maybe(Identifier),
                         step_id :: Identifier,
                         break_id :: maybe(Identifier),
                         final_id :: maybe(Identifier),
@@ -181,6 +186,7 @@
  @rhombusblock(
   '(#,(@rhombus(complete_id, ~var)),    // expression macro
     (#,(@rhombus(accum_id, ~var)) = #,(@rhombus(accum_expr, ~var)), ...),
+    #,(@rhombus(pre_clause_id, ~var)),  // optional definition macro
     #,(@rhombus(step_id, ~var)),        // definition macro
     #,(@rhombus(break_id, ~var)),       // optional expression macro
     #,(@rhombus(final_id, ~var)),       // optional expression macro
@@ -196,10 +202,11 @@
  termination of the iteration depending on element values or an
  accumulated value.
 
- As an example, for the @rhombus(List, ~reducer),
+ As an example, for the @rhombus(List, ~reducer) reducer,
  @rhombus(complete_id, ~var) reverses an accumulated list, one
  @rhombus(accum_id, ~var) is initialized to @rhombus([]) and represents
- an accumulated (in reverse) list, @rhombus(step_id, ~var) adds a new
+ an accumulated (in reverse) list, @rhombus(pre_clause_id, ~var) is
+ false, @rhombus(step_id, ~var) adds a new
  value to the front of the list and binds it to a fresh variable
  @rhombus(next_accum_id, ~var), @rhombus(break_id) and @rhombus(final_id)
  are false (because early termination is never needed by the reducer),
@@ -228,13 +235,20 @@
   input. When no further inputs are available, @rhombus(complete_id, ~var)
   receives the final state to convert it in to the result value.}
 
+ @item{The optional @rhombus(pre_clause_id, ~var) should refer to
+  a macro that expects @rhombus(data, ~var) and produces definitions
+  to be placed before any @rhombus(for) clauses, therefore visible to
+  the whole @rhombus(for) body. For example, it can be used to provide
+  static information for @rhombus(accum_id, ~var)s, which should be
+  visible even in @rhombus(for) clauses.}
+
  @item{The @rhombus(step_id, ~var) should refer to a macro that expects
   @rhombus(data, ~var) followed by an expression that produces a value (or
   multiple values) to be accumulated. It should expand to definitions that
   bind whatever is needed by @rhombus(break_id, ~var),
   @rhombus(final_id, ~var), and especially @rhombus(step_result_id, ~var).}
 
- @item{The optional @rhombus(break_id, ~var) identifier should refer to
+ @item{The optional @rhombus(break_id, ~var) should refer to
   a macro that expects @rhombus(data, ~var) and produces a boolean that
   indicates whether to stop the iteration with the value(s) accumulated
   through previous steps, not accumulating in this step. Supplying
@@ -242,7 +256,7 @@
   needed before the iteration would otherwise complete, which might
   enable a more efficient compilation.}
 
- @item{The optional @rhombus(final_id, ~var) identifier should refer to
+ @item{The optional @rhombus(final_id, ~var) should refer to
   a macro that expects @rhombus(data, ~var) and produces a boolean that
   indicates whether to stop the iteration after the accumulation of the
   current step. Like @rhombus(break_id), Supplying @rhombus(#false) for

--- a/rhombus/scribblings/ref-values.scrbl
+++ b/rhombus/scribblings/ref-values.scrbl
@@ -57,13 +57,24 @@
 }
 
 @doc(
-  reducer.macro 'values($id = $expr, ...)'
+  reducer.macro 'values($id $maybe_annot $init, ...)'
+
+  grammar maybe_annot:
+    #,(@rhombus(::, ~bind)) $annot
+    #,(@rhombus(:~, ~bind)) $annot
+    #,(epsilon)
+
+  grammar init:
+    = $expr
+    : $body; ...
 ){
 
  A @tech{reducer} used with @rhombus(for), expects as many results from a
- @rhombus(for) body as @rhombus(id)s. For the first iteration of
+ @rhombus(for) body as @rhombus(id)s. When @rhombus(id) is
+ @rhombus(_, ~bind), a fresh identifier is used, otherwise
+ @rhombus(id) is bound as follows. For the first iteration of
  the @rhombus(for) body, each @rhombus(id)'s value is the result
- of the corresponding @rhombus(expr). The results of a @rhombus(for) body
+ of the corresponding @rhombus(init). The results of a @rhombus(for) body
  for one iteration then serve as the values of the @rhombus(id)s
  for the next iteration. The values of the whole @rhombus(for) expression
  are the final values of the @rhombus(id)s.

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -160,6 +160,117 @@ check:
 
 check:
   use_static
+  def set:
+    for values(set :~ Set = dynamic({1, 4, 9, 16, 25})):
+      each i: 0..8
+      if set[i] | set.remove(i) | set
+  set ++ {36}
+  ~is {9, 16, 25, 36}
+
+check:
+  use_static
+  def set:
+    for values(set :: Set = dynamic({1, 4, 9, 16, 25})):
+      each i: 0..8
+      if set[i] | set.remove(i) | set
+  set ++ {36}
+  ~is {9, 16, 25, 36}
+
+check:
+  use_static
+  for values(set :~ Set = dynamic({1, 4, 9, 16, 25})):
+    each i: 0..8
+    keep_when set[i]
+    set.remove(i)
+  ~is {9, 16, 25}
+
+check:
+  use_static
+  for values(set :: Set = dynamic({1, 4, 9, 16, 25})):
+    each i: 0..8
+    keep_when set[i]
+    set.remove(i)
+  ~is {9, 16, 25}
+
+check:
+  for values(_ = 0, _ = 0+1):
+    each i: 0..8
+    values(i, i+1)
+  ~is values(7, 8)
+
+check:
+  for values(_ :~ Int = 0, _ :~ Int = 0+1):
+    each i: 0..8
+    values(i, i+1)
+  ~is values(7, 8)
+
+check:
+  for values(_ :: Int = 0, _ :: Int = 0+1):
+     each i: 0..8
+     values(i, i+1)
+  ~is values(7, 8)
+
+check:
+  for values(_ :~ Int = 0, _ :~ Int = 0+1):
+    each _: 0..8
+    values("oops", "oh no")
+  ~is values("oops", "oh no")
+
+check:
+  for values(_ :~ Int = 0, _ :: Int = 0+1):
+    each _: 0..8
+    values("oops", "oh no")
+  ~throws values(
+    "value does not satisfy annotation",
+    "\"oh no\"",
+    "Int",
+  )
+
+check:
+  for values(_ :: Int = 0, _ :: Int = 0+1):
+    each _: 0..8
+    values("oops", "oh no")
+  ~throws values(
+    "value does not satisfy annotation",
+    "\"oops\"",
+    "Int",
+  )
+
+check:
+  for values(_ :~ Int = "oops", _ :~ Int = "oh no"):
+    each i: 0..8
+    values(i, i+1)
+  ~is values(7, 8)
+
+check:
+  for values(_ :~ Int = "oops", _ :: Int = "oh no"):
+    each i: 0..8
+    values(i, i+1)
+  ~throws values(
+    "value does not satisfy annotation",
+    "\"oh no\"",
+    "Int",
+  )
+
+check:
+  for values(_ :: Int = "oops", _ :: Int = "oh no"):
+    each i: 0..8
+    values(i, i+1)
+  ~throws values(
+    "value does not satisfy annotation",
+    "\"oops\"",
+    "Int",
+  )
+
+check:
+  for values(_: println("first"); 0, _: println("second"); 0+1):
+    each i: 0..8
+    println(i)
+    values(i, i+1)
+  ~prints "first\nsecond\n0\n1\n2\n3\n4\n5\n6\n7\n"
+
+check:
+  use_static
   class Posn(x, y)
   fun point_xs(l :~ List.of(List.of(Posn))):
     for:

--- a/rhombus/tests/reducer-macro.rhm
+++ b/rhombus/tests/reducer-macro.rhm
@@ -13,6 +13,7 @@ block:
       annot_meta.unpack_predicate(a)
     reducer_meta.pack('build_reverse',
                       '(l = List.empty)',
+                      #false,
                       'build_cons',
                       #false,
                       #false,
@@ -39,7 +40,7 @@ block:
 block:
   reducer.macro 'counted($(r :: reducer_meta.Parsed))':
     let '($wrap, ($(bind && '$id $_'), ...),
-          $step, $break, $final, $finish,
+          $pre, $step, $break, $final, $finish,
           $si, $data)':
       reducer_meta.unpack(r)
     let [si, ...]:
@@ -50,6 +51,7 @@ block:
     reducer_meta.pack(
       'build_return',
       '(count = 0, $bind, ...)',
+      pre.unwrap() && 'build_pre',
       'build_inc',
       break.unwrap() && 'build_break',
       final.unwrap() && 'build_final',
@@ -57,10 +59,10 @@ block:
       '(($statinfo_meta.values_key,
          $(statinfo_meta.pack_group('$si ... ()'))))',
       '[[count, $id, ...],
-        $wrap, $step, $break, $final, $finish,
+        $wrap, $pre, $step, $break, $final, $finish,
         $data]'
     )
-  expr.macro 'build_return [$_, $wrap, $_, $_, $_, $_, $data] $e':
+  expr.macro 'build_return [$_, $wrap, $_, $_, $_, $_, $_, $data] $e':
     'call_with_values(
        fun (): $e,
        fun
@@ -71,14 +73,16 @@ block:
              fun (): $wrap $data (values(r, $('...'))),
              fun (r, $('...')): values(r, $('...'), c)
            ))'
-  defn.macro 'build_inc [$_, $_, $step, $_, $_, $_, $data] $e':
+  defn.macro 'build_pre [$_, $_, $pre, $_, $_, $_, $_, $data]':
+    '$pre $data'
+  defn.macro 'build_inc [$_, $_, $_, $step, $_, $_, $_, $data] $e':
     '$step $data $e'
-  expr.macro 'build_break [$_, $_, $_, $break, $_, $_, $data]':
+  expr.macro 'build_break [$_, $_, $_, $_, $break, $_, $_, $data]':
     '$break $data'
-  expr.macro 'build_final [$_, $_, $_, $_, $final, $_, $data]':
+  expr.macro 'build_final [$_, $_, $_, $_, $_, $final, $_, $data]':
     '$final $data'
   expr.macro 'build_finish [[$count, $id, ...],
-                            $_, $_, $_, $_, $finish,
+                            $_, $_, $_, $_, $_, $finish,
                             $data]':
     'block:
        def ($id, ...) = $finish $data


### PR DESCRIPTION
Instead of unsound propagation of static infos from the initial expressions, use static infos from inline annotations, which can be unchecked as usual (and the user is responsible for that).

Also add support for
- `_` in place of id;
- block-style initial expressions;
- propagation of static infos for results.

Fix #449.