### PR TITLE
add `as` support in `expose`

### DIFF
--- a/rhombus/draw/private/rkt.rhm
+++ b/rhombus/draw/private/rkt.rhm
@@ -2,9 +2,6 @@
 import:
   lib("racket/class.rkt"):
     expose:
-      send
-      #{is-a?}
-    rename:
       send as rkt_send
       #{is-a?} as rkt_is_a
   lib("racket/draw.rkt")

--- a/rhombus/measure.rhm
+++ b/rhombus/measure.rhm
@@ -1,8 +1,8 @@
 #lang rhombus/and_meta
 import:
   lib("racket/base.rkt"):
-    expose: time
-    rename: time as rkt_time
+    expose:
+      time as rkt_time
   rhombus/runtime
 
 export:

--- a/rhombus/pict/scribblings/radial.scrbl
+++ b/rhombus/pict/scribblings/radial.scrbl
@@ -12,7 +12,10 @@
   ~hidden:
     import:
       pict:
-        expose: beside rectangle ellipse
+        expose:
+          beside
+          rectangle
+          ellipse
       pict/radial open
 )
 
@@ -140,7 +143,7 @@
   ~eval: radial_eval
   radial_pict()
   radial_pict(~fill: #'inherit).colorize("red")
-  radial_pict(~width: 64, ~height: 32, ~rotate: math.pi * 1/2)  
+  radial_pict(~width: 64, ~height: 32, ~rotate: math.pi * 1/2)
   radial_pict(~inner_pause: 0.5, ~outer_pause: 0.25, ~fill: "black")
   radial_pict(~outer_pull: 0.25, ~fill: "purple")
   radial_pict(~inner_pull: 0.25, ~fill: "forestgreen")

--- a/rhombus/scribblings/ref-import-macro.scrbl
+++ b/rhombus/scribblings/ref-import-macro.scrbl
@@ -64,27 +64,31 @@
 @examples(
   ~eval: macro_eval
   ~defn:
-    impo.modifier 'as_rkt: $(name :: Identifier) ...':
+    impo.modifier 'as_rkt: $(name :: Identifier); ...':
       'rename:
          $name as $(Syntax.make_id("rkt_" +& name, name))
          ...'
   ~repl:
     import:
       lib("racket/base.rkt"):
-        as_rkt: add1 sub1
+        as_rkt:
+          add1
+          sub1
     base.rkt_sub1(base.rkt_add1(1))
   ~defn:
-    impo.modifier 'expose_as_rkt: $(name :: Identifier) ...':
+    impo.modifier 'expose_as_rkt: $(name :: Identifier); ...':
       ~import imp
       let '$(ex_imp :: impo_meta.ParsedModifier(imp))':
-        'expose: $name ...'
+        'expose: $name; ...'
       let '$(rn_imp :: impo_meta.ParsedModifier(ex_imp))':
-        'as_rkt: $name ...'
+        'as_rkt: $name; ...'
       rn_imp
   ~repl:
     import:
       lib("racket/base.rkt"):
-        expose_as_rkt: add1 sub1
+        expose_as_rkt:
+          add1
+          sub1
     rkt_sub1(rkt_add1(1))
 )
 

--- a/rhombus/scribblings/ref-import.scrbl
+++ b/rhombus/scribblings/ref-import.scrbl
@@ -300,31 +300,42 @@
 }
 
 @doc(
-  impo.modifier 'expose $id'
+  ~nonterminal:
+    rename_as: rename ~impo
+  impo.modifier 'expose $id_or_rename_as'
   impo.modifier 'expose:
-                   $id ...
+                   $id_or_rename_as
                    ...'
+  grammar id_or_rename_as:
+    $id
+    $rename_as
 ){
 
  Modifies an @rhombus(import) clause so that the listed
  @rhombus(id)s are imported without a prefix. The exposed
  ids remain accessible though the import's prefix, too.
 
+ If @rhombus(as, ~impo) is used, the @rhombus(id) is renamed in
+ addition to being exposed, or in other words, it behaves like a
+ combination of @rhombus(rename, ~impo) and @rhombus(expose, ~impo).
+
 }
 
 @doc(
   ~nonterminal:
     local_id: block id
-  impo.modifier 'rename $id #,(@rhombus(as, ~impo)) $local_id'
+  impo.modifier 'rename $rename_as'
   impo.modifier 'rename:
-                   $id #,(@rhombus(as, ~impo)) $local_id
+                   $rename_as
                    ...'
+  grammar rename_as:
+    $id #,(@rhombus(as, ~impo)) $local_id
 ){
 
  Modifies an @rhombus(import) clause so that @rhombus(local_id)
  is used in place of the imported id name @rhombus(id).
  The new name @rhombus(local_id) applies to modifiers after the
- @rhombus(rename) modifier.
+ @rhombus(rename, ~impo) modifier.
 
 }
 

