### PR TITLE
shrubbery: exact rationals as literals

### DIFF
--- a/rhombus/private/arithmetic.rkt
+++ b/rhombus/private/arithmetic.rkt
@@ -59,7 +59,7 @@
 
 (define-infix rhombus* *
   #:weaker-than (rhombus**)
-  #:same-on-left-as (rhombus/ div mod rem))
+  #:same-as (rhombus/))
 
 (define-infix rhombus/ /
   #:weaker-than (rhombus**))

--- a/rhombus/private/print.rkt
+++ b/rhombus/private/print.rkt
@@ -92,6 +92,8 @@
        [else (other v mode op)])]
     [(exact-integer? v)
      (write v op)]
+    [(and (rational? v) (exact? v))
+     (write v op)]
     [(boolean? v)
      (display (if v "#true" "#false") op)]
     [(void? v)

--- a/rhombus/scribblings/ref-number.scrbl
+++ b/rhombus/scribblings/ref-number.scrbl
@@ -194,24 +194,29 @@
 @doc(
   operator ((x :: Number) + (y :: Number)) :: Number
   operator ((x :: Number) - (y :: Number)) :: Number
+  operator (- (x :: Number)) :: Number
   operator ((x :: Number) * (y :: Number)) :: Number
   operator ((x :: Number) / (y :: Number)) :: Number
   operator ((x :: Number) ** (y :: Number)) :: Number
 ){
 
- The usual arithmetic operators with the usual precedence, except that
- @rhombus(/) does not have the same precedence as @rhombus(*) when it
- appears to the left of @rhombus(*).
+ The usual arithmetic operators with the usual precedence.
+
+ Note that forms like @rhombus(+1), @rhombus(-1), and @rhombus(1/2) are
+ immediate numbers, as opposed to uses of the @rhombus(+), @rhombus(-),
+ and @rhombus(/) operators.
 
 @examples(
   1+2
   3-4
+  - 4
   5*6
-  8/2
+  8 / 2
+  7 / 2
+  7.0/2
   1+2*3
   2**10
-  ~error:
-    6/2*3
+  6 / 2 * 3
 )
 
 }
@@ -223,7 +228,9 @@
   operator ((x :: Integral) mod (y :: Integral)) :: Integral
 ){
 
- Integer division (truncating), remainder, and modulo operations.
+ Integer division (truncating), remainder, and modulo operations. These
+ operators have stronger pecedence than @rhombus(+) and @rhombus(-) but
+ no precedence relationship to @rhombus(*), @rhombus(/), or @rhombus(**).
 
 @examples(
   7 div 5

--- a/rhombus/scribblings/ref-stxobj.scrbl
+++ b/rhombus/scribblings/ref-stxobj.scrbl
@@ -189,7 +189,7 @@ Metadata for a syntax object can include a source location and the raw
 @examples(
   match '1 + 2'
   | '$n + $m': [n, m]
-  match '(1/1) (2/1) (3/1)'
+  match '(1 / 1) (2 / 1) (3 / 1)'
   | '($x/1) ...': [x, ...]
   match '1 + 2 * 3'
   | '$x ... * 3': [x, ...]

--- a/rhombus/tests/arithmetic.rhm
+++ b/rhombus/tests/arithmetic.rhm
@@ -15,7 +15,7 @@ check:
 check:
   ~eval
   10 / 2 * 4
-  ~throws "operators at same precedence, but only in the other order"
+  ~is 20
 
 check:
   fun five(x):
@@ -27,8 +27,8 @@ check: 3 ** 4 ~is 3*3*3*3
 check: 2 ** 3 ** 2 ~is 2 ** (3 ** 2)
 check: 2 ** 3 ** 2 == (2 ** 3) ** 2 ~is #false
 check:
-  2**2 + 2**2 - 2**2 * 2**2 div 2**2
-  ~is 4 + 4 - 4 * 4 div 4
+  2**2 + 2**2 - (2**2 * 2**2) div 2**2
+  ~is 4 + 4 - (4 * 4) div 4
 check:
   [2**2 / 2**2 , 2**2 * 2**2 , 2**2 mod 2**2]
   ~is [4/4, 4*4, 4 mod 4]

--- a/rhombus/tests/number.rhm
+++ b/rhombus/tests/number.rhm
@@ -96,3 +96,8 @@ check:
   1 is_a Real.at_most("oops") ~throws values("contract violation", "Real", "\"oops\"")
   1 is_a Real.in("oops", 2) ~throws values("contract violation", "Real", "\"oops\"")
   1 is_a Real.in(1, "oops") ~throws values("contract violation", "Real", "\"oops\"")
+
+  to_string(1/2) ~is "1/2"
+  to_string(1/2, ~mode: #'expr) ~is "1/2"
+  to_string(#{1+2i}) ~is "1+2i"
+  to_string(#{1+2i}, ~mode: #'expr) ~is "#{1+2i}"

--- a/shrubbery/scribblings/token-parsing.scrbl
+++ b/shrubbery/scribblings/token-parsing.scrbl
@@ -18,7 +18,7 @@ star (★) in the left column indicates the productions that correspond to
 @tech{terms} or comments.
 
 @deftech{Numbers} are supported directly in simple forms---decimal integers,
-decimal floating point, and hexadecimal/octal/binary integers---in all cases allowing
+decimal floating point, hexadecimal/octal/binary integers, and fractions---in all cases allowing
 @litchar{_}s between digits. A @s_exp_braces escape
 provides access to the full Racket S-expression number grammar. Special
 floating-point values use a @litchar{#} notation: @litchar{#inf},
@@ -133,6 +133,7 @@ but the table below describes the shape of @litchar("@") forms.
     ["", "", bor, @nonterm{hexinteger}, ""],
     ["", "", bor, @nonterm{octalinteger}, ""],
     ["", "", bor, @nonterm{binaryinteger}, ""],
+    ["", "", bor, @nonterm{fraction}, ""],
     empty_line,
     [no_lex, @nonterm{integer}, bis, bseq(boptional(@nonterm{sign}), @nonterm{nonneg}), ""],
     empty_line,
@@ -201,6 +202,9 @@ but the table below describes the shape of @litchar("@") forms.
     ["", "", bor, bseq(@litchar{_}, @nonterm{bit}), ""],
     empty_line,
 
+    [no_lex, @nonterm{fraction}, bis, bseq(@nonterm{integer}, @litchar{/}, @nonterm{nonneg}), @elem{@nonterm{nonneg} @notecol{not 0}}],
+    empty_line,
+    
     [is_lex, @nonterm{boolean}, bis, @litchar{#true}, ""],
     ["", "", bor, @litchar{#false}, ""],
     empty_line,

--- a/shrubbery/tests/input.rkt
+++ b/shrubbery/tests/input.rkt
@@ -46,6 +46,9 @@ let (x = 1, y = 2): x+y
 
 define pi: 3.14
 
+1/2
+1/2.0
+1/0000
 '1 + -2'
 
 define fib(n):
@@ -367,6 +370,9 @@ INPUT
      (parens (group x (op =) 1) (group y (op =) 2))
      (block (group x (op +) y)))
     (group define pi (block (group 3.14)))
+    (group 1/2)
+    (group 1 (op /) 2.0)
+    (group 1 (op /) 0)
     (group (quotes (group 1 (op +) -2)))
     (group
      define

--- a/shrubbery/write.rkt
+++ b/shrubbery/write.rkt
@@ -229,7 +229,8 @@
           (write-escaped v op)])]
       [(or (string? v)
            (bytes? v)
-           (exact-integer? v))
+           (exact-integer? v)
+           (and (rational? v) (exact? v)))
        (write* v op)]
       [(flonum? v)
        (cond


### PR DESCRIPTION
Allow `1/2` as a literal, for example. To go along with this, lift the precedence restriction in Rhombus against `*` after `/`.