### PR TITLE
disallow `let` and `def` on the same identifier in the same definition context

### DIFF
--- a/rhombus/private/class-dot.rkt
+++ b/rhombus/private/class-dot.rkt
@@ -11,6 +11,7 @@
          "class-method-result.rkt"
          (submod "dot.rkt" for-dot-provider)
          "dotted-sequence-parse.rkt"
+         "export-check.rkt"
          "parens.rkt"
          "static-info.rkt"
          "expression.rkt"
@@ -52,8 +53,10 @@
                        [public-name-field/mutate ...]
                        [dot-id ...]
                        [private-field-desc ...]
-                       [ex ...])
+                       [ex ...]
+                       base-ctx scope-ctx)
                  names])
+    (register-field-check #'(base-ctx scope-ctx ex ...))
     (define-values (method-names method-impl-ids method-defns)
       (method-static-entries method-mindex method-vtable method-results #'name-ref #'name? final? #f))
     (with-syntax ([(method-name ...) method-names]
@@ -167,8 +170,10 @@
                        name? name-instance name-ref static-name-ref
                        internal-name-instance internal-name-ref
                        dot-provider-name [dot-id ...]
-                       [ex ...])
+                       [ex ...]
+                       base-ctx scope-ctx)
                  names])
+    (register-field-check #'(base-ctx scope-ctx ex ...))
     (define-values (method-names method-impl-ids method-defns)
       (method-static-entries method-mindex method-vtable method-results #'static-name-ref #'name? #f #t))
     (with-syntax ([(method-name ...) method-names]

--- a/rhombus/private/class.rkt
+++ b/rhombus/private/class.rkt
@@ -663,7 +663,8 @@
                                                         (quote-syntax private-field-static-infos)
                                                         (quote-syntax private-field-argument))
                                                   ...]
-                                                 [export ...]))
+                                                 [export ...]
+                                                 base-stx scope-stx))
                (build-class-static-infos exposed-internal-id
                                          super
                                          given-constructor-rhs

--- a/rhombus/private/export-check.rkt
+++ b/rhombus/private/export-check.rkt
@@ -1,0 +1,78 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     "introducer.rkt"))
+
+(provide (for-syntax register-field-check
+                     register-provide-check))
+
+;; Resgisters a check that an identifie is defined; this check
+;; needs to be deferred until all definitions in the module have
+;; been discovered
+(define-for-syntax (register-field-check stx)
+  (when (syntax-transforming-module-expression?)
+    (syntax-local-lift-module-end-declaration #`(check-export-bound . #,stx))))
+
+(define-for-syntax (check-identifier base-ctx forward-ctx id
+                                     [spaces (cons #f (syntax-local-module-interned-scope-symbols))])
+  (unless (for/or ([space (in-list spaces)])
+            (identifier-binding ((space->introducer space) id)))
+    (if (let ([intro (make-syntax-delta-introducer forward-ctx base-ctx)])
+          (for/or ([space (in-list spaces)])
+            (identifier-binding ((space->introducer space) (intro id 'add)))))
+        (raise-syntax-error #f "exported identifier defined later, but not in scope for export" id)
+        (raise-syntax-error #f "exported identifier not defined" id))))
+
+(define-syntax (check-export-bound stx)
+  (syntax-parse stx
+    [(_ base-ctx forward-ctx . fields)
+     (for ([field (in-list (syntax->list #'fields))])
+       (define (check id rule)
+         (syntax-parse rule
+           [() (check-identifier #'base-ctx #'forward-ctx id)]
+           [(#:space _ . rule)
+            (check id #'rule)]
+           [(#:only space ...)
+            (check-identifier #'base-ctx #'forward-ctx id (syntax->datum #'(space ...)))]
+           [(#:except space ...)
+            (define ht (for/hasheq ([space (in-list (cons #f (syntax-local-module-interned-scope-symbols)))])
+                         (values space #t)))
+            (check-identifier #'base-ctx #'forward-ctx id
+                              (hash-keys (for/fold ([ht ht]) ([space (in-list (syntax->datum #'(space ...)))])
+                                           (hash-remove ht #f))))]))
+       (syntax-parse field
+         [id:identifier
+          (check #'id #'())]
+         [(ext-id int-id . rule)
+          (check #'int-id #'rule)]
+         [_ (error "oops" field)]))
+     #'(void)]))
+
+(define-for-syntax (register-provide-check stx)
+  (syntax-local-lift-module-end-declaration #`(check-export-provide . #,stx)))
+
+;; The job of this checker is to povide a better error message in the
+;; case that an identifer is defined via `let`. So, we don't have to check
+;; antyhing invconvenient, such as a restriction to a particular space
+(define-syntax (check-export-provide stx)
+  (syntax-parse stx
+    [(_ base-ctx forward-ctx . exs)
+     (for ([ex (in-list (syntax->list #'exs))])
+       (let loop ([ex ex])
+         (syntax-parse ex
+           #:datum-literals (combine-out all-spaces-out all-from-out for-meta for-label
+                                         only-spaces-out except-spaces-out all-spaces-defined-out
+                                         except-out)
+           [(combine-out ex ...)
+            (for ([ex (in-list (syntax->list #'(ex ...)))])
+              (loop ex ))]
+           [(all-spaces-out o ...)
+            (for ([o (in-list (syntax->list #'(o ...)))])
+              (define id
+                (syntax-parse o
+                  [(int-id ext-id) #'int-id]
+                  [_:identifier o]))
+              (check-identifier #'base-ctx #'forward-ctx id))]
+           [_
+            (void)])))])
+  #'(void))

--- a/rhombus/private/import-check.rkt
+++ b/rhombus/private/import-check.rkt
@@ -1,0 +1,77 @@
+#lang racket/base
+(require syntax/parse/pre
+         racket/phase+space)
+
+;; `check-require-bindings` is used to check for duplicate imports, but
+;; specificaly ones that are duplicate with respect to `let`
+
+(provide check-require-bindings)
+
+(define (check-require-bindings req sub)
+  (define top-req req)
+  (define (check-identifier id phase space)
+    (when (and (identifier-binding id)
+               (identifier-distinct-binding id (sub id)))
+      (raise-syntax-error #f "duplicate import" id)))
+  (let loop ([req req]             
+             [phase-shift (syntax-local-phase-level)]
+             [just-phase #f]
+             [for-space #f]
+             [just-space #f]
+             [excepts #hasheq()])
+    (syntax-parse req
+      #:datum-literals (portal
+                        for-meta for-syntax for-template for-label just-meta
+                        for-space just-space
+                        only prefix
+                        all-except prefix-all-except
+                        rename)
+      [(portal id content) (check-identifier #'id phase-shift for-space)]
+      [(for-syntax req ...)
+       (for ([req (in-list (syntax->list #'(req ...)))])
+         (loop req (+ phase-shift 1) just-phase for-space just-space excepts))]
+      [(for-template req ...)
+       (for ([req (in-list (syntax->list #'(req ...)))])
+         (loop req (- phase-shift 1) just-phase for-space just-space excepts))]
+      [(for-meta phase-level req ...)
+       (when (syntax-e #'phase-level)
+         (for ([req (in-list (syntax->list #'(req ...)))])
+           (loop req (+ phase-shift (syntax-e #'phase-level)) just-phase for-space just-space excepts)))]
+      [(just-meta phase-level req ...)
+       (let ([new-just-phase (syntax-e #'phase-level)])
+         (when (or (not just-phase)
+                   (equal? just-phase new-just-phase))
+           (for ([req (in-list (syntax->list #'(req ...)))])
+             (loop req phase-shift new-just-phase for-space just-space excepts))))]
+      [(for-space space req ...)
+       (for ([req (in-list (syntax->list #'(req ...)))])
+         (loop req phase-shift just-phase (syntax-e #'space) just-space excepts))]
+      [(just-space space req ...)
+       (unless (or (not just-space)
+                   (eq? just-space (syntax-e #'space)))
+         (for ([req (in-list (syntax->list #'(req ...)))])
+           (loop req phase-shift just-phase for-space (syntax-e #'just-space) excepts)))]
+      [(only _ id ...)
+       (for ([id (in-list (syntax->list #'(id ...)))])
+         (check-identifier id phase-shift for-space))]
+      [(rename _ id _)
+       (check-identifier #'id phase-shift for-space)]
+      [(prefix . _)
+       (raise-syntax-error #f "not supported" req)]
+      [(all-except raw-module-path id ...)
+       (loop #'raw-module-path phase-shift just-phase for-space just-space
+             (for/fold ([excepts excepts]) ([id (in-list (syntax->list #'(id ...)))])
+               (hash-set excepts (syntax-e id) #t)))]
+      [(prefix-all-except . _)
+       (raise-syntax-error #f "not supported" req)]
+      [_
+       ;; module path
+       (define phase+space+symss (syntax-local-module-exports (syntax->datum req)))
+       (for ([phase+space+syms (in-list phase+space+symss)]
+             #:do [(define phase (phase+space-phase (car phase+space+syms)))
+                   (define space (phase+space-space (car phase+space+syms)))]
+             #:when (or (not just-space) (eq? just-space space))
+             #:when (or (not just-phase) (eq? just-phase phase))
+             [sym (in-list (cdr phase+space+syms))])
+         (define space (phase+space-space (car phase+space+syms)))
+         (check-identifier (datum->syntax top-req sym) (+ phase phase-shift) (or for-space space)))])))

--- a/rhombus/private/interface.rkt
+++ b/rhombus/private/interface.rkt
@@ -267,7 +267,8 @@
                                                      name? name-instance internal-name-ref name-ref-or-error
                                                      internal-name-instance internal-name-ref
                                                      dot-provider-name [dot-id ...]
-                                                     [export ...]))
+                                                     [export ...]
+                                                     base-stx scope-stx))
                (build-interface-desc supers parent-names options
                                      method-mindex method-names method-vtable method-results method-private dots
                                      internal-name

--- a/rhombus/private/namespace.rkt
+++ b/rhombus/private/namespace.rkt
@@ -12,7 +12,8 @@
          "parse.rkt"
          "name-root.rkt"
          "name-root-ref.rkt"
-         "parens.rkt")
+         "parens.rkt"
+         "export-check.rkt")
 
 (provide (for-space rhombus/defn
                     namespace))
@@ -55,6 +56,7 @@
                                                                               #'forward-base-ctx)
                                                 #'scoped-ctx)
                                                #'base-ctx))
+     (register-field-check #'(forward-base-ctx forward-ctx . fields))
      #'(define-name-root name
          #:extends extends
          #:fields
@@ -67,6 +69,7 @@
                      ((make-syntax-delta-introducer #'all-ctx #'ctx) #'scoped)
                      #'plain))
      (define fields (parse-exports #'(combine-out ex ...) expose))
+     (register-field-check #`(ctx all-ctx #,@fields))
      (define (generate-definitions ext-id int-id rule)
        (for/list ([space+id (in-list (let loop ([rule rule])
                                        (syntax-parse rule
@@ -224,7 +227,7 @@
                                                                (expose space-id)))
                (values space-sym #t)))
            (cond
-             [(null? use-spaces) ht]
+             [(zero? (hash-count use-spaces)) ht]
              [else (add-name-at-all-spaces ht id id use-spaces '#:only)]))]
         [(except-out starting-e exclude-e)
          (define all-except-ht (loop #'exclude-e except-ht #hasheq() spaces spaces-mode))

--- a/rhombus/private/veneer.rkt
+++ b/rhombus/private/veneer.rkt
@@ -280,7 +280,8 @@
                                                  []
                                                  [dot-id ...]
                                                  []
-                                                 [export ...]))
+                                                 [export ...]
+                                                 base-stx scope-stx))
                (build-class-static-infos #:veneer? #t
                                          #f
                                          super

--- a/rhombus/scribblings/ref-def.scrbl
+++ b/rhombus/scribblings/ref-def.scrbl
@@ -70,7 +70,10 @@
 
  Like @rhombus(def), but for bindings that become visible only after the
  @rhombus(let) form within its definition context. The @rhombus(let) form
- cannot be used in a top-level context outside of a module or local block.
+ cannot be used in a top-level context outside of a module or local
+ block. The @rhombus(let) can be used with the same name multiple times
+ in a module or block, but the same name cannot be defined with both
+ @rhombus(def) and @rhombus(let) within a module or block.
 
 @examples(
   block:

--- a/rhombus/tests/e.rhm
+++ b/rhombus/tests/e.rhm
@@ -1,0 +1,8 @@
+#lang rhombus/and_meta
+
+
+block:
+  namespace ns:
+    let z = 200
+    export all_defined
+  10

--- a/rhombus/tests/let.rhm
+++ b/rhombus/tests/let.rhm
@@ -33,3 +33,89 @@ check:
     && syntax_meta.equal_name_and_scopes(id1, id3)
     && syntax_meta.equal_name_and_scopes(id2, id3)
   ~is #true
+
+check:
+  def x = 1
+  block:
+    def y = x
+    let x = 2
+    y
+  ~is 1
+
+check:
+  let x = 1
+  block:
+    def y = x
+    let x = 2
+    y
+  ~is 1
+
+check:
+  let x = 1
+  block:
+    let x = 2
+    def y = x
+    y
+  ~is 2
+
+check:
+  ~eval
+  block:
+    def x = 1
+    let x = 2
+    "ok"
+  ~raises "duplicate definition"
+
+check:
+  ~eval
+  block:
+    let x = 2
+    def x = 1
+    "ok"
+  ~raises "duplicate definition"
+
+check:
+  ~eval
+  block:
+    let x = 2
+    let y = 2
+    def x = 1
+    "ok"
+  ~raises "duplicate definition"
+
+check:
+  ~eval
+  import rhombus/meta open
+  block:
+    def x = "outer"
+    defn.macro 'm $id':
+      'let $id = "inner"
+       x'
+    m x
+  ~raises "duplicate definition"
+  
+check:
+  ~eval
+  block:
+    let x = 2
+    import rhombus.List as x
+    "ok"
+  ~raises "duplicate import"
+
+check:
+  ~eval
+  block:
+    let x = 2
+    import rhombus as x
+    "ok"
+  ~raises "duplicate import"
+
+check:
+  ~eval
+  block:
+    let x = 2
+    import rhombus/meta open
+    defn.macro 'm $id':
+      'import rhombus as $id'
+    m x
+  ~raises "duplicate import"

--- a/rhombus/tests/namespace.rhm
+++ b/rhombus/tests/namespace.rhm
@@ -112,3 +112,21 @@ check:
     annot.macro 'Num': 'Real'
   1 :: Num
   ~is 1
+
+check:
+  ~eval
+  module m ~lang rhombus:
+    namespace ~open:
+      export:
+        nonesuch
+  ~throws "exported identifier not defined"
+
+check:
+  ~eval
+  module m ~lang rhombus:
+    namespace ~open:
+      export:
+        nonesuch
+      let nonesuch = 8
+  ~throws "exported identifier defined later"
+

--- a/rhombus/tests/use-site-scope.rhm
+++ b/rhombus/tests/use-site-scope.rhm
@@ -198,20 +198,26 @@ check:
   ~is "inner"
 
 check:
-  let x = "outer"
-  defn.macro 'm $id':
-    'def $id = "inner"
-     x'
-  m x
-  ~is "outer"
+  ~eval
+  import rhombus/meta open
+  block:
+    let x = "outer"
+    defn.macro 'm $id':
+      'def $id = "inner"
+       x'
+    m x
+  ~throws "duplicate definition"
 
 check:
-  def x = "outer"
-  defn.macro 'm $id':
-    'let $id = "inner"
-     x'
-  m x
-  ~is "inner"
+  ~eval
+  import rhombus/meta open
+  block:
+    def x = "outer"
+    defn.macro 'm $id':
+      'let $id = "inner"
+       x'
+    m x
+  ~throws "duplicate definition"
 
 check:
   ~eval
@@ -237,31 +243,27 @@ check:
   result
   ~is "inner"
 
-module flat_defn2 ~lang rhombus/and_meta:
-  export result
-  let x = "outer"
-  defn.macro 'm $result $id':
-    'def $id = "inner"
-     def $result = x'
-  m result x
+check:
+  ~eval
+  module flat_defn2 ~lang rhombus/and_meta:
+    export result
+    let x = "outer"
+    defn.macro 'm $result $id':
+      'def $id = "inner"
+       def $result = x'
+    m result x
+  ~throws "duplicate definition"
 
 check:
-  import self!flat_defn2 open
-  result
-  ~is "outer"
-
-module flat_defn3 ~lang rhombus/and_meta:
-  export result
-  def x = "outer"
-  defn.macro 'm $result $id':
-    'let $id = "inner"
-     def $result = x'
-  m result x
-
-check:
-  import self!flat_defn3 open
-  result
-  ~is "inner"
+  ~eval
+  module flat_defn3 ~lang rhombus/and_meta:
+    export result
+    def x = "outer"
+    defn.macro 'm $result $id':
+      'let $id = "inner"
+       def $result = x'
+    m result x
+  ~throws "duplicate definition"
 
 check:
   ~eval


### PR DESCRIPTION
The fist commit in this PR is intended to address #480 by making the combination of `def` and `let` for the same identifier an error in a given binding context. Otherwise, the commit preserves the current behavior and intent of `let`.

The second commit addresses the longstanding problem that `export`s by a namespace of an unbounded identifier didn't trigger an error until an attempt to use the exported binding. That repair is part of this PR because the new checking has particular support for `let`: it detects the case that the identifier is unbound because it is defined later with `let` and ties to provide a better error message in that case. (I have run into that situation and been confused a handful of times, and I think the improved error message would have helped.)

In the February 22 Rhombus meeting, there was a brief discussion about changing the meaning of `let` to create different definition contexts  before and after the `let`. After looking into that possibility, though, I concluded that it wouldn't help enough to detangle competing `let`s and `def`s within a block, and it wouldn't interfere with the intent of `let` and the way that I have been using `let` in practice. So, there's no change along those lines that here.
