### PR TITLE
add `matches` infix operator

### DIFF
--- a/rhombus/private/annotation.rkt
+++ b/rhombus/private/annotation.rkt
@@ -833,7 +833,7 @@
    'none))
 (define-annotation-syntax is_a
   (annotation-infix-operator
-   (annot-quote ::)
+   (annot-quote is_a)
    `((default . stronger))
    'macro
    (lambda (stx) (error "should not get here"))

--- a/rhombus/private/core.rkt
+++ b/rhombus/private/core.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre
-                     shrubbery/print
                      (only-in "ellipsis.rkt"
                               [... rhombus...])
                      (only-in "quasiquote.rkt"

--- a/rhombus/scribblings/ref-match.scrbl
+++ b/rhombus/scribblings/ref-match.scrbl
@@ -80,6 +80,23 @@
 )
 }
 
+
+@doc(
+  expr.macro '$expr matches $bind'
+){
+
+ Produces @rhombus(#true) if the value of @rhombus(expr) matches
+ @rhombus(bind), @rhombus(#false) otherwise. Equivalent to
+ @rhombus(expr is_a matching(bind)).
+
+@examples(
+  [1, 2, 3] matches [_, _, _]
+  [1, 2, 3] is_a matching([_, _, _])
+)
+
+}
+
+
 @doc(
   bind.macro '_'
 ){

--- a/rhombus/tests/match.rhm
+++ b/rhombus/tests/match.rhm
@@ -66,3 +66,8 @@ version_guard.at_least "8.11.1.8":
     | "string": "matched"
     | ~else: "unmatched"
     ~is "unmatched"
+
+check:
+  0 matches (i :: Int when i mod 3 == 0) ~is #true
+  1 matches (i :: Int unless i mod 3 == 0) ~is #true
+  [1, 2, 3] matches ([x, ...] when math.sum(x, ...) == 6) ~is #true

--- a/scribble/private/rhombus-spacer.rhm
+++ b/scribble/private/rhombus-spacer.rhm
@@ -24,6 +24,7 @@ export:
     final
     private
     match
+    matches
     ::
     :~
     is_a
@@ -231,7 +232,7 @@ spacer.bridge fun(self, tail, context, esc):
           fun (self):
             spacer.set(self, if has_name | #'~defn | #'~expr),
           fun (name):
-            unless has_name | has_name := !(name is_a matching(''))
+            unless has_name | has_name := !(name matches '')
         )
   let new_tail = adjust_fun(tail, esc, ~find_name: find_name)
   let new_self = adjust_self(self)
@@ -649,6 +650,10 @@ spacer.bridge match(self, tail, context, esc):
         Syntax.make([#'alts, adjust_block(b), ...]).relocate(a)
       '$self $new_expr $new_a'
   | ~else: '$self $tail'
+
+spacer.bridge matches(self, tail, context, esc):
+  ~in: ~expr
+  '$self $(spacer.adjust_sequence(tail, #'~bind, esc))'
 
 meta:
   fun adjust_colon(tail, esc):

--- a/scribble/tests/rhombus-spacer.rhm
+++ b/scribble/tests/rhombus-spacer.rhm
@@ -978,6 +978,27 @@ check_spacer:
       "ok"
 
 check_spacer:
+  1+2 matches 3
+  $datum $none $datum $(expr.full) $datum
+
+  1
+    + 2 matches 3
+
+check_spacer:
+  [1, 2, 3] matches [_, _, _]
+  [$datum, $datum, $datum] $(expr.full) [$bind, $bind, $bind]
+
+  [
+    1,
+    2,
+    3
+  ] matches [
+    _,
+    _,
+    _
+  ]
+
+check_spacer:
   [1, 2, 3] :: List
   [$datum, $datum, $datum] $(expr.full) $annot
 


### PR DESCRIPTION
This is like `matches` macro in Rust, which can serve as a shorthand and more discoverable alternative to
`<expr> is_a matching(<bind>)`.