### PR TITLE
use internal-definition contexts for `let` scopes

### DIFF
--- a/rhombus/private/forwarding-sequence.rkt
+++ b/rhombus/private/forwarding-sequence.rkt
@@ -149,7 +149,7 @@
          #:literals (begin define-values define-syntaxes rhombus-forward pop-forward #%require provide #%provide quote-syntax
                            define-syntax-parameter)
          [(rhombus-forward sub-form ...)
-          (define introducer (make-syntax-introducer #t))
+          (define introducer (make-syntax-introducer/intdef))
           #`(begin
               #,@(reverse accum)
               (sequence [state base-ctx #,(introducer #'add-ctx) base-ctx stx-params]
@@ -267,6 +267,12 @@
                          [(#:module wrap) #`(wrap #,exp-form)]
                          [_ exp-form]))])
                 (sequence [#,(saw-end-expr #'state) base-ctx add-ctx remove-ctx stx-params] . forms))])])))
+
+;; use internal-definition contexts to allow scope pruning
+(define-for-syntax (make-syntax-introducer/intdef)
+  (define intdef-ctx (syntax-local-make-definition-context))
+  (lambda (stx)
+    (internal-definition-context-add-scopes intdef-ctx stx)))
 
 (define-syntax (rhombus-forward stx)
   (raise-syntax-error #f

--- a/rhombus/tests/let.rhm
+++ b/rhombus/tests/let.rhm
@@ -19,3 +19,17 @@ check:
 check:
   check_later()
   ~is "ok"
+
+// check scope pruning in `let`
+check:
+  import:
+    meta -1:
+      rhombus/meta.syntax_meta
+  let (id1, id2):
+    let id1 = Syntax.literal 'id'
+    values(id1, Syntax.literal 'id')
+  let id3 = Syntax.literal 'id'
+  syntax_meta.equal_name_and_scopes(id1, id2)
+    && syntax_meta.equal_name_and_scopes(id1, id3)
+    && syntax_meta.equal_name_and_scopes(id2, id3)
+  ~is #true


### PR DESCRIPTION
*(Is this a reasonable solution?)*

This allows the scope-pruning behavior of `quote-syntax` to apply.

Fix #467.