### PR TITLE
docs: use `Parameter.def` to document parameters

### DIFF
--- a/rhombus/pict/scribblings/balloon.scrbl
+++ b/rhombus/pict/scribblings/balloon.scrbl
@@ -75,20 +75,12 @@
 }
 
 @doc(
-  def current_color :: Parameter
-  fun current_color() :: Color || String
-  fun current_color(color :: Color || String) :: Void
-
-  def current_horiz_margin :: Parameter
-  fun current_horiz_margin() :: Real
-  fun current_horiz_margin(margin :: Real)
-
-  def current_vert_margin :: Parameter
-  fun current_vert_margin() :: Real
-  fun current_vert_margin(margin :: Real)
+  Parameter.def current_color :: Color || String
+  Parameter.def current_horiz_margin :: Real
+  Parameter.def current_vert_margin :: Real
 ){
 
- Parameters for argument defaults in @rhombus(pin).
+ Context parameters for argument defaults in @rhombus(pin).
 
 }
 

--- a/rhombus/pict/scribblings/text.scrbl
+++ b/rhombus/pict/scribblings/text.scrbl
@@ -174,7 +174,7 @@ paragraph typesetting.
          @item{@litchar{'} → @litchar{’} (curly single close quote)}
 
       )}
- 
+
 )
 
  The @rhombus(width) argument determines the maximum width of a line,
@@ -232,9 +232,7 @@ paragraph typesetting.
 }
 
 @doc(
-  def current_font :: Parameter
-  fun current_font() :: Font
-  fun current_font(font :: Font) :: Void
+  Parameter.def current_font :: draw.Font
 ){
 
  The default font used by functions from @rhombusmodname(pict/text) for
@@ -243,9 +241,7 @@ paragraph typesetting.
 }
 
 @doc(
-  def current_para_width :: Parameter
-  fun current_para_width() :: Real
-  fun current_para_width(width :: Real) :: Void
+  Parameter.def current_para_width :: Real
 ){
 
  The default line width for @rhombus(para) and related functions.
@@ -253,9 +249,7 @@ paragraph typesetting.
 }
 
 @doc(
-  def current_line_sep :: Parameter
-  fun current_line_sep() :: Real
-  fun current_line_sep(sep :: Real) :: Void
+  Parameter.def current_line_sep :: Real
 ){
 
  The default amount of separate used between lines by @rhombus(lines),

--- a/rhombus/private/annotation.rkt
+++ b/rhombus/private/annotation.rkt
@@ -804,7 +804,8 @@
 
 (define-name-root Any
   #:fields
-  ([of Any.of]))
+  ([of Any.of]
+   [to_boolean Any.to_boolean]))
 
 (define-name-root Int
   #:fields
@@ -1016,3 +1017,36 @@
                              ...)))
                    #'())
                   #'tail))]))))
