### PR TITLE
change precedence of `::` and `:~`

### DIFF
--- a/rhombus/private/annotation.rkt
+++ b/rhombus/private/annotation.rkt
@@ -136,10 +136,10 @@
     #:check-result check-annotation-result
     #:make-identifier-form raise-not-a-annotation)
 
-  (define-syntax-class :annotation-seq
+  (define-syntax-class (:annotation-seq prec-op)
     #:attributes (parsed tail)
     (pattern stxes
-             #:with (~var || (:annotation-infix-op+form+tail #'::)) #`(#,group-tag . stxes)))
+             #:with (~var || (:annotation-infix-op+form+tail prec-op)) #`(#,group-tag . stxes)))
 
   (define-splicing-syntax-class :inline-annotation
     #:attributes (converter annotation-str static-infos)
@@ -400,7 +400,7 @@
    'macro
    (lambda (form tail)
      (syntax-parse tail
-       [(op::name . t::annotation-seq)
+       [(op::name . (~var t (:annotation-seq #'::)))
         (values
          (build-annotated-expression #'op.name #'t
                                      checked? form #'t.parsed
@@ -458,7 +458,7 @@
    'macro
    (lambda (form tail)
      (syntax-parse tail
-       [(op::name . t::annotation-seq)
+       [(op::name . (~var t (:annotation-seq #'::)))
         #:with left::binding-form form
         (values
          (syntax-parse #'t.parsed
@@ -501,7 +501,7 @@
    'macro
    (lambda (form tail)
      (syntax-parse tail
-       [(op . t::annotation-seq)
+       [(op . (~var t (:annotation-seq #'is_a)))
         (values
          (syntax-parse #'t.parsed
            [c-parsed::annotation-predicate-form
@@ -812,9 +812,16 @@
 (define (negative-real? r) (and (real? r) (r . < . 0.0)))
 (define (nonnegative-real? r) (and (real? r) (r . >= . 0.0)))
 
-;; not exported, but referenced by `:annotation-seq` so that
+;; not exported, but referenced by `:annotation-seq` uses so that
 ;; annotation parsing terminates appropriately
 (define-annotation-syntax ::
+  (annotation-infix-operator
+   (annot-quote ::)
+   `((default . weaker))
+   'macro
+   (lambda (stx) (error "should not get here"))
+   'none))
+(define-annotation-syntax is_a
   (annotation-infix-operator
    (annot-quote ::)
    `((default . stronger))

--- a/rhombus/tests/annotation.rhm
+++ b/rhombus/tests/annotation.rhm
@@ -1,13 +1,28 @@
 #lang rhombus
 
-// check for sensible precedence of `::` mixed with expression
+// check for sensible precedence of `is_a` mixed with expression
 check:
-  "a" :: String && #true ~is #true
-  "a" :: String +& "ok" ~is "aok"
+  "a" is_a String && #true ~is #true
+  "a" is_a String +& "ok" ~is "#trueok"
+
+// check for different precedence of `::`, especially intended
+// for bindings
+check:
+  ~eval
+  "a" :: String && #true
+  ~throws  "literal not allowed as an annotation"
+check:
+  ("a" :: String) && #true ~is #true
+  (block:
+     def x :: String || Int = "ok"
+     x) ~is "ok"
+  (block:
+     def x :: String || Int = 5
+     x) ~is 5
 
 check:
   ~eval
-  "a" :: PosInt . count()
+  "a" is_a PosInt . count()
   ~throws "operators with inconsistently declared precedence"
 
 check:


### PR DESCRIPTION
This change causes

```
fun f(x :: String || Int): "ok"
```

to define a function that accepts a string or integer, not a function that accepts anything by matching either `x :: String` or `Int` (as an identifier that matches anything).

The old precedence for `::` was intended to contexts where `is_a` is better or more likely, while the opposite precedence works better in binding positions where `::` and `:~` are more typically used. The `is_a` operator is not changed here, so `p is_a Posn && p.x` is still `(p is_a Posn) && p.x`, not `p is_a (Posn && p.x)`.

If this change seems ok, it probably won't break many programs, but it still might be best included with a set of upcoming changes.