--- a/rhombus/tests/import-module.rhm
+++ b/rhombus/tests/import-module.rhm
@@ -80,6 +80,25 @@ check:
 
 check:
   import:
+    lib("rhombus/tests/example-c.rhm") as ex_c:
+      expose: exint
+      rename: exint as ex_int
+  def ex_int = 10
+  10 :: ex_int
+  ex_int
+  ~is 10
+
+check:
+  import:
+    lib("rhombus/tests/example-c.rhm") as ex_c:
+      expose: exint as ex_int
+  def ex_int = 10
+  10 :: ex_int
+  ex_int
+  ~is 10
+
+check:
+  import:
     lib("rhombus/tests/example-c.rhm"):
       open
       only_space: expr

--- a/rhombus/tests/import-namespace.rhm
+++ b/rhombus/tests/import-namespace.rhm
@@ -74,6 +74,25 @@ check:
 check:
   import:
     .n:
+      expose: exint
+      rename: exint as ex_int
+  def ex_int = 10
+  10 :: ex_int
+  ex_int
+  ~is 10
+
+check:
+  import:
+    .n:
+      expose: exint as ex_int
+  def ex_int = 10
+  10 :: ex_int
+  ex_int
+  ~is 10
+
+check:
+  import:
+    .n:
       open
       only_space: expr
   exint

--- a/rhombus/tests/import.rhm
+++ b/rhombus/tests/import.rhm
@@ -81,7 +81,7 @@ check:
 
 check:
   ~eval
-  import: .List: 
+  import: .List:
             rename: cons as kons
   List.kons(1, [2])
   ~is List.cons(1, [2])
@@ -89,7 +89,7 @@ check:
 check:
   ~eval
   import: lib("rhombus/tests/example-a.rhm") open
-  import: .ExList: 
+  import: .ExList:
             rename: cons as kons
   [ExList.kons(1, [2]),
    List.cons(1, [2])]
@@ -99,7 +99,7 @@ check:
   ~eval
   import: lib("rhombus/tests/example-a.rhm") open
   block:
-    import: .ExList: 
+    import: .ExList:
               rename: cons as kons
     [ExList.kons(1, [2]),
      List.cons(1, [2])]
@@ -185,6 +185,13 @@ check:
     lib("rhombus/tests/example-f.rhm"):
       expose prefix
       rename prefix as pfx
+  [pfx.original, pfx.added]
+  ~is ["orig", "add"]
+
+check:
+  import:
+    lib("rhombus/tests/example-f.rhm"):
+      expose prefix as pfx
   [pfx.original, pfx.added]
   ~is ["orig", "add"]
 

--- a/scribble/private/docmodule.rhm
+++ b/scribble/private/docmodule.rhm
@@ -1,14 +1,14 @@
 #lang rhombus/and_meta
-
 import:
-  lib("scribble/manual.rkt") expose:
-    defmodule racketmodlink
+  lib("scribble/manual.rkt"):
+    expose:
+      defmodule
+      racketmodlink
   "rhombus.rhm" open
-  meta:
-    lib("racket/base.rkt")
   meta_label:
-    rhombus expose:
-      import
+    rhombus:
+      expose:
+        import
 
 export:
   docmodule


### PR DESCRIPTION
This works like a combination of `rename` and `expose`, which is not very common, but does appear to be used in the Rhombus codebase.

Also change the grammar to disallow multiple names in a group in the multi-group form, to avoid confusion with the `as` form.