+
+(define-annotation-syntax Any.to_boolean
+  (identifier-binding-annotation (binding-form #'to_boolean-infoer
+                                               #'val)
+                                 #'val
+                                 #'()))
+
+(define-syntax (to_boolean-infoer stx)
+  (syntax-parse stx
+    [(_ static-infos val)
+     (binding-info "to_boolean"
+                   #'val
+                   #'()
+                   #'((val (0)))
+                   #'to_boolean-matcher
+                   #'to_boolean-committer
+                   #'to_boolean-binder
+                   #'(converted-val val))]))
+
+(define-syntax (to_boolean-matcher stx)
+  (syntax-parse stx
+    [(_ arg-id (converted-val val) IF success fail)
+     #'(IF #t success fail)]))
+
+(define-syntax (to_boolean-committer stx)
+  (syntax-parse stx
+    [(_ arg-id (converted-val val))
+     #'(define converted-val (and arg-id #t))]))
+
+(define-syntax (to_boolean-binder stx)
+  (syntax-parse stx
+    [(_ arg-id (converted-val val))
+     #'(define val converted-val)]))

--- a/rhombus/scribblings/ref-annotation.scrbl
+++ b/rhombus/scribblings/ref-annotation.scrbl
@@ -40,12 +40,15 @@
 @doc(
   annot.macro 'Any'
   annot.macro 'Any.of($expr, ...)'
+  annot.macro 'Any.to_boolean'
   annot.macro 'None'
 ){
 
  The @rhombus(Any, ~annot) annotation matches any value. An
  @rhombus(Any.of, ~annot) annotaton matches any value that is equal (in
- the sense of @rhombus(==)) to one of the @rhombus(expr) results.
+ the sense of @rhombus(==)) to one of the @rhombus(expr) results. The
+ @rhombus(Any.to_boolean, ~annot) annotation matches any value and
+ converts non-@rhombus(#false) value to @rhombus(#true).
 
  The @rhombus(None, ~annot) annotation matches no values, or in other
  words, is equivalent to @rhombus(Any.of(), ~annot). It is useful for
@@ -56,6 +59,8 @@
   "hello" is_a Any
   "hello" is_a Any.of("hello", "goodbye")
   "hola" is_a Any.of("hello", "goodbye")
+  "hello" :: Any.to_boolean
+  #false :: Any.to_boolean
   "will not match" is_a None
   "will not match" is_a Any.of()
 )

--- a/rhombus/scribblings/ref-eval.scrbl
+++ b/rhombus/scribblings/ref-eval.scrbl
@@ -70,9 +70,7 @@ by an evaluator, for example.
 }
 
 @doc(
-  def Evaluator.current :: Parameter
-  fun Evaluator.current() :: Evaluator
-  fun Evaluator.current(ns :: Evaluator) :: Void
+  Parameter.def Evaluator.current :: Parameter
 ){
 
  A @tech{context parameter} for the current evaluator.

--- a/rhombus/scribblings/ref-io.scrbl
+++ b/rhombus/scribblings/ref-io.scrbl
@@ -67,9 +67,7 @@ input, while an @deftech{output port} is specifically for output.
 
 
 @doc(
-  def Port.Input.current :: Parameter
-  fun Port.Input.current() :: Port.Input
-  fun Port.Input.current(in :: Port.Input) :: Void
+  Parameter.def Port.Input.current :: Port.Input
 ){
 
  A @tech{context parameter} for the default port to use when reading.
@@ -77,9 +75,7 @@ input, while an @deftech{output port} is specifically for output.
 }
 
 @doc(
-  def Port.Output.current :: Parameter
-  fun Port.Output.current() :: Port.Output
-  fun Port.Output.current(out :: Port.Output) :: Void
+  Parameter.def Port.Output.current :: Port.Output
 ){
 
  A @tech{context parameter} for the default port to use when printing.
@@ -88,9 +84,7 @@ input, while an @deftech{output port} is specifically for output.
 
 
 @doc(
-  def Port.Output.current_error :: Parameter
-  fun Port.Output.current_error() :: Port.Output
-  fun Port.Output.current_error(out :: Port.Output) :: Void
+  Parameter.def Port.Output.current_error :: Port.Output
 ){
 
  A @tech{context parameter} for the default port to use when printing
@@ -99,7 +93,8 @@ input, while an @deftech{output port} is specifically for output.
 }
 
 @doc(
-  fun Port.Output.flush(out :: Port.Output = Port.Output.current()) :: Void
+  fun Port.Output.flush(out :: Port.Output = Port.Output.current())
+    :: Void
 ){
 
  Flushes the content of @rhombus(out)'s buffer.
@@ -357,7 +352,7 @@ input, while an @deftech{output port} is specifically for output.
 
 }
 
-@doc(  
+@doc(
   fun PrintDesc.special(v :: Any,
                         alt_pd :: PrintDesc,
                         ~length: length :: NonnegInt = 1,
@@ -380,9 +375,8 @@ input, while an @deftech{output port} is specifically for output.
 
 
 @doc(
-  def Printable.current_pretty :: Parameter
-  fun Printable.current_pretty() :: Boolean
-  fun Printable.current_pretty(on :: Any) :: Void
+  Parameter.def Printable.current_pretty :: Any.to_boolean
+    = #false
 ){
 
  A @tech{context parameter} that determines the default printing mode.
@@ -393,9 +387,8 @@ input, while an @deftech{output port} is specifically for output.
 
 
 @doc(
-  def Printable.current_optimal :: Parameter
-  fun Printable.current_optimal() :: Boolean
-  fun Printable.current_optimal(on :: Any) :: Void
+  Parameter.def Printable.current_optimal :: Any.to_boolean
+    = #false
 ){
 
  A @tech{context parameter} that determines whether pretty printing uses
@@ -407,9 +400,8 @@ input, while an @deftech{output port} is specifically for output.
 
 
 @doc(
-  def Printable.current_page_width :: Parameter
-  fun Printable.current_page_width() :: Boolean
-  fun Printable.current_page_width(on :: Any) :: Void
+  Parameter.def Printable.current_page_width :: NonnegInt
+    = 80
 ){
 
  A @tech{context parameter} for pretty printing that determines the
@@ -419,9 +411,8 @@ input, while an @deftech{output port} is specifically for output.
 
 
 @doc(
-  def Printable.current_graph :: Parameter
-  fun Printable.current_graph() :: Boolean
-  fun Printable.current_graph(on :: Any) :: Void
+  Parameter.def Printable.current_graph :: Any.to_boolean
+    = #false
 ){
 
  A @tech{context parameter} that determines whether printing shows

--- a/rhombus/scribblings/ref-random.scrbl
+++ b/rhombus/scribblings/ref-random.scrbl
@@ -46,12 +46,10 @@
 }
 
 @doc(
-  def Random.current :: Parameter
-  fun Random.current() :: Random
-  fun Random.current(prng :: Random) :: Void
+  Parameter.def Random.current :: Random = Random()
 ){
 
- A parameter for the pseudo-random number generator that is used by
+ A @tech{context parameter} for the pseudo-random number generator that is used by
  @rhombus(math.random).
 
 }

--- a/rhombus/slideshow/scribblings/slide.scrbl
+++ b/rhombus/slideshow/scribblings/slide.scrbl
@@ -3,7 +3,7 @@
 @(import:
     meta_label:
       rhombus open
-      slideshow open      
+      slideshow open
       draw.Font)
 
 @title(~tag: "slide"){Creating Slides}
@@ -132,12 +132,10 @@
 }
 
 @doc(
-  def current_assembler :: Parameter
-  fun current_assembler() :: Function.of_arity(3)
-  fun current_assembler(assemblr :: Function.of_arity(3)) :: Void
+  Parameter.def current_assembler :: Function.of_arity(3)
 ){
 
- A parameter for a function used to combine a slide title, layout mode,
+ A context parameter for a function used to combine a slide title, layout mode,
  and content pict. The title can be a pict or @rhombus(#false), and the
  layout mode is a value that satifies @rhombus(SlideLayout, ~annot).
 
@@ -153,12 +151,10 @@
 }
 
 @doc(
-  def current_title_font :: Parameter
-  fun current_title_font() :: Font
-  fun current_title_font(font :: Font) :: Void
+  Parameter.def current_title_font :: Font
 ){
 
- A parameter for the font used by @rhombus(titlet).
+ A context parameter for the font used by @rhombus(titlet).
 
 }
 
@@ -193,7 +189,7 @@
  @rhombus(#'nonarchival).
 
 }
-     
+
 @doc(
   annot.macro 'SlideLayout'
 ){

--- a/rhombus/tests/annotation.rhm
+++ b/rhombus/tests/annotation.rhm
@@ -112,3 +112,17 @@ check:
   "x" :: True ~is "x"
   "x" :: False ~throws "does not satisfy"
   #false :: True ~throws "does not satisfy"
+
+check:
+  #true :: Any ~is #true
+  #true :: Any.of(#true, #false) ~is #true
+  #true :: Any.to_boolean ~is #true
+  #true :: None ~throws "does not satisfy"
+  #false :: Any ~is #false
+  #false :: Any.of(#true, #false) ~is #false
+  #false :: Any.to_boolean ~is #false
+  #false :: None ~throws "does not satisfy"
+  "x" :: Any ~is "x"
+  "x" :: Any.of(#true, #false) ~throws "does not satisfy"
+  "x" :: Any.to_boolean ~is #true
+  "x" :: None ~throws "does not satisfy"

--- a/rhombus/tests/printable.rhm
+++ b/rhombus/tests/printable.rhm
@@ -9,7 +9,7 @@ block:
     Printable.render(pd, [out])
     Printable.current_pretty([on])
     Printable.current_optimal([on])
-    Printable.current_page_width([on])
+    Printable.current_page_width([width])
     Printable.current_graph([on])
     PrintDesc.concat(pd, ...)
     PrintDesc.newline()

--- a/scribble/private/rhombus-spacer.rhm
+++ b/scribble/private/rhombus-spacer.rhm
@@ -48,6 +48,7 @@ export:
     match_unless
     $
     pattern
+    Parameter
 
 module for_doc:
   export:
@@ -987,3 +988,7 @@ spacer.bridge pattern(self, tail, context, esc):
     | '$(_ :: Name(esc))' || '': name
     | ~else: #false
   '$self $(adjust_syntax_class(tail, esc, adjust_name))'
+
+spacer.bridge Parameter.def(self, tail, context, esc):
+  ~in: ~defn
+  '$self $(adjust_field(tail, esc))'

--- a/scribble/tests/rhombus-spacer.rhm
+++ b/scribble/tests/rhombus-spacer.rhm
@@ -32,7 +32,7 @@ defn.macro 'def_unquote $name: $context_expr':
   '«def context = $context_expr
     syntax_class Term:
       kind ~term
-    | '$('$') t':
+    | '$('$')t':
         match_when t.property(#'#{typeset-space-name}) == context
     unquote_bind.macro '$name':
       '_ :: Term'
@@ -1386,3 +1386,33 @@ check_spacer:
             = 3
     ):
       case
+
+check_spacer:
+  Parameter.def color = "red"
+  $(defn.full) . $(defn.full) $none $expr $datum
+
+  Parameter.def color
+    = "red"
+
+check_spacer:
+  Parameter.def color :: String = "red"
+  $(defn.full) . $(defn.full) $none $bind $annot $expr $datum
+
+  Parameter.def color
+    :: String
+    = "red"
+
+check_spacer:
+  Parameter.def color: "red"
+  $(defn.full) . $(defn.full) $none: $datum
+
+  Parameter.def color:
+    "red"
+
+check_spacer:
+  Parameter.def color :: String: "red"
+  $(defn.full) . $(defn.full) $none $bind $annot: $datum
+
+  Parameter.def color
+    :: String:
+      "red"


### PR DESCRIPTION
This PR also includes a commit that adds `Any.to_boolean`, mainly for documenting “Boolean parameters” here.