### PR TITLE
allow `~open` in `pattern` shorthands

### DIFF
--- a/rhombus/private/unquote-binding-primitive.rkt
+++ b/rhombus/private/unquote-binding-primitive.rkt
@@ -184,7 +184,10 @@
 
 (define-for-syntax (parse-pattern stx)
   (syntax-parse stx
-    [(form-id (~optional form1:identifier) . tail)
+    [(form-id
+      (~optional (~seq form1:identifier
+                       (~optional (~and #:open (~bind [open? #t])))))
+      . tail)
      (parameterize ([inline-attr-depth (cond
                                          [(inline-attr-depth) => add1]
                                          [else 0])]
@@ -199,7 +202,8 @@
                    (build-syntax-class-pattern stx
                                                rsc
                                                #'#f
-                                               (and (not (attribute form1))
+                                               (and (or (not (attribute form1))
+                                                        (attribute open?))
                                                     #'form-id)
                                                (attribute form1)
                                                #f)

--- a/rhombus/scribblings/ref-stxobj.scrbl
+++ b/rhombus/scribblings/ref-stxobj.scrbl
@@ -513,18 +513,19 @@ Metadata for a syntax object can include a source location and the raw
     class_clause: syntax_class ~defn
     pattern_case: syntax_class ~defn
 
-  bind.macro 'pattern $maybe_id:
+  bind.macro 'pattern $maybe_id_open:
                 $class_clause
                 ...
               | $pattern_case
               | ...'
-  unquote_bind.macro 'pattern $maybe_id:
+  unquote_bind.macro 'pattern $maybe_id_open:
                         $class_clause
                         ...
                       | $pattern_case
                       | ...'
 
-  grammar maybe_id:
+  grammar maybe_id_open:
+    $id ~open
     $id
     #,(epsilon)
 ){
@@ -533,6 +534,8 @@ Metadata for a syntax object can include a source location and the raw
  matching with an inline @rhombus(syntax_class) form. It has the same
  grammar as inline @rhombus(syntax_class), except that an @rhombus(id)
  can be present with the same meaning as in
+ @rhombus(::, ~unquote_bind); moreover, when @rhombus(~open) is
+ present, the match is @rhombus(open, ~impo)ed in the same sense as in
  @rhombus(::, ~unquote_bind). The @rhombus(id) can also be omitted, in
  which case the match isn't bound but all fields are available.
 

--- a/rhombus/tests/syntax-class.rhm
+++ b/rhombus/tests/syntax-class.rhm
@@ -667,6 +667,35 @@ block:
     m('8 1; 9 2 3')
     ~matches ['1', '2']
 
+block:
+  fun m(stx):
+    def '$(pattern match ~open
+           | '9 $x $_'
+           | '8 $x':
+               match_when #true); ...' = stx
+    [x, ...]
+  check:
+    m('8 1')
+    ~matches ['1']
+  check:
+    m('8 1; 9 2 3')
+    ~matches ['1', '2']
+
+block:
+  fun m(stx):
+    def '$(pattern match ~open:
+             kind ~sequence
+           | '9 $x $_'
+           | '8 $x':
+               match_when #true); ...' = stx
+    [x, ...]
+  check:
+    m('8 1')
+    ~matches ['1']
+  check:
+    m('8 1; 9 2 3')
+    ~matches ['1', '2']
+
 // pattern shorthand binding
 block:
   fun m(stx):
@@ -724,6 +753,35 @@ block:
          | '8 $x':
              match_when #true, ...] = stx
     [match.x, ...]
+  check:
+    m(['8 1'])
+    ~matches ['1']
+  check:
+    m(['8 1', '9 2 3'])
+    ~matches ['1', '2']
+
+block:
+  fun m(stx):
+    def [pattern match ~open
+         | '9 $x $_'
+         | '8 $x':
+             match_when #true, ...] = stx
+    [x, ...]
+  check:
+    m(['8 1'])
+    ~matches ['1']
+  check:
+    m(['8 1', '9 2 3'])
+    ~matches ['1', '2']
+
+block:
+  fun m(stx):
+    def [pattern match ~open:
+           kind ~sequence
+         | '9 $x $_'
+         | '8 $x':
+             match_when #true, ...] = stx
+    [x, ...]
   check:
     m(['8 1'])
     ~matches ['1']


### PR DESCRIPTION
This form is useful when you need to name a match, but the match’s attributes are already being used.