### PR TITLE
add use-site scopes for definition and expression expansion

### DIFF
--- a/enforest/name-root.rkt
+++ b/enforest/name-root.rkt
@@ -21,7 +21,7 @@
     (call-as-transformer
      op-stx
      (list stxes)
-     syntax-track-origin
+     syntax-track-origin #f
      (lambda (stxes)
        (define-values (target tail) (proc in-space stxes))
        (unless (or (identifier? target)

--- a/enforest/operator.rkt
+++ b/enforest/operator.rkt
@@ -214,46 +214,46 @@
 (define (lookup-space-description space-sym)
   #f)
 
-(define (apply-prefix-direct-operator op form stx track-origin checker)
+(define (apply-prefix-direct-operator op form stx track-origin use-site-scopes? checker)
   (define proc (operator-proc op))
   (checker (call-as-transformer
             stx
             (list form)
-            track-origin
+            track-origin use-site-scopes?
             (lambda (form)
               (proc form stx)))
            proc))
 
-(define (apply-infix-direct-operator op form1 form2 stx track-origin checker)
+(define (apply-infix-direct-operator op form1 form2 stx track-origin use-site-scopes? checker)
   (define proc (operator-proc op))
   (checker (call-as-transformer
             stx
             (list form1 form2)
-            track-origin
+            track-origin use-site-scopes?
             (lambda (form1 form2)
               (proc form1 form2 stx)))
            proc))
 
-(define (apply-prefix-transformer-operator op op-stx tail track-origin checker)
+(define (apply-prefix-transformer-operator op op-stx tail track-origin use-site-scopes? checker)
   (define proc (operator-proc op))
   (define-values (form new-tail)
     (call-as-transformer
      op-stx
      (list tail)
-     track-origin
+     track-origin use-site-scopes?
      (lambda (tail)
        (define-values (form new-tail) (proc tail))
        (values (checker form proc)
                new-tail))))
   (check-transformer-result form new-tail proc))
 
-(define (apply-infix-transformer-operator op op-stx form1 tail track-origin checker)
+(define (apply-infix-transformer-operator op op-stx form1 tail track-origin use-site-scopes? checker)
   (define proc (operator-proc op))
   (define-values (form new-tail)
     (call-as-transformer
      op-stx
      (list form1 tail)
-     track-origin
+     track-origin use-site-scopes?
      (lambda (form1 tail)
        (define-values (form new-tail) (proc form1 tail))
        (values (checker form proc)

--- a/enforest/sequence.rkt
+++ b/enforest/sequence.rkt
@@ -47,7 +47,9 @@
               (~optional (~seq #:check-result check-result)
                          #:defaults ([check-result #'check-is-syntax]))
               (~optional (~seq #:track-origin track-origin)
-                         #:defaults ([track-origin #'syntax-track-origin])))
+                         #:defaults ([track-origin #'syntax-track-origin]))
+              (~optional (~seq #:use-site-scopes? use-site-scopes?)
+                         #:defaults ([use-site-scopes? #'#f])))
         ...)
      #`(begin
          (define-syntax-class form
@@ -64,7 +66,7 @@
              (apply-sequence-transformer t (transform-out head-id)
                                          (transform-out (datum->syntax #f (cons head-name head-tail)))
                                          tail-tail
-                                         track-origin
+                                         track-origin use-site-scopes?
                                          check-result))
            (values (transform-in parsed) (transform-in remaining-tail)))
          #,@(if (syntax-e #'form?)
@@ -76,13 +78,13 @@
                        [_ #f])))
                 '()))]))
 
-(define (apply-sequence-transformer t id stx tail track-origin checker)
+(define (apply-sequence-transformer t id stx tail track-origin use-site-scopes? checker)
   (define proc (sequence-transformer-proc t))
   (define-values (forms new-tail)
     (call-as-transformer
      id
      (list stx tail)
-     track-origin
+     track-origin use-site-scopes?
      (lambda (stx tail)
        (define-values (forms new-tail) (proc stx tail))
        (values (datum->syntax #f (checker forms proc))

--- a/enforest/transformer.rkt
+++ b/enforest/transformer.rkt
@@ -53,7 +53,9 @@
               (~optional (~seq #:check-result check-result)
                          #:defaults ([check-result #'check-is-syntax]))
               (~optional (~seq #:track-origin track-origin)
-                         #:defaults ([track-origin #'syntax-track-origin])))
+                         #:defaults ([track-origin #'syntax-track-origin]))
+              (~optional (~seq #:use-site-scopes? use-site-scopes?)
+                         #:defaults ([use-site-scopes? #'#f])))
         ...)
      #`(begin
          (define-syntax-class form
@@ -69,7 +71,7 @@
                                                       (begin
                                                         (transform-out ; from an enclosing transformer
                                                          (datum->syntax #f (cons #'hname.name #'hname.tail))))
-                                                      track-origin
+                                                      track-origin use-site-scopes?
                                                       check-result)))
            (pattern ((~datum group) (~and head ((~datum parsed) tag inside . inside-tail)) . tail)
                     #:when (eq? (syntax-e #'tag) 'parsed-tag)
@@ -87,7 +89,7 @@
                                    (apply-transformer t (transform-out implicit-id)
                                                       (transform-out
                                                        (datum->syntax #f (list* implicit-name #'head #'tail)))
-                                                      track-origin
+                                                      track-origin use-site-scopes?
                                                       check-result))))
 
          #,@(if (syntax-e #'transform-id)
@@ -110,12 +112,12 @@
                              #t)])))
                 '()))]))
 
-(define (apply-transformer t id stx track-origin checker)
+(define (apply-transformer t id stx track-origin use-site-scopes? checker)
   (define proc (transformer-proc t))
   (call-as-transformer
    id
    (list stx)
-   track-origin
+   track-origin use-site-scopes?
    (lambda (stx)
      (define forms (checker (proc stx) proc))
      (datum->syntax #f forms))))

--- a/rhombus/private/binding.rkt
+++ b/rhombus/private/binding.rkt
@@ -61,7 +61,7 @@
                             (call-as-transformer
                              #'infoer-id
                              (list form)
-                             syntax-track-origin
+                             syntax-track-origin #f
                              proc))
                           proc)))
 

--- a/rhombus/private/parse.rkt
+++ b/rhombus/private/parse.rkt
@@ -62,7 +62,8 @@
     #:in-space in-decl-space
     #:transformer-ref declaration-transformer-ref
     #:check-result check-declaration-result
-    #:track-origin track-sequence-origin)
+    #:track-origin track-sequence-origin
+    #:use-site-scopes? #t)
 
   ;; Form at the top of a module or in a `nested` block:
   (define-rhombus-transform
@@ -73,7 +74,8 @@
     #:in-space in-decl-space
     #:transformer-ref nestable-declaration-transformer-ref
     #:check-result check-nestable-declaration-result
-    #:track-origin track-sequence-origin)
+    #:track-origin track-sequence-origin
+    #:use-site-scopes? #t)
 
   ;; Form in a definition context:
   (define-rhombus-transform
@@ -84,7 +86,8 @@
     #:in-space in-defn-space
     #:transformer-ref definition-transformer-ref
     #:check-result check-definition-result
-    #:track-origin track-sequence-origin)
+    #:track-origin track-sequence-origin
+    #:use-site-scopes? #t)
 
   ;; Form in a definition context that can consume extra groups:
   (define-rhombus-sequence-transform
@@ -95,7 +98,8 @@
     #:in-space in-defn-space
     #:transformer-ref definition-sequence-transformer-ref
     #:check-result check-definition-result
-    #:track-origin track-sequence-origin)
+    #:track-origin track-sequence-origin
+    #:use-site-scopes? #t)
 
   ;; Form in an expression context:
   (define-rhombus-enforest
@@ -110,7 +114,8 @@
     #:infix-operator-ref expression-infix-operator-ref
     #:check-result check-expression-result
     #:make-identifier-form make-identifier-expression
-    #:relative-precedence expression-relative-precedence)
+    #:relative-precedence expression-relative-precedence
+    #:use-site-scopes? #t)
 
   (define name-root-binding-ref
     (make-name-root-ref #:binding-ref (lambda (v)

--- a/rhombus/private/use-site.rkt
+++ b/rhombus/private/use-site.rkt
@@ -1,0 +1,13 @@
+#lang racket/base
+
+(provide remove-use-site-scopes)
+
+;; syntax-local-identifier-as-binding works only on identifiers
+(define (remove-use-site-scopes stx)
+  (cond
+    [(identifier? stx) (syntax-local-identifier-as-binding stx)]
+    [(syntax->list stx)
+     => (lambda (l)
+          (datum->syntax (syntax-local-identifier-as-binding (datum->syntax stx 'id))
+                         (map remove-use-site-scopes l)))]
+    [else stx]))

--- a/rhombus/tests/use-site-scope.rhm
+++ b/rhombus/tests/use-site-scope.rhm
@@ -1,0 +1,648 @@
+#lang rhombus/and_meta
+
+// This test suite also checks that module and internal-definition
+// contexts agree in behavior.
+
+// check addition of use-site scopes
+check:
+  let x = "outer"
+  expr.macro 'm $(id :: Term)':
+    'block:
+       let $id = "inner"
+       x'
+  m x
+  ~is "outer"
+
+check:
+  let x = "outer"
+  expr.macro 'm $(id :: Term)':
+    'block:
+       def $id = "inner"
+       x'
+  m x
+  ~is "outer"
+
+check:
+  def x = "outer"
+  expr.macro 'm $(id :: Term)':
+    'block:
+       let $id = "inner"
+       x'
+  m x
+  ~is "outer"
+
+check:
+  def x = "outer"
+  expr.macro 'm $(id :: Term)':
+    'block:
+       def $id = "inner"
+       x'
+  m x
+  ~is "outer"
+
+module expr1 ~lang rhombus/and_meta:
+  export result
+  let x = "outer"
+  expr.macro 'm $(id :: Term)':
+    'block:
+       let $id = "inner"
+       x'
+  def result = m x
+
+check:
+  import self!expr1 open
+  result
+  ~is "outer"
+
+module expr2 ~lang rhombus/and_meta:
+  export result
+  let x = "outer"
+  expr.macro 'm $(id :: Term)':
+    'block:
+       def $id = "inner"
+       x'
+  def result = m x
+
+check:
+  import self!expr2 open
+  result
+  ~is "outer"
+
+module expr3 ~lang rhombus/and_meta:
+  export result
+  def x = "outer"
+  expr.macro 'm $(id :: Term)':
+    'block:
+       let $id = "inner"
+       x'
+  def result = m x
+
+check:
+  import self!expr3 open
+  result
+  ~is "outer"
+
+module expr4 ~lang rhombus/and_meta:
+  export result
+  def x = "outer"
+  expr.macro 'm $(id :: Term)':
+    'block:
+       def $id = "inner"
+       x'
+  def result = m x
+
+check:
+  import self!expr4 open
+  result
+  ~is "outer"
+
+check:
+  let x = "outer"
+  defn.macro 'm $id':
+    'block:
+       let $id = "inner"
+       x'
+  m x
+  ~is "outer"
+
+check:
+  let x = "outer"
+  defn.macro 'm $id':
+    'block:
+       def $id = "inner"
+       x'
+  m x
+  ~is "outer"
+
+check:
+  def x = "outer"
+  defn.macro 'm $id':
+    'block:
+       let $id = "inner"
+       x'
+  m x
+  ~is "outer"
+
+check:
+  def x = "outer"
+  defn.macro 'm $id':
+    'block:
+       def $id = "inner"
+       x'
+  m x
+  ~is "outer"
+
+module nested_defn1 ~lang rhombus/and_meta:
+  export result
+  let x = "outer"
+  defn.macro 'm $result $id':
+    'def $result:
+       let $id = "inner"
+       x'
+  m result x
+
+check:
+  import self!nested_defn1 open
+  result
+  ~is "outer"
+
+module nested_defn2 ~lang rhombus/and_meta:
+  export result
+  let x = "outer"
+  defn.macro 'm $result $id':
+    'def $result:
+       def $id = "inner"
+       x'
+  m result x
+
+check:
+  import self!nested_defn2 open
+  result
+  ~is "outer"
+
+module nested_defn3 ~lang rhombus/and_meta:
+  export result
+  def x = "outer"
+  defn.macro 'm $result $id':
+    'def $result:
+       let $id = "inner"
+       x'
+  m result x
+
+check:
+  import self!nested_defn3 open
+  result
+  ~is "outer"
+
+module nested_defn4 ~lang rhombus/and_meta:
+  export result
+  def x = "outer"
+  defn.macro 'm $result $id':
+    'def $result:
+       def $id = "inner"
+       x'
+  m result x
+
+check:
+  import self!nested_defn4 open
+  result
+  ~is "outer"
+
+// check removal of use-site scopes
+check:
+  let x = "outer"
+  defn.macro 'm $id':
+    'let $id = "inner"
+     x'
+  m x
+  ~is "inner"
+
+check:
+  let x = "outer"
+  defn.macro 'm $id':
+    'def $id = "inner"
+     x'
+  m x
+  ~is "outer"
+
+check:
+  def x = "outer"
+  defn.macro 'm $id':
+    'let $id = "inner"
+     x'
+  m x
+  ~is "inner"
+
+check:
+  ~eval
+  block:
+    import rhombus/meta open
+    def x = "outer"
+    defn.macro 'm $id':
+      'def $id = "inner"
+       x'
+    m x
+  ~throws "duplicate binding name"
+
+module flat_defn1 ~lang rhombus/and_meta:
+  export result
+  let x = "outer"
+  defn.macro 'm $result $id':
+    'let $id = "inner"
+     def $result = x'
+  m result x
+
+check:
+  import self!flat_defn1 open
+  result
+  ~is "inner"
+
+module flat_defn2 ~lang rhombus/and_meta:
+  export result
+  let x = "outer"
+  defn.macro 'm $result $id':
+    'def $id = "inner"
+     def $result = x'
+  m result x
+
+check:
+  import self!flat_defn2 open
+  result
+  ~is "outer"
+
+module flat_defn3 ~lang rhombus/and_meta:
+  export result
+  def x = "outer"
+  defn.macro 'm $result $id':
+    'let $id = "inner"
+     def $result = x'
+  m result x
+
+check:
+  import self!flat_defn3 open
+  result
+  ~is "inner"
+
+check:
+  ~eval
+  module flat_defn4 ~lang rhombus/and_meta:
+    export result
+    def x = "outer"
+    defn.macro 'm $result $id':
+      'def $id = "inner"
+       def $result = x'
+    m result x
+  ~throws "identifier already defined"
+
+// check interaction with `flip_introduce`
+check:
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       let $tmp = $rhs ...
+       block:
+         let $id = $tmp
+         block $body'
+  def x = "outer"
+  values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+  ~is values("inner", "outer")
+
+check:
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       let $tmp = $rhs ...
+       block:
+         def $id = $tmp
+         block $body'
+  def x = "outer"
+  values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+  ~is values("inner", "outer")
+
+check:
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       def $tmp = $rhs ...
+       block:
+         let $id = $tmp
+         block $body'
+  def x = "outer"
+  values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+  ~is values("inner", "outer")
+
+check:
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       def $tmp = $rhs ...
+       block:
+         def $id = $tmp
+         block $body'
+  def x = "outer"
+  values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+  ~is values("inner", "outer")
+
+module nested_let1 ~lang rhombus/and_meta:
+  export result1 result2
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       let $tmp = $rhs ...
+       block:
+         let $id = $tmp
+         block $body'
+  def x = "outer"
+  def (result1, result2) = values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+
+check:
+  import self!nested_let1 open
+  values(result1, result2)
+  ~is values("inner", "outer")
+
+module nested_let2 ~lang rhombus/and_meta:
+  export result1 result2
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       let $tmp = $rhs ...
+       block:
+         def $id = $tmp
+         block $body'
+  def x = "outer"
+  def (result1, result2) = values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+
+check:
+  import self!nested_let2 open
+  values(result1, result2)
+  ~is values("inner", "outer")
+
+module nested_let3 ~lang rhombus/and_meta:
+  export result1 result2
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       def $tmp = $rhs ...
+       block:
+         let $id = $tmp
+         block $body'
+  def x = "outer"
+  def (result1, result2) = values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+
+check:
+  import self!nested_let3 open
+  values(result1, result2)
+  ~is values("inner", "outer")
+
+module nested_let4 ~lang rhombus/and_meta:
+  export result1 result2
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       def $tmp = $rhs ...
+       block:
+         def $id = $tmp
+         block $body'
+  def x = "outer"
+  def (result1, result2) = values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+
+check:
+  import self!nested_let4 open
+  values(result1, result2)
+  ~is values("inner", "outer")
+
+check:
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       let $tmp = $rhs ...
+       let $id = $tmp
+       block $body'
+  def x = "outer"
+  values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+  ~is values("inner", "outer")
+
+check:
+  expr.macro 'letrec_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       let $tmp = $rhs ...
+       def $id = $tmp
+       block $body'
+  def x = "outer"
+  letrec_in x = "inner":
+    x
+  ~is "inner"
+
+check:
+  ~eval
+  block:
+    import rhombus/meta open
+    expr.macro 'letrec_in $id = $rhs ...:
+                  $(body :: Block)':
+      def tmp = syntax_meta.flip_introduce(id)
+      'block:
+         let $tmp = $rhs ...
+         def $id = $tmp
+         block $body'
+    def x = "outer"
+    letrec_in x = x:
+      x
+  ~throws "cannot use before initialization"
+
+check:
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       def $tmp = $rhs ...
+       let $id = $tmp
+       block $body'
+  def x = "outer"
+  values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+  ~is values("inner", "outer")
+
+check:
+  expr.macro 'letrec_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       def $tmp = $rhs ...
+       def $id = $tmp
+       block $body'
+  def x = "outer"
+  letrec_in x = "inner":
+    x
+  ~is "inner"
+
+check:
+  ~eval
+  block:
+    import rhombus/meta open
+    expr.macro 'letrec_in $id = $rhs ...:
+                  $(body :: Block)':
+      def tmp = syntax_meta.flip_introduce(id)
+      'block:
+         def $tmp = $rhs ...
+         def $id = $tmp
+         block $body'
+    def x = "outer"
+    letrec_in x = x:
+      x
+  ~throws "cannot use before initialization"
+
+module flat_let1 ~lang rhombus/and_meta:
+  export result1 result2
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       let $tmp = $rhs ...
+       let $id = $tmp
+       block $body'
+  def x = "outer"
+  def (result1, result2) = values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+
+check:
+  import self!flat_let1 open
+  values(result1, result2)
+  ~is values("inner", "outer")
+
+module flat_let2 ~lang rhombus/and_meta:
+  export result
+  expr.macro 'letrec_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       let $tmp = $rhs ...
+       def $id = $tmp
+       block $body'
+  def x = "outer"
+  def result = (
+    letrec_in x = "inner":
+      x
+  )
+
+check:
+  import self!flat_let2 open
+  result
+  ~is "inner"
+
+check:
+  ~eval
+  module flat_let2 ~lang rhombus/and_meta:
+    expr.macro 'letrec_in $id = $rhs ...:
+                  $(body :: Block)':
+      def tmp = syntax_meta.flip_introduce(id)
+      'block:
+         let $tmp = $rhs ...
+         def $id = $tmp
+         block $body'
+    def x = "outer"
+    letrec_in x = x:
+      x
+  import self!flat_let2
+  ~throws "cannot use before initialization"
+
+module flat_let3 ~lang rhombus/and_meta:
+  export result1 result2
+  expr.macro 'let_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       def $tmp = $rhs ...
+       let $id = $tmp
+       block $body'
+  def x = "outer"
+  def (result1, result2) = values(
+    let_in x = "inner":
+      x,
+    let_in x = x:
+      x
+  )
+
+check:
+  import self!flat_let3 open
+  values(result1, result2)
+  ~is values("inner", "outer")
+
+module flat_let4 ~lang rhombus/and_meta:
+  export result
+  expr.macro 'letrec_in $id = $rhs ...:
+                $(body :: Block)':
+    def tmp = syntax_meta.flip_introduce(id)
+    'block:
+       def $tmp = $rhs ...
+       def $id = $tmp
+       block $body'
+  def x = "outer"
+  def result = (
+    letrec_in x = "inner":
+      x
+  )
+
+check:
+  import self!flat_let4 open
+  result
+  ~is "inner"
+
+check:
+  ~eval
+  module flat_let4 ~lang rhombus/and_meta:
+    expr.macro 'letrec_in $id = $rhs ...:
+                  $(body :: Block)':
+      def tmp = syntax_meta.flip_introduce(id)
+      'block:
+         def $tmp = $rhs ...
+         def $id = $tmp
+         block $body'
+    def x = "outer"
+    letrec_in x = x:
+      x
+  import self!flat_let4
+  ~throws "cannot use before initialization"


### PR DESCRIPTION
Part 2 of 2, following up on #476.

Use-site scope tracking is enabled only for expression, definition, and declaration contexts. I'm pretty sure they're not needed anywhere else, although I worry that I might be overlooking something. Disabling use-site-scope tracking for other contexts avoids having to figure out where to remove them.

It's not obvious from the documentation for `local-expand` that an internal-definition-signalling list must be provided as the context argument is needed to enable use-site scopes. Inventing a new context each time in `call-as-transformer` is a little awkward, but it's ok as far as I can reason though it. I'm inclined to blame `local-expand` for having an awkward interface, plan to improve the docs, and leave it at that.

There's a little clean-up in this commit to remove `rhombus-mixed-forwarding-sequence`, which is unused, even though it's not really about support for use-site scopes.