### PR TITLE
identify some identifiers as to-be-ignored by check syntax

### DIFF
--- a/shrubbery/parse.rkt
+++ b/shrubbery/parse.rkt
@@ -127,11 +127,14 @@
 (define (closer-expected-opener closer) (and (pair? closer) (cdr closer)))
 (define (make-closer-expected str tok) (cons str tok))
 
-(define group-tag (syntax-raw-property (datum->syntax #f 'group) '()))
-(define top-tag (syntax-raw-property (datum->syntax #f 'top) '()))
-(define parens-tag (syntax-raw-property (datum->syntax #f 'parens) '()))
-(define brackets-tag (syntax-raw-property (datum->syntax #f 'brackets) '()))
-(define alts-tag (syntax-raw-property (datum->syntax #f 'alts) '()))
+(define (syntax-raw-identifier-property stx)
+  (syntax-property (syntax-raw-property stx '()) 'identifier-as-keyword #t))
+
+(define group-tag (syntax-raw-identifier-property (datum->syntax #f 'group)))
+(define top-tag (syntax-raw-identifier-property (datum->syntax #f 'top)))
+(define parens-tag (syntax-raw-identifier-property (datum->syntax #f 'parens)))
+(define brackets-tag (syntax-raw-identifier-property (datum->syntax #f 'brackets)))
+(define alts-tag (syntax-raw-identifier-property (datum->syntax #f 'alts)))
 
 (define within-parens-str "within parentheses, brackets, or braces")
 
@@ -1113,10 +1116,12 @@
               (list (car l)))
           post-syntaxes
           (let ([tag (if opener-t
-                         (datum->syntax (token-value opener-t)
-                                        'brackets
-                                        (token-value opener-t)
-                                        (token-value opener-t))
+                         (syntax-property
+                          (datum->syntax (token-value opener-t)
+                                         'brackets
+                                         (token-value opener-t)
+                                         (token-value opener-t))
+                          'identifier-as-keyword #t)
                          brackets-tag)])
             (cond
               [(null? new-content) (list tag)]
@@ -1447,7 +1452,7 @@
 (define (add-span-srcloc start-t end-t l
                          #:alt [alt-start-t #f])
   (define (add-srcloc l s-loc loc)
-    (cons (let* ([stx (datum->syntax* #f (car l) loc stx-for-original-property)])
+    (cons (let* ([stx (datum->syntax* #f (car l) loc stx-for-identifier-as-keyword)])
             (if (syntax? start-t)
                 (let* ([stx (syntax-property-copy stx start-t syntax-raw-property)]
                        [stx (syntax-property-copy stx start-t syntax-raw-prefix-property)]

--- a/shrubbery/scribblings/language.scrbl
+++ b/shrubbery/scribblings/language.scrbl
@@ -84,7 +84,9 @@ resulting shrubbery is not empty, it is parsed in the same way that
  @seclink["raw-text"]{raw-text properties} for text before and after the
  group elements. For an operator, source-location information and properties
  are associated to the operator identifier, and not the
- wrapper @racket[op] identifier.
+ wrapper @racket[op] identifier. Each structuring identifier like
+ @racket[group], @racket[block], @racket[parens], or @racket[op]
+ has the @racket['identifier-as-keyword] syntax property as @racket[#t].
 
  The default @racket['top] mode read @racket[in] until an end-of-file,
  and it expects a sequence of groups that are indented consistently


### PR DESCRIPTION
This makes some of the identifiers that were making the giant green blobs invisible to Check Syntax and seems to avoid the ones show in #489. I'm not sure if this is right, however. It also seems to get `#%parens` sometimes and maybe some others.

If you want to try it out, you'll need [this recent commit to DrRacket](https://github.com/racket/drracket/commit/150f105882fc64c484eb2664925215bbc4a7e128).

In this example:

```
def op = 5
'+'
```

we still get the arrow.

In this example:

```
def parens = 5
'(abc,
  
  def,

  ghi,

  jkl)'
```

we don't anymore.

I also notice when playing around, that there are some `#%body` that are being ignored, but the ones I saw didn't have source locations.

Overall, I'm very not sure this is the right change!

related to #489

