### PR TITLE
per-key configuration of static-info union and intersection; use of intersection by `if` and `cond`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -29,4 +29,4 @@
     "gui-easy"
     "compatibility"))
 
-(define version "0.24")
+(define version "0.25")

--- a/rhombus/private/append-key.rkt
+++ b/rhombus/private/append-key.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
 
-(provide #%append)
-
-(define #%append #f)
+(define-static-info-key-syntax/provide #%append
+  (static-info-key static-info-identifier-union
+                   static-info-identifier-intersect))

--- a/rhombus/private/call-result-key.rkt
+++ b/rhombus/private/call-result-key.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
 
-(provide #%call-result
-         #%call-results-at-arities)
-
-(define #%call-result #f)
-(define #%call-results-at-arities #f)
+(define-static-info-key-syntax/provide #%call-result
+  (static-info-key static-infos-result-union
+                   static-infos-result-intersect))

--- a/rhombus/private/class-annotation.rkt
+++ b/rhombus/private/class-annotation.rkt
@@ -6,6 +6,7 @@
          (submod "annot-macro.rkt" for-class)
          (for-syntax "class-transformer.rkt")
          (submod "dot.rkt" for-dot-provider)
+         "dot-provider-key.rkt"
          "dotted-sequence-parse.rkt")
 
 (provide (for-syntax build-class-annotation-form

--- a/rhombus/private/class-binding.rkt
+++ b/rhombus/private/class-binding.rkt
@@ -6,6 +6,7 @@
                      (only-in enforest/operator operator-proc)
                      "srcloc.rkt")
          "binding.rkt"
+         "dot-provider-key.rkt"
          (submod "bind-macro.rkt" for-class)
          "composite.rkt"
          "parens.rkt"

--- a/rhombus/private/class-method-result.rkt
+++ b/rhombus/private/class-method-result.rkt
@@ -126,7 +126,7 @@
            (define all-static-infos
              (if all-count
                  (for/foldr ([all-static-infoss (for/list ([_ (in-range all-count)])
-                                                  '())]
+                                                  #'())]
                              #:result (if (eqv? all-count 1)
                                           #`#,(car all-static-infoss)
                                           #`((#%values #,all-static-infoss))))
@@ -146,9 +146,10 @@
      (define (gen id [de-method? #f])
        (if (syntax-e id)
            (list #`(define-static-info-syntax #,id
-                     #,(if (eq? (syntax-e #'kind) 'property)
-                           #`(#%call-results-at-arities ((#,(if de-method? 0 1) #,all-static-infos)))
-                           #`(#%call-result #,all-static-infos))
+                     (#%call-result
+                      #,(if (eq? (syntax-e #'kind) 'property)
+                            #`(#:at_arities ((#,(arithmetic-shift 1 (if de-method? 0 1)) #,all-static-infos)))
+                            all-static-infos))
                      #,@(if (syntax-e #'arity)
                             (list #`(#%function-arity #,(if de-method?
                                                             (de-method-arity #'arity)

--- a/rhombus/private/class-method.rkt
+++ b/rhombus/private/class-method.rkt
@@ -20,6 +20,7 @@
          "static-info.rkt"
          "indirect-static-info-key.rkt"
          (submod "dot.rkt" for-dot-provider)
+         "dot-provider-key.rkt"
          (submod "assign.rkt" for-assign)
          "parens.rkt"
          (submod "function-parse.rkt" for-call)

--- a/rhombus/private/class-primitive.rkt
+++ b/rhombus/private/class-primitive.rkt
@@ -13,6 +13,7 @@
          "dot-parse.rkt"
          "function-arity-key.rkt"
          "call-result-key.rkt"
+         "dot-provider-key.rkt"
          "composite.rkt"
          "class-desc.rkt"
          "define-arity.rkt"

--- a/rhombus/private/class-static-info.rkt
+++ b/rhombus/private/class-static-info.rkt
@@ -11,6 +11,7 @@
          "call-result-key.rkt"
          "function-arity-key.rkt"
          "function-arity.rkt"
+         "dot-provider-key.rkt"
          "static-info.rkt"
          "class-able.rkt")
 
@@ -154,7 +155,7 @@
                                               [si (syntax->list #'(public-field-static-infos ...))])
                                      (append
                                       (if (syntax-e maybe-set)
-                                          (list #`(#%call-results-at-arities ((1 #,si)))
+                                          (list #`(#%call-result (#:at_arities ((2 #,si))))
                                                 #'(#%function-arity 6))
                                           (list #`(#%call-result #,si)
                                                 #'(#%function-arity 2)))

--- a/rhombus/private/dot-provider-key.rkt
+++ b/rhombus/private/dot-provider-key.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
 
-(provide #%dot-provider)
-
-(define #%dot-provider #f)
+(define-static-info-key-syntax/provide #%dot-provider
+  (static-info-key static-info-identifier-union
+                   static-info-identifier-intersect))

--- a/rhombus/private/dot.rkt
+++ b/rhombus/private/dot.rkt
@@ -31,7 +31,6 @@
 
              in-dot-provider-space))
   (provide define-dot-provider-syntax
-           #%dot-provider
            prop:field-name->accessor
            prop:field-name->mutator
            curry-method))

--- a/rhombus/private/function-arity-key.rkt
+++ b/rhombus/private/function-arity-key.rkt
@@ -1,5 +1,10 @@
 #lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt"
+         "function-arity.rkt")
 
-(provide #%function-arity)
-
-(define #%function-arity #f)
+(define-static-info-key-syntax/provide #%function-arity
+  (static-info-key (lambda (a b)
+                     (union-arity-summaries (list (syntax->datum a) (syntax->datum b))))
+                   (lambda (a b)
+                     (intersect-arity-summaries (list (syntax->datum a) (syntax->datum b))))))

--- a/rhombus/private/index-key.rkt
+++ b/rhombus/private/index-key.rkt
@@ -1,7 +1,11 @@
 #lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
 
-(provide #%index-get
-         #%index-set)
+(define-static-info-key-syntax/provide #%index-get
+  (static-info-key static-info-identifier-union
+                   static-info-identifier-intersect))
 
-(define #%index-get #f)
-(define #%index-set #f)
+(define-static-info-key-syntax/provide #%index-set
+  (static-info-key static-info-identifier-union
+                   static-info-identifier-intersect))

--- a/rhombus/private/index-result-key.rkt
+++ b/rhombus/private/index-result-key.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
 
-(provide #%index-result)
-
-(define #%index-result #f)
+(define-static-info-key-syntax/provide #%index-result
+  (static-info-key static-infos-union
+                   static-infos-intersect))

--- a/rhombus/private/indirect-static-info-key.rkt
+++ b/rhombus/private/indirect-static-info-key.rkt
@@ -1,5 +1,5 @@
 #lang racket/base
+(require "static-info.rkt")
 
 (provide #%indirect-static-info)
 
-(define #%indirect-static-info #f)

--- a/rhombus/private/interface.rkt
+++ b/rhombus/private/interface.rkt
@@ -23,6 +23,7 @@
          "class-step.rkt"
          "class-static-info.rkt"
          "dotted-sequence-parse.rkt"
+         "dot-provider-key.rkt"
          (for-syntax "class-transformer.rkt")
          (only-meta-in 1
                        "class-method.rkt")

--- a/rhombus/private/sequence-constructor-key.rkt
+++ b/rhombus/private/sequence-constructor-key.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
 
-(provide #%sequence-constructor)
-
-(define #%sequence-constructor #f)
+(define-static-info-key-syntax/provide #%sequence-constructor
+  (static-info-key static-info-identifier-union
+                   static-info-identifier-intersect))

--- a/rhombus/private/sequence-element-key.rkt
+++ b/rhombus/private/sequence-element-key.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
+(require (for-syntax racket/base)
+         "static-info.rkt")
 
-(provide #%sequence-element)
-
-(define #%sequence-element #f)
+(define-static-info-key-syntax/provide #%sequence-element
+  (static-info-key static-infos-union
+                   static-infos-intersect))

--- a/rhombus/private/syntax-object.rkt
+++ b/rhombus/private/syntax-object.rkt
@@ -580,9 +580,10 @@
   (syntax-srcloc (maybe-respan stx)))
 
 (define/method Syntax.property
-  #:static-infos ((#%call-results-at-arities
-                   ((3 #,syntax-static-infos)
-                    (4 #,syntax-static-infos))))
+  #:static-infos ((#%call-result
+                   (#:at_arities
+                    ((8 ())
+                     (16 #,syntax-static-infos)))))
   (case-lambda
     [(stx prop)
      (syntax-property (extract-ctx who stx #:false-ok? #f) prop)]

--- a/rhombus/private/values-key.rkt
+++ b/rhombus/private/values-key.rkt
@@ -1,5 +1,5 @@
 #lang racket/base
+(require "static-info.rkt")
 
 (provide #%values)
 
-(define #%values #f)

--- a/rhombus/private/veneer.rkt
+++ b/rhombus/private/veneer.rkt
@@ -26,6 +26,7 @@
          "class-method.rkt"
          "class-top-level.rkt"
          "dotted-sequence-parse.rkt"
+         "dot-provider-key.rkt"
          "parens.rkt"
          (submod "namespace.rkt" for-exports)
          "class-able.rkt"

--- a/rhombus/scribblings/ref-cond.scrbl
+++ b/rhombus/scribblings/ref-cond.scrbl
@@ -21,6 +21,12 @@
  @rhombus(#false)), returns the result of the @rhombus(then_body) clause,
  otherwise returns the result of the @rhombus(else_body) clause.
 
+ Static information is gathered from @rhombus(then_body) and
+ @rhombus(else_body) under the same conditions as the right-hand side of
+ @rhombus(def) (see @secref("static-info-rules")), and the information is
+ intersected to determine the static information of the @rhombus(if)
+ form.
+
 @examples(
   if #true
   | "yes"
@@ -68,6 +74,13 @@
 
  If no @rhombus(clause_test_expr) produces a true value and there is no
  @rhombus(~else) clause, a run-time exception is thrown.
+
+ Static information is gathered from @rhombus(clause_result_body)s or
+ @rhombus(clause_result_expr) under the same conditions as the right-hand
+ side of @rhombus(def) (see @secref("static-info-rules")), and the
+ information is intersected to determine the static information of the
+ @rhombus(cond) form.
+
 
 }
 

--- a/rhombus/scribblings/ref-def.scrbl
+++ b/rhombus/scribblings/ref-def.scrbl
@@ -27,10 +27,13 @@
  A @rhombus(bind) can be just an identifier or @rhombus(id_name), or it
  can be constructed with a binding operator, such as a pattern form or
  @rhombus(::) for annotations. The number of result values must match
- the number of @rhombus(bind)s.
+ the number of @rhombus(bind)s. Static information is gathered from
+ @rhombus(rhs_expr) or @rhombus(body) and propagated to
+ @rhombus(lhs_bind) as described in @secref("static-info-rules")).
 
- An identifier is bound in the @rhombus(expr, ~space) @tech{space}, and most
- binding operators also create bindings in the @rhombus(expr, ~space) space.
+ An identifier is bound in the @rhombus(expr, ~space) @tech{space}, and
+ most binding operators also create bindings in the
+ @rhombus(expr, ~space) space.
 
  When @rhombus(def) is used with @rhombus(=), then @rhombus(rhs_expr) must
  not contain any immediate @rhombus(=) terms (although @rhombus(=) can

--- a/rhombus/scribblings/ref-static-info.scrbl
+++ b/rhombus/scribblings/ref-static-info.scrbl
@@ -4,6 +4,8 @@
     "nonterminal.rhm" open
     "macro.rhm")
 
+@(def statinfo_key_defn = @rhombus(statinfo.key, ~defn))
+
 @title{Static Information}
 
 @doc(
@@ -67,7 +69,8 @@
    ((#,(@rhombus(key_id, ~var)), #,(@rhombus(val, ~var))), ...))
 
  Keys for static information are compared based on binding, not merely
- the key's symbolic form.
+ the key's symbolic form. Key identifiers should be defined with
+ @rhombus(statinfo.key, ~defn).
 
  See @secref("annotation-macro") for an example.
 
@@ -133,9 +136,69 @@
  avoid expansion of terms that are nested within a block.
 
  Keys for static information are compared based on binding, not merely
- the key's symbolic form.
+ the key's symbolic form.  Key identifiers should be defined with
+ @statinfo_key_defn.
 
 }
+
+@doc(
+  fun statinfo_meta.gather(expr_stx :: Syntax) :: Syntax
+){
+
+ Returns all of the static information of @rhombus(expr_stx) in unpacked
+ form. The returned static information corresponds to all the possible
+ keys for which @rhombus(statinfo_meta.lookup) would return a value.
+
+}
+
+@doc(
+  fun statinfo_meta.union(statinfo_stx :: Syntax, ...) :: Syntax
+  fun statinfo_meta.intersect(statinfo_stx :: Syntax, ...) :: Syntax
+){
+
+ Takes static information in unpacked form and combines it into one set
+ of static information in unpacked form, where the returned information
+ is the union or intersection of all given information.
+
+}
+
+
+@doc(
+  ~nonterminal:
+    union_proc_expr: block expr
+    intersect_proc_expr: block expr
+
+  defn.macro '«statinfo.key $id:
+                 $clause
+                 ...»'
+  grammar clause:
+    ~union: union_proc_expr
+    ~intersect: intersect_proc_expr
+){
+
+ Binds @rhombus(id) for use as a static info key identifier. Both
+ @rhombus(union_proc_expr) and @rhombus(intersect_proc_expr) are
+ required, and they should each produce a function that accepts two
+ syntax objects as values for static information keyed by @rhombus('id').
+ The union operation is used, for example, on static information from
+ annotations combined with @rhombus(&&, ~annot), and interaction is used
+ on static information from annotations combined with
+ @rhombus(||, ~annot).
+
+ Typically, a definition @rhombus(statinfo.key id) should be paired with
+ a definition @rhombus(meta #,(rhombus(def)) #,(rhombus(id_key, ~var)) = 'id') so
+ that @rhombus(id_key, ~var) can be used directly as a key, instead of
+ @rhombus('id').
+
+ When a static information key is not an identifier bound via
+ @rhombus(statinfo.key, ~defn), then default union and intersection operations
+ are used for the key's values. The default functions use the same merge
+ operations as @rhombus(statinfo_meta.call_result_key), which means that
+ they merge nested static information.
+
+}
+
+
 
 @doc(
   def statinfo_meta.call_result_key :: Identifier

--- a/rhombus/tests/cond.rhm
+++ b/rhombus/tests/cond.rhm
@@ -11,3 +11,52 @@ check:
   | #false: 17
   | ~else: 18
   ~is 18
+
+check:
+  use_static
+  (if #true | [1] | ["one"])[0]
+  ~is 1
+
+check:
+  ~eval
+  use_static
+  (if #true | [1] | "one")[0]
+  ~throws "specialization not known"
+
+check:
+  use_static
+  (cond | 1 == 2: [1] | 2 == 2: ["one"])[0]
+  ~is "one"
+
+check:
+  use_static
+  (cond | 1 == 2: [1] | ~else: ["one"])[0]
+  ~is "one"
+
+check:
+  use_static
+  (cond | 1 == 2: [1] | ~else ["one"])[0]
+  ~is "one"
+
+check:
+  ~eval
+  use_static
+  (if #true | [1] | "one")[0]
+  ~throws "specialization not known"
+
+check:
+  ~eval
+  use_static
+  (cond | #true: [1] | ~else: "one")[0]
+  ~throws "specialization not known"
+
+
+check:
+  ~eval
+  use_static
+  class Posn(x, y)
+  def p = (if #true
+           | Posn(1, 2)
+           | #void)
+  p.x
+  ~throws "no such field or method"

--- a/rhombus/tests/function.rhm
+++ b/rhombus/tests/function.rhm
@@ -20,6 +20,53 @@ check:
   (fun (x, ~y = 0): #void) is_a Function.of_arity(1, ~y) ~is #true
   (fun (x, ~y): #void) is_a Function.of_arity(1, ~y) ~is #true
 
+block:
+  use_static
+  fun g(x, ...): [x, ...]
+  let f :: Function.of_arity(1) = (g :: Function.of_arity(2))
+  check f(1) ~is [1]
+  check f(1, 2) ~is [1, 2]
+
+check:
+  ~eval
+  use_static
+  fun g(x, ...): [x, ...]
+  def f :: Function.of_arity(1) = (g :: Function.of_arity(2))
+  f()
+  ~throws "wrong number of arguments in function call"
+
+check:
+  ~eval
+  use_static
+  fun g(x, ...): [x, ...]
+  def f :: Function.of_arity(1) = (g :: Function.of_arity(2))
+  f(1, 2, 3)
+  ~throws "wrong number of arguments in function call"
+
+check:
+  use_static
+  fun f1(g :: Function.of_arity(1)):
+    g(1)
+  fun f2(g :: Function.of_arity(1, ~ok)):
+    g(1)
+  fun f3(g :: Function.of_arity(1, ~ok)):
+    g(1, ~ok: 10)
+  ~completes
+
+check:
+  ~eval
+  use_static
+  fun f(g :: Function.of_arity(1)):
+    g(1, ~kw: 10)
+  ~throws "keyword argument not recognized"
+
+check:
+  ~eval
+  use_static
+  fun f(g :: Function.of_arity(1) || Function.of_arity(2)):
+    g(1)
+  ~throws "wrong number of arguments "
+
 check:
   (fun (x): #void) is_a Function.of_arity(#void, error("I throw first!"))
   ~throws "I throw first!"

--- a/rhombus/tests/statinfo-macro.rhm
+++ b/rhombus/tests/statinfo-macro.rhm
@@ -71,3 +71,22 @@ check:
   statinfo_meta.sequence_element_key.unwrap()
   statinfo_meta.values_key.unwrap()
   ~completes
+
+block:
+  use_static
+  expr.macro 'both ($(a :: expr_meta.Parsed)) ($(b :: expr_meta.Parsed)): $c':
+    statinfo_meta.wrap(c, statinfo_meta.union(statinfo_meta.gather(a), statinfo_meta.gather(b)))
+  expr.macro 'either ($(a :: expr_meta.Parsed)) ($(b :: expr_meta.Parsed)): $c':
+    statinfo_meta.wrap(c, statinfo_meta.intersect(statinfo_meta.gather(a), statinfo_meta.gather(b)))
+  check (both ([]) ([]): [1])[0] ~is 1
+  check (either ([]) ([]): [1])[0] ~is 1
+  check (both ([]) ([]): "")[0] ~throws "expected: List"
+
+check:
+  ~eval
+  use_static
+  import rhombus/meta open
+  expr.macro 'either ($(a :: expr_meta.Parsed)) ($(b :: expr_meta.Parsed)): $c':
+    statinfo_meta.wrap(c, statinfo_meta.intersect(statinfo_meta.gather(a), statinfo_meta.gather(b)))
+  (either ([]) (""): 0) ++ []
+  ~throws "specialization not known"


### PR DESCRIPTION
This PR has two changes:

* Change the way keys for static information are defined so that the definition can supply union and intersection operations on values associated with the key. The operations are also directly exposed by `statinfo_meta.union` and `statinfo_meta.intersect`. 
* Change `if` and `cond` to trigger earlier enforestation of body forms under the same circumstances as `def`, and then intersect static information from the branches to provide static information for the overall `if` or `cond` form. This kind of expansion and intersection is not done for `match`, because enforesting the result bodies requires expanding the binding patterns, and it's not clear that earlier expansion there is a good idea.

As an example use, these changes allow me to remove some annotations on `if`s (or on `let` bindings where the right-hand size if an `if`) that seemed especially annoying in some of my `rhombus/slideshow`-based slides.
