### PR TITLE
add `..=` for inclusive finite ranges

### DIFF
--- a/rhombus/pict/private/anim.rhm
+++ b/rhombus/pict/private/anim.rhm
@@ -599,7 +599,7 @@ fun merge_epochs([p :~ _AnimPict, ...], dalign):
   let max_epoch = math.max(math.max(0, epochs_length(p) - duration_start(p) - 1), ...)
   let ps && [p :~ AnimPict, ...] = [reify_epochs(p, min_epoch, max_epoch), ...]
   let all_epochs:
-    for List (i: min_epoch .. max_epoch + 1):
+    for List (i: min_epoch ..= max_epoch):
       math.max(p.epoch_extent(i), ...)
   values (ps, -min_epoch, max_duration_epoch + 1, all_epochs)
 

--- a/rhombus/private/range.rkt
+++ b/rhombus/private/range.rkt
@@ -1,30 +1,29 @@
 #lang racket/base
 (require (for-syntax racket/base
-                     syntax/parse/pre
-                     "srcloc.rkt")
+                     syntax/parse/pre)
          "expression.rkt"
          "static-info.rkt"
          "parse.rkt"
          (prefix-in rhombus-a: "arithmetic.rkt")
          "sequence-constructor-key.rkt"
          "treelist.rkt"
-         (submod "list.rkt" for-listable))
+         (submod "list.rkt" for-listable)
+         "realm.rkt")
 
 (provide ..)
 
 (define-syntax ..
   (expression-infix-operator
    (expr-quote ..)
-   (list
-    (cons (expr-quote rhombus-a:+) 'weaker)
-    (cons (expr-quote rhombus-a:-) 'weaker)
-    (cons (expr-quote rhombus-a:*) 'weaker)
-    (cons (expr-quote rhombus-a:/) 'weaker))
+   `((,(expr-quote rhombus-a:+) . weaker)
+     (,(expr-quote rhombus-a:-) . weaker)
+     (,(expr-quote rhombus-a:*) . weaker)
+     (,(expr-quote rhombus-a:/) . weaker))
    'macro
    (lambda (form1 tail)
      (syntax-parse tail
        [(_)
-        (values (wrap-as-static-sequence #`(in-naturals #,form1))
+        (values (wrap-as-static-sequence #`(in-infinite-range #,form1))
                 #'())]
        [(_ . more)
         #:with (~var rhs (:infix-op+expression+tail #'..)) #'(group . more)
@@ -51,3 +50,42 @@
 
 (define (in-listable-range/proc a b)
   (listable-range (in-range a b)))
+
+(define (check-integer who int)
+  (unless (exact-integer? int)
+    (raise-argument-error* who rhombus-realm "Int" int)))
+
+(define-sequence-syntax in-infinite-range
+  (lambda () #'in-infinite-range/proc)
+  (lambda (stx)
+    (syntax-parse stx
+      [[(id) (_ start-expr)]
+       #'[(id)
+          (:do-in
+           ([(start) start-expr])
+           (unless (variable-reference-from-unsafe? (#%variable-reference))
+             (check-integer 'in-infinite-range start))
+           ([pos start])
+           #t
+           ([(id) pos])
+           #t
+           #t
+           ((+ pos 1)))]]
+      [_ #f])))
+
+(define (in-infinite-range/proc start)
+  (check-integer 'in-infinite-range start)
+  (infinite-range start))
+
+(struct infinite-range (start)
+  #:property prop:sequence (lambda (r)
+                             (make-do-sequence
+                              (lambda ()
+                                (values
+                                 values
+                                 #f
+                                 add1
+                                 (infinite-range-start r)
+                                 #f
+                                 #f
+                                 #f)))))

--- a/rhombus/scribblings/ref-sequence.scrbl
+++ b/rhombus/scribblings/ref-sequence.scrbl
@@ -31,6 +31,7 @@ internal state, and the state can even be specific to a particular
 
 }
 
+
 @doc(
   ~nonterminal:
     n_expr: block expr
@@ -46,13 +47,22 @@ internal state, and the state can even be specific to a particular
  specified, the result is an infinite sequence that contains all integers
  starting from @rhombus(n, ~var).
 
- The @rhombus(..)'s precedence is lower than the arithmetic operators
- @rhombus(+), @rhombus(-), @rhombus(*), and @rhombus(/). In particular,
- @rhombus(n_expr..1+m_expr) creates a sequence that includes
- @rhombus(m, ~var) for many forms @rhombus(m_expr).
+ The @rhombus(..) operator's precedence is lower than the arithmetic operators
+ @rhombus(+), @rhombus(-), @rhombus(*), and @rhombus(/).
 
  A @rhombus(..) expression has static information that makes it
  acceptable as a sequence to @rhombus(for) in static mode.
+
+}
+
+@doc(
+  ~nonterminal:
+    n_expr: block expr
+    m_expr: block expr
+  expr.macro '$n_expr ..= $m_expr'
+){
+
+ Like @rhombus(n_expr .. m_expr), but with an inclusive upper bound.
 
 }
 

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -7,10 +7,15 @@ check:
   (0..) is_a Listable ~is #false
   0..2 ~is_a Sequence
   0..2 ~is_a Listable
+  0..=2 ~is_a Sequence
+  0..=2 ~is_a Listable
   -2.. ~is_a Sequence
   (-2..) is_a Listable ~is #false
   -2..0 ~is_a Sequence
   -2..0 ~is_a Listable
+  -2..=0 ~is_a Sequence
+  -2..=0 ~is_a Listable
+  [& -2..0, & 0..=2] ~is [-2, -1, 0, 1, 2]
 
 block:
   def mutable accum = []
@@ -64,6 +69,23 @@ check:
             _: 0..2):
     i
   ~is [-2, -1]
+
+check:
+  for List:
+    each i: 0..=2
+    i
+  ~is [0, 1, 2]
+
+check:
+  for List:
+    each i: dynamic(0..=2)
+    i
+  ~is [0, 1, 2]
+
+check:
+  for List (i: 0..=2):
+    i
+  ~is [0, 1, 2]
 
 check:
   for Map:

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -2,10 +2,15 @@
 import:
   "version_guard.rhm"
 
-check: 0.. ~is_a Sequence
-check: 0..2 ~is_a Sequence
-check: 0..2 ~is_a Listable
-check: (0..) is_a Listable ~is #false
+check:
+  0.. ~is_a Sequence
+  (0..) is_a Listable ~is #false
+  0..2 ~is_a Sequence
+  0..2 ~is_a Listable
+  -2.. ~is_a Sequence
+  (-2..) is_a Listable ~is #false
+  -2..0 ~is_a Sequence
+  -2..0 ~is_a Listable
 
 block:
   def mutable accum = []
@@ -37,6 +42,28 @@ check:
   for List (i: 0..2):
     i
   ~is [0, 1]
+
+check:
+  for List:
+    each:
+      i: -2..
+      _: 0..2
+    i
+  ~is [-2, -1]
+
+check:
+  for List:
+    each:
+      i: dynamic(-2..)
+      _: 0..2
+    i
+  ~is [-2, -1]
+
+check:
+  for List (i: -2..,
+            _: 0..2):
+    i
+  ~is [-2, -1]
 
 check:
   for Map:


### PR DESCRIPTION
The `..=` operator has a precedent in Rust.

This PR also includes a commit that fixes suffix `..`.