### PR TITLE
add `Comparable`

### DIFF
--- a/demo.rhm
+++ b/demo.rhm
@@ -312,7 +312,7 @@ sum([1, 2, 3])
 fun
 | is_sorted([] || [_]): #true
 | is_sorted([head, next, tail, ...]):
-   head <= next && is_sorted([next, tail, ...])
+   head .<= next && is_sorted([next, tail, ...])
 
 is_sorted([1, 2, 3, 4, 5])
 is_sorted([1, 2, 30, 4, 5])

--- a/info.rkt
+++ b/info.rkt
@@ -29,4 +29,4 @@
     "gui-easy"
     "compatibility"))
 
-(define version "0.25")
+(define version "0.26")

--- a/rhombus/pict/private/static.rhm
+++ b/rhombus/pict/private/static.rhm
@@ -132,10 +132,10 @@ class Pict():
     PrintDesc.special(snapshot().handle, ~mode: #'print,
                       "Pict(...)")
 
-  abstract property width
-  abstract property height
-  abstract property ascent
-  abstract property descent
+  abstract property width :~ Real
+  abstract property height :~ Real
+  abstract property ascent :~ Real
+  abstract property descent :~ Real
 
   abstract property duration :~ Int
   abstract method epoch_extent(i :: Int) :~ Real

--- a/rhombus/private/annotation.rkt
+++ b/rhombus/private/annotation.rkt
@@ -24,7 +24,8 @@
          "parse.rkt"
          "realm.rkt"
          "parens.rkt"
-         "if-blocked.rkt")
+         "if-blocked.rkt"
+         "number.rkt")
 
 (provide is_a
          (for-spaces (#f
@@ -783,21 +784,21 @@
 (define-annotation-syntax Any (identifier-annotation #'(lambda (x) #t) #'()))
 (define-annotation-syntax None (identifier-annotation #'(lambda (x) #f) #'()))
 (define-annotation-syntax Boolean (identifier-annotation #'boolean? #'()))
-(define-annotation-syntax Int (identifier-annotation #'exact-integer? #'()))
-(define-annotation-syntax PosInt (identifier-annotation #'exact-positive-integer? #'()))
-(define-annotation-syntax NegInt (identifier-annotation #'exact-negative-integer? #'()))
-(define-annotation-syntax NonnegInt (identifier-annotation #'exact-nonnegative-integer? #'()))
-(define-annotation-syntax Flonum (identifier-annotation #'flonum? #'()))
-(define-annotation-syntax Byte (identifier-annotation #'byte? #'()))
-(define-annotation-syntax Number (identifier-annotation #'number? #'()))
-(define-annotation-syntax Integral (identifier-annotation #'integer? #'()))
-(define-annotation-syntax Rational (identifier-annotation #'rational? #'()))
-(define-annotation-syntax Exact (identifier-annotation #'exact-number? #'()))
-(define-annotation-syntax Inexact (identifier-annotation #'inexact-number? #'()))
-(define-annotation-syntax Real (identifier-annotation #'real? #'()))
-(define-annotation-syntax PosReal (identifier-annotation #'positive-real? #'()))
-(define-annotation-syntax NegReal (identifier-annotation #'negative-real? #'()))
-(define-annotation-syntax NonnegReal (identifier-annotation #'nonnegative-real? #'()))
+(define-annotation-syntax Int (identifier-annotation #'exact-integer? int-static-infos))
+(define-annotation-syntax PosInt (identifier-annotation #'exact-positive-integer? int-static-infos))
+(define-annotation-syntax NegInt (identifier-annotation #'exact-negative-integer? int-static-infos))
+(define-annotation-syntax NonnegInt (identifier-annotation #'exact-nonnegative-integer? int-static-infos))
+(define-annotation-syntax Byte (identifier-annotation #'byte? int-static-infos))
+(define-annotation-syntax Flonum (identifier-annotation #'flonum? flonum-static-infos))
+(define-annotation-syntax Number (identifier-annotation #'number? number-static-infos))
+(define-annotation-syntax Integral (identifier-annotation #'integer? rational-static-infos))
+(define-annotation-syntax Rational (identifier-annotation #'rational? rational-static-infos))
+(define-annotation-syntax Exact (identifier-annotation #'exact-number? rational-static-infos))
+(define-annotation-syntax Inexact (identifier-annotation #'inexact-number? real-static-infos))
+(define-annotation-syntax Real (identifier-annotation #'real? real-static-infos))
+(define-annotation-syntax PosReal (identifier-annotation #'positive-real? real-static-infos))
+(define-annotation-syntax NegReal (identifier-annotation #'negative-real? real-static-infos))
+(define-annotation-syntax NonnegReal (identifier-annotation #'nonnegative-real? real-static-infos))
 (define-annotation-syntax Void (identifier-annotation #'void? #'()))
 (define-annotation-syntax False (identifier-annotation #'not #'()))
 (define-annotation-syntax True (identifier-annotation #'(lambda (x) (and x #t)) #'()))

--- a/rhombus/private/bytes.rkt
+++ b/rhombus/private/bytes.rkt
@@ -7,11 +7,14 @@
          "call-result-key.rkt"
          "index-key.rkt"
          "append-key.rkt"
+         "compare-key.rkt"
          (submod "annotation.rkt" for-class)
          "mutability.rkt"
          "define-arity.rkt"
          "class-primitive.rkt"
-         "rhombus-primitive.rkt")
+         "rhombus-primitive.rkt"
+         "number.rkt"
+         "realm.rkt")
 
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
@@ -31,7 +34,13 @@
   #:no-constructor-static-info
   #:instance-static-info ((#%index-get Bytes.get)
                           (#%index-set Bytes.set)
-                          (#%append Bytes.append))
+                          (#%append Bytes.append)
+                          (#%compare ((< bytes<?)
+                                      (<= bytes<=?)
+                                      (= bytes=?)
+                                      (!= bytes!=?)
+                                      (>= bytes>=?)
+                                      (> bytes>?))))
   #:existing
   #:opaque
   #:fields ()
@@ -90,6 +99,7 @@
 (define/method (Bytes.length bstr)
   #:inline
   #:primitive (bytes-length)
+  #:static-infos ((#%call-result #,int-static-infos))
   (bytes-length bstr))
 
 (define/method Bytes.subbytes
@@ -133,6 +143,21 @@
     [(bstr dest-start src) (bytes-copy! bstr dest-start src)]
     [(bstr dest-start src src-start) (bytes-copy! bstr dest-start src src-start)]
     [(bstr dest-start src src-start src-end) (bytes-copy! bstr dest-start src src-start src-end)]))
+
+(define (bytes!=? a b)
+  (if (and (bytes? a) (bytes? b))
+      (not (bytes=? a b))
+      (raise-argument-error* '!= rhombus-realm "Bytes" (if (bytes? a) b a))))
+
+(define (bytes<=? a b)
+  (if (and (bytes? a) (bytes? b))
+      (not (bytes>? a b))
+      (raise-argument-error* '<= rhombus-realm "Bytes" (if (bytes? a) b a))))
+
+(define (bytes>=? a b)
+  (if (and (bytes? a) (bytes? b))
+      (not (bytes<? a b))
+      (raise-argument-error* '>= rhombus-realm "Bytes" (if (bytes? a) b a))))
 
 (begin-for-syntax
   (install-literal-static-infos! 'bytes bytes-static-infos))

--- a/rhombus/private/class-able.rkt
+++ b/rhombus/private/class-able.rkt
@@ -32,6 +32,7 @@
              [(get) (class-desc-index-method-id super)]
              [(set) (class-desc-index-set-method-id super)]
              [(append) (class-desc-append-method-id super)]
+             [(compare) (class-desc-compare-method-id super)]
              [else (error "unknown able")]))))
 
 ;; gets public or private id, whatever is available to supply arity info in case
@@ -48,30 +49,32 @@
 ;;   * `here-<which>able?` implies that a <which> method is declared or inherited and implements
 ;;     `<Which>able`; if #f, instances may still be callable through an inherited private implementation
 ;;   * `public-<which>able?` can be #f even if `here-<which>able?` if the <which> method is not public
-(define-for-syntax (able-method-status which super interfaces method-mindex method-vtable method-private)
+(define-for-syntax (able-method-status which super interfaces method-mindex method-vtable method-private
+                                       #:name [which-name which])
   (define is-able?
     (or (and super (memq which (objects-desc-flags super)))
         (for/or ([intf (in-list interfaces)])
           (memq which (objects-desc-flags intf)))))
   (values is-able?
           (and is-able?
-               (or (hash-ref method-private which #f)
-                   (let ([m (hash-ref method-mindex which #f)])
+               (or (hash-ref method-private which-name #f)
+                   (let ([m (hash-ref method-mindex which-name #f)])
                      (and m
                           (not (eq? '#:abstract (vector-ref method-vtable (mindex-index m))))))))
           (and is-able?
                (not (hash-ref method-private which #f)))))
 
 (define-for-syntax (able-method-as-property which prop:whichable-id able?
-                                            method-mindex method-vtable method-private)
+                                            method-mindex method-vtable method-private
+                                            #:name [which-name which])
   (cond
     [able?
      (cond
-       [(hash-ref method-private which #f)
+       [(hash-ref method-private which-name #f)
         => (lambda (which-id)
              (list #`(cons #,prop:whichable-id #,which-id)))]
        [else
-        (define midx (hash-ref method-mindex which))
+        (define midx (hash-ref method-mindex which-name))
         (list #`(cons #,prop:whichable-id
                       #,(vector-ref method-vtable (mindex-index midx))))])]
     [else null]))
@@ -79,10 +82,12 @@
 (define-for-syntax (able-method-for-class-desc which
                                                able? public-able?
                                                super
-                                               method-mindex method-vtable method-private)
+                                               method-mindex method-vtable method-private
+                                               #:const [const #f])
   (cond
     [(and able? (not public-able?))
      #`(quote-syntax #,(cond
+                         [const const]
                          [(hash-ref method-private which #f)
                           => (lambda (which-id) which-id)]
                          [else
@@ -92,5 +97,6 @@
                             [(get) (class-desc-index-method-id super)]
                             [(set) (class-desc-index-set-method-id super)]
                             [(append) (class-desc-append-method-id super)]
+                            [(compare) (class-desc-compare-method-id super)]
                             [else (error "unknown able")])]))]
     [else #'#f]))

--- a/rhombus/private/class-method-result.rkt
+++ b/rhombus/private/class-method-result.rkt
@@ -11,6 +11,7 @@
          "index-result-key.rkt"
          "index-key.rkt"
          "append-key.rkt"
+         "compare-key.rkt"
          "values-key.rkt"
          (submod "function-parse.rkt" for-build)
          (only-in "function-arity.rkt"
@@ -35,11 +36,12 @@
 (define-syntax (define-method-result-syntax stx)
   (syntax-parse stx
     [(_ id (ret::ret-annotation) (super-result-id ...)
-        maybe-final-id convert-ok? checked-append? kind arity
+        maybe-final-id convert-ok? checked-append? checked-compare? kind arity
         maybe-call-statinfo-id
         maybe-ref-statinfo-id+id
         maybe-set-statinfo-id+id
-        maybe-append-statinfo-id+id)
+        maybe-append-statinfo-id+id
+        maybe-compare-statinfo-id+id)
      #:do [(define-values (proc predicate? count annot-str static-infos)
              (cond
                [(attribute ret.converter)
@@ -187,7 +189,9 @@
          #,@(gen-bounce #'maybe-set-statinfo-id+id #'#%index-set #f)
          #,@(gen-bounce #'maybe-append-statinfo-id+id #'#%append #f
                         ;; boxed identifier means "checked" for `#%append`
-                        #:box-id? (syntax-e #'checked-append?)))]))
+                        #:box-id? (syntax-e #'checked-append?))
+         #,@(gen-bounce #'maybe-compare-statinfo-id+id #'#%compare #f
+                        #:box-id? (syntax-e #'checked-compare?)))]))
 
 (define-for-syntax (de-method-arity arity)
   (datum->syntax #f

--- a/rhombus/private/class-parse.rkt
+++ b/rhombus/private/class-parse.rkt
@@ -57,7 +57,7 @@
    dots          ; list of symbols for dot syntax
    dot-provider  ; #f or compile-time identifier
    static-infos  ; syntax object for additional instance static-infos
-   flags))       ; 'call (=> public `call` is Callable), 'get, 'set, 'append; others specific to class/interface/veneer
+   flags))       ; 'call (=> public `call` is Callable), 'get, 'set, 'append, 'compare; others specific to class/interface/veneer
 
 (struct class-desc objects-desc
   ;; `flags` from `objects-desc` can include 'authentic, 'prefab, 'no-recon
@@ -79,6 +79,7 @@
    index-method-id       ; for `get`
    index-set-method-id   ; for `set`
    append-method-id      ; for `append`
+   compare-method-id      ; for `compare`
    indirect-call-method-id ; #f or identifier for `call`
    prefab-guard-id))
 

--- a/rhombus/private/class-primitive.rkt
+++ b/rhombus/private/class-primitive.rkt
@@ -271,6 +271,7 @@
                                  #f ; not indexable
                                  #f ; not mutable indexable
                                  #f ; not appendable
+                                 #f ; not comparable
                                  #f ; not callable (again)
                                  #f ; not prefab
                                  )))

--- a/rhombus/private/class-static-info.rkt
+++ b/rhombus/private/class-static-info.rkt
@@ -29,6 +29,8 @@
     (able-statinfo-indirect-id 'set super interfaces name-id intro))
   (define append-statinfo-indirect-id
     (able-statinfo-indirect-id 'append super interfaces name-id intro))
+  (define compare-statinfo-indirect-id
+    (able-statinfo-indirect-id 'compare super interfaces name-id intro))
 
   (define super-call-statinfo-indirect-id
     (able-super-statinfo-indirect-id 'call super interfaces))
@@ -68,6 +70,9 @@
               #'())
        #,@(if append-statinfo-indirect-id
               #`((#%indirect-static-info #,append-statinfo-indirect-id))
+              #'())
+       #,@(if compare-statinfo-indirect-id
+              #`((#%indirect-static-info #,compare-statinfo-indirect-id))
               #'())))
 
   (define indirect-static-infos
@@ -81,6 +86,7 @@
           index-statinfo-indirect-id
           index-set-statinfo-indirect-id
           append-statinfo-indirect-id
+          compare-statinfo-indirect-id
 
           super-call-statinfo-indirect-id
 

--- a/rhombus/private/comparable.rkt
+++ b/rhombus/private/comparable.rkt
@@ -1,0 +1,445 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     enforest/operator
+                     "srcloc.rkt"
+                     "statically-str.rkt"
+                     "interface-parse.rkt")
+         "provide.rkt"
+         "expression.rkt"
+         "repetition.rkt"
+         (submod "annotation.rkt" for-class)
+         "parse.rkt"
+         (only-in "arithmetic.rkt" .< .<= .= .>= .>)
+         (submod "map.rkt" for-append)
+         "append-key.rkt"
+         "compare-key.rkt"
+         "call-result-key.rkt"
+         "static-info.rkt"
+         "repetition.rkt"
+         "compound-repetition.rkt"
+         "realm.rkt"
+         (only-in "class-desc.rkt" define-class-desc-syntax)
+         (only-in "class-method-result.rkt" method-result)
+         "is-static.rkt"
+         "number.rkt")
+
+(provide (for-spaces (rhombus/class
+                      rhombus/annot)
+                     Comparable)
+         (for-spaces (#f
+                      rhombus/repet)
+                     (rename-out
+                      [rhombus< <]
+                      [rhombus<= <=]
+                      [rhombus>= >=]
+                      [rhombus> >])
+                     compares_equal
+                     compares_unequal))
+
+(define-values (prop:Comparable Comparable? Comparable-ref)
+  (make-struct-type-property 'Comparable))
+
+(define-annotation-syntax Comparable
+  (identifier-annotation #'comparable? #'((#%compare ((< general<)
+                                                      (<= general<=)
+                                                      (= general=)
+                                                      (!= general!=)
+                                                      (>= general>=)
+                                                      (> general>))))))
+
+(define (comparable? v)
+  (or (real? v)
+      (string? v)
+      (bytes? v)
+      (symbol? v)
+      (keyword? v)
+      (Comparable? v)))
+
+(define-class-desc-syntax Comparable
+  (interface-desc #'()
+                  '#(#&compare_to #&less #&less_or_equal #&compares_equal #&compares_unequal #&greater_or_equal #&greater)
+                  #'#(#:abstract
+                      Comparable.less
+                      Comparable.less_or_equal
+                      Comparable.compares_equal
+                      Comparable.compares_unequal
+                      Comparable.greater_or_equal
+                      Comparable.greater)
+                  (hasheq 'compare_to 0
+                          'less 1
+                          'less_or_equal 2
+                          'compares_equal 3
+                          'compares_unequal 4
+                          'greater_or_equal 5
+                          'greater 6)
+                  (hasheq 'compare_to #'compare-to-result
+                          'less #'boolean-result
+                          'less_or_equal #'boolean-result
+                          'compares_equal #'boolean-result
+                          'compares_unequal #'boolean-result
+                          'greater_or_equal #'boolean-result
+                          'greater #'boolean-result)
+                  '()
+                  #f
+                  #'()
+                  '(compare veneer)
+                  ;; --------------------
+                  #'Comparable
+                  #'Comparable
+                  #'prop:Comparable
+                  #'prop:Comparable
+                  #'Comparable-ref
+                  #t
+                  #f
+                  null))
+
+(define-syntax compare-to-result
+  (method-result #'exact-integer? #t 1 "Int" int-static-infos 4))
+
+(define-syntax boolean-result
+  (method-result #'boolean? #t 1 "Boolean" #'() 4))
+
+(define-for-syntax (parse-compare op form1 form2 self-stx form1-in
+                                  static?
+                                  comparable-static-info
+                                  k)
+  (define-values (direct-compare1/maybe-boxed direct-compare2/maybe-boxed)
+    (comparable-static-info #'#%compare))
+  (define checked1? (and direct-compare1/maybe-boxed
+                         (box? (syntax-e direct-compare1/maybe-boxed))))
+  (define checked2? (and direct-compare2/maybe-boxed
+                         (box? (syntax-e direct-compare2/maybe-boxed))))
+  (define checked? (or checked1? checked2?))
+  (define direct-compare1 (if checked1?
+                              (unbox (syntax-e direct-compare1/maybe-boxed))
+                              direct-compare1/maybe-boxed))
+  (define direct-compare2 (if checked2?
+                              (unbox (syntax-e direct-compare2/maybe-boxed))
+                              direct-compare2/maybe-boxed))
+  (define (get-compare-id direct-compare)
+    (cond
+      [(and (syntax? direct-compare)
+            (eq? '#:method (syntax-e direct-compare)))
+       (values (case op
+                 [(<) #'method<]
+                 [(<=) #'method<=]
+                 [(=) #'method=]
+                 [(!=) #'method!=]
+                 [(>=) #'method>=]
+                 [(>) #'method>]
+                 [else (error "unrecognized op" op)])
+               #t)]
+      [(identifier? direct-compare)
+       (values direct-compare #f)]
+      [else
+       (define id
+         (for/or ([pr (in-list (or (and direct-compare (syntax->list direct-compare)) null))])
+           (syntax-parse pr
+             [(c-op id)
+              #:when (eq? op (syntax-e #'c-op))
+              #'id]
+             [_ #f])))
+       (cond
+         [(identifier? id)
+          (values id #t)]
+         [(and (syntax? id)
+               (box? (syntax-e id))
+               (identifier? (unbox (syntax-e id))))
+          (values (unbox (syntax-e id)) #f)]
+         [else (values (case op
+                         [(<) #'general<]
+                         [(<=) #'general<=]
+                         [(=) #'general=]
+                         [(!=) #'general!=]
+                         [(>=) #'general>=]
+                         [(>) #'general>]
+                         [else (error "unrecognized op" op)])
+                       #t)])]))
+  (define-values (compare1-id bool1?) (get-compare-id direct-compare1))
+  (define-values (compare2-id bool2?) (get-compare-id direct-compare2))
+  (define-values (generic-id generic-bool2) (get-compare-id #f))
+  (define-values (compare-id bool?)
+    (cond
+      [(and static? (not direct-compare1) (not direct-compare2))
+       (raise-syntax-error #f
+                           (string-append "specialization not known" statically-str)
+                           self-stx
+                           #f
+                           (list form1-in
+                                 form2))]
+      [(not direct-compare1) (values compare2-id bool2?)]
+      [(not direct-compare2) (values compare1-id bool1?)]
+      [(free-identifier=? compare1-id compare2-id) (values compare2-id bool2?)]
+      [(free-identifier=? compare1-id generic-id) (values compare2-id bool2?)]
+      [(free-identifier=? compare2-id generic-id) (values compare1-id bool1?)]
+      [(not static?) (get-compare-id #f)]
+      [else
+       (raise-syntax-error #f
+                           (string-append "incompatible specializations from arguments" statically-str)
+                           self-stx
+                           #f
+                           (list form1-in
+                                 form2))]))
+  (k compare-id bool?
+     (not checked?)
+     form1 form2))
+
+(define (!= a b) (not (= a b)))
+
+(define-for-syntax (build-compare compare-id op bool? direct? form1 form2 orig-stxes)
+  (relocate+reraw
+   (respan (datum->syntax #f orig-stxes))
+   (datum->syntax (quote-syntax here)
+                  (let ([e (if direct?
+                               (list compare-id form1 form2)
+                               `(,#'let ([a1 ,form1]
+                                         [a2 ,form2])
+                                        (,#'check-comparable ',(case op
+                                                                 [(=) 'compares_equal]
+                                                                 [(!=) 'compares_unequal]
+                                                                 [else op])
+                                                             ,(case op
+                                                                [(<) 1]
+                                                                [(<=) 2]
+                                                                [(=) 3]
+                                                                [(!=) 4]
+                                                                [(>=) 5]
+                                                                [(>) 6])
+                                                             a1
+                                                             a2)
+                                        (,compare-id a1 a2)))])
+                    (if bool?
+                        e
+                        `(,op ,e 0))))))
+
+(define-for-syntax (make-comp-expression op)
+  (lambda (form1-in form2 self-stx)
+    (define static? (is-static-context? self-stx))
+    (define form1 (rhombus-local-expand form1-in))
+    (parse-compare
+     op form1 form2 self-stx form1-in
+     static?
+     (lambda (key) (values (syntax-local-static-info form1 key)
+                           (syntax-local-static-info form2 key)))
+     (lambda (compare-id bool? direct? form1 form2)
+       (build-compare compare-id op bool? direct? form1 form2
+                      (list form1-in self-stx form2))))))
+
+(define-for-syntax (make-comp-repetition op)
+  (lambda (form1 form2 self-stx)
+    (define static? (is-static-context? self-stx))
+    (syntax-parse form1
+      [form1-info::repetition-info
+       (syntax-parse form2
+         [form2-info::repetition-info
+          (build-compound-repetition
+           self-stx
+           (list form1 form2)
+           (lambda (form1 form2)
+             (parse-compare
+              op form1 form2 self-stx form1
+              static?
+              (lambda (key)
+                (values (repetition-static-info-lookup #'form1-info.element-static-infos key)
+                        (repetition-static-info-lookup #'form2-info.element-static-infos key)))
+              (lambda (compare-id bool? direct? form1 form2)
+                (values
+                 (build-compare compare-id op bool? direct? form1 form2
+                                (list form1 self-stx form2))
+                 #'())))))])])))
+
+(define-for-syntax precedences
+  (operator-precedences (syntax-local-value (quote-syntax .<))))
+(define-for-syntax repet-precedences
+  (operator-precedences (syntax-local-value (repet-quote .<))))
+
+(define-syntax-rule (define-compare-op def-op op .op)
+  (begin
+    (define-syntax def-op
+      (expression-infix-operator
+       (expr-quote def-op)
+       precedences
+       'automatic
+       (make-comp-expression 'op)
+       'left))
+    (define-repetition-syntax def-op
+      (repetition-infix-operator
+       (repet-quote def-op)
+       repet-precedences
+       'automatic
+       (make-comp-repetition 'op)
+       'left))))
+
+(define-compare-op rhombus< < .<)
+(define-compare-op rhombus<= <= .<=)
+(define-compare-op compares_equal = .=)
+(define-compare-op compares_unequal != .!=)
+(define-compare-op rhombus>= >= .>=)
+(define-compare-op rhombus> > .>)
+
+;; checking for the same `compare` method relies on the fact that `class`
+;; will generate a new procedure each time that `compare` is overridden
+(define (same-compare? a b)
+  (eq? a b))
+
+(define compare-who/method 'Comparable.compare_to)
+
+(define (raise-mismatch what op v1 v2
+                        #:method [method 'compare_to]
+                        #:both-compare? [both-compare? #f])
+  (define other-what (if both-compare?
+                         (string-append "other " what)
+                         "other value"))
+  (raise-arguments-error*
+   op rhombus-realm
+   (string-append "cannot compare "
+                  (case (string-ref what 0)
+                    [(#\a #\i) "an "]
+                    [else "a "])
+                  what " and " other-what
+                  (if both-compare?
+                      (string-append ";\n two "
+                                     what
+                                     "s must share the same `"
+                                     (symbol->string method)
+                                     "` implementation")
+                      ""))
+   what v1
+   other-what v2))
+
+(define-syntax-rule (define-general general-op method-op
+                      op wrap vtable-index
+                      num-op
+                      char-op
+                      string-op
+                      bytes-op
+                      symbol-op
+                      keyword-op)
+  (begin
+    (define (general-op v1 v2)
+      (cond
+        [(number? v1)
+         (unless (number? v2)
+           (raise-mismatch "number" 'op v1 v2))
+         (wrap (num-op v1 v2))]
+        [(char? v1)
+         (unless (char? v2)
+           (raise-mismatch "character" 'op v1 v2))
+         (wrap (char-op v1 v2))]
+        [(string? v1)
+         (unless (string? v2)
+           (raise-mismatch "string" 'op v1 v2))
+         (wrap (string-op v1 v2))]
+        [(bytes? v1)
+         (unless (bytes? v2)
+           (raise-mismatch "byte string" 'op v1 v2))
+         (wrap (bytes-op v1 v2))]
+        [(symbol? v1)
+         (unless (symbol? v2)
+           (raise-mismatch "symbol" 'op v1 v2))
+         (wrap (symbol-op v1 v2))]
+        [(keyword? v1)
+         (unless (keyword? v2)
+           (raise-mismatch "keyword" 'op v1 v2))
+         (wrap (keyword-op v1 v2))]
+        [else (method-op v1 v2)]))
+    (define (method-op v1 v2)
+      (define vt1 (Comparable-ref v1 #f))
+      (unless vt1
+        (raise-argument-error* compare-who/method rhombus-realm "Comparable" v1))
+      (define app1 (vector-ref vt1 vtable-index))
+      (define vt2 (Comparable-ref v2 #f))
+      (unless (and vt2
+                   (same-compare? (vector-ref vt1 0) (vector-ref vt2 0))
+                   (same-compare? (vector-ref vt1 vtable-index) (vector-ref vt2 vtable-index)))
+        (raise-mismatch "comparable object" 'op v1 v2
+                        #:method (if (same-compare? (vector-ref vt1 0) (vector-ref vt2 0))
+                                     'op
+                                     'compare_to)
+                        #:both-compare? (and vt2 #t)))
+      (app1 v1 v2))))
+
+(define-general general< method<
+  < values 1
+  <
+  char<?
+  string<?
+  bytes<?
+  symbol<?
+  keyword<?)
+
+(define-general general<= method<=
+  <= values 2
+  <=
+  char<=?
+  string<=?
+  (lambda (a b) (not (bytes>? a b)))
+  (lambda (a b) (or (eq? a b) (symbol<? a b)))
+  (lambda (a b) (or (eq? a b) (keyword<? a b))))
+
+(define-general general= method=
+  compares_equal values 3
+  =
+  char=?
+  string=?
+  bytes=?
+  eq?
+  eq?)
+
+(define-general general!= method!=
+  compares_unequal not 4
+  =
+  char=?
+  string=?
+  bytes=?
+  eq?
+  eq?)
+
+(define-general general>= method>=
+  >= values 5
+  >=
+  char>=?
+  string>=?
+  (lambda (a b) (not (bytes<? a b)))
+  (lambda (a b) (or (eq? a b) (symbol<? b a)))
+  (lambda (a b) (or (eq? a b) (keyword<? b a))))
+
+(define-general general> method>
+  >= values 6
+  >
+  char>?
+  string>?
+  bytes>?
+  (lambda (a b) (symbol<? b a))
+  (lambda (a b) (keyword<? b a)))
+
+(define (Comparable.less a b)
+  (< ((vector-ref (Comparable-ref a #f) 0) a b) 0))
+(define (Comparable.less_or_equal a b)
+  (<= ((vector-ref (Comparable-ref a #f) 0) a b) 0))
+(define (Comparable.compares_equal a b)
+  (= ((vector-ref (Comparable-ref a #f) 0) a b) 0))
+(define (Comparable.compares_unequal a b)
+  (not (= ((vector-ref (Comparable-ref a #f) 0) a b) 0)))
+(define (Comparable.greater_or_equal a b)
+  (>= ((vector-ref (Comparable-ref a #f) 0) a b) 0))
+(define (Comparable.greater a b)
+  (> ((vector-ref (Comparable-ref a #f) 0) a b) 0))
+
+(define (check-comparable op vtable-index a1 a2)
+  (define vt1 (Comparable-ref a1 #f))
+  (unless vt1
+    (raise-arguments-error*
+     op rhombus-realm
+     "checked `compare` must be applied to an comparable object"
+     "value" a1))
+  (define vt2 (Comparable-ref a2 #f))
+  (unless (and vt2
+               (same-compare? (vector-ref vt1 0) (vector-ref vt2 0))
+               (same-compare? (vector-ref vt1 vtable-index) (vector-ref vt2 vtable-index)))
+    (raise-mismatch "comparable object" op a1 a2
+                    #:method (if (same-compare? (vector-ref vt1 0) (vector-ref vt2 0))
+                                 op
+                                 'compare_to)
+                    #:both-compare? (and vt2 #t))))

--- a/rhombus/private/compare-key.rkt
+++ b/rhombus/private/compare-key.rkt
@@ -1,0 +1,41 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre)
+         "static-info.rkt")
+
+;; value for #%compare is either
+;;   #:method
+;;   compare_to_id
+;;   ((op id_or_box) ...)
+;; where id_or_box is
+;;   op_id
+;;   &compare_to_id
+
+(define-static-info-key-syntax/provide #%compare
+  (static-info-key (lambda (a b)
+                     a)
+                   (lambda (a b)
+                     (cond
+                       [(and (eq? '#:method (syntax-e a)) (eq? '#:method (syntax-e b)))
+                        a]
+                       [(or (identifier? a) (identifier? b))
+                        (static-info-identifier-intersect a b)]
+                       [else
+                        (let ([as (syntax->list a)]
+                              [bs (syntax->list b)])
+                          (and as
+                               bs
+                               ;; we could try to intersect at a finer granularity, but
+                               ;; just check whether they're the same
+                               (= (length as) (length bs))
+                               (for/and ([a (in-list as)]
+                                         [b (in-list bs)])
+                                 (syntax-parse (list a b)
+                                   [((a-op a-id:identifier) (b-op b-id:identifier))
+                                    (and (eq? (syntax-e #'a-op) (syntax-e #'b-op))
+                                         (free-identifier=? #'a-id #'b-id))]
+                                   [((a-op #&a-id:identifier) (b-op #&b-id:identifier))
+                                    (and (eq? (syntax-e #'a-op) (syntax-e #'b-op))
+                                         (free-identifier=? #'a-id #'b-id))]
+                                   [_ #false]))
+                               a))]))))

--- a/rhombus/private/core.rkt
+++ b/rhombus/private/core.rkt
@@ -101,6 +101,7 @@
         "key-comp-primitive.rkt"
         "indexable.rkt"
         "appendable.rkt"
+        "comparable.rkt"
         "listable.rkt"
         "assign.rkt"
         "equal.rkt"

--- a/rhombus/private/equatable.rkt
+++ b/rhombus/private/equatable.rkt
@@ -7,7 +7,9 @@
          "realm.rkt"
          (only-in "class-desc.rkt" define-class-desc-syntax)
          (only-in "class-method-result.rkt" method-result)
-         "define-arity.rkt")
+         "define-arity.rkt"
+         "call-result-key.rkt"
+         "number.rkt")
 
 (provide (for-spaces (rhombus/class
                       rhombus/namespace)
@@ -54,7 +56,7 @@
   (method-result #'(lambda (x) #t) #t 1 "Any" #'() 8))
 
 (define-syntax hash-code-result
-  (method-result #'exact-integer? #t 1 "Int" #'() 4))
+  (method-result #'exact-integer? #t 1 "Int" int-static-infos 4))
 
 (define (equal-recur-internal-method this other recur)
   ((vector-ref (Equatable-ref this) 0) this other recur))
@@ -70,6 +72,7 @@
    hash_code_combine_unordered))
 
 (define/arity (Equatable.hash v)
+  #:static-infos ((#%call-result #,int-static-infos))
   (equal-always-hash-code v))
 
 (define/arity (identity_hash v)

--- a/rhombus/private/interface.rkt
+++ b/rhombus/private/interface.rkt
@@ -112,6 +112,7 @@
                        index-statinfo-indirect-id
                        index-set-statinfo-indirect-id
                        append-statinfo-indirect-id
+                       compare-statinfo-indirect-id
 
                        super-call-statinfo-indirect-id
 
@@ -135,6 +136,7 @@
                      [index-statinfo-indirect index-statinfo-indirect-id]
                      [index-set-statinfo-indirect index-set-statinfo-indirect-id]
                      [append-statinfo-indirect append-statinfo-indirect-id]
+                     [compare-statinfo-indirect compare-statinfo-indirect-id]
                      [super-call-statinfo-indirect super-call-statinfo-indirect-id])
          (values
           #`(begin
@@ -153,7 +155,7 @@
                                           #,internal-internal-name
                                           instance-static-infos
                                           call-statinfo-indirect index-statinfo-indirect
-                                          index-set-statinfo-indirect append-statinfo-indirect
+                                          index-set-statinfo-indirect append-statinfo-indirect compare-statinfo-indirect
                                           super-call-statinfo-indirect]
                                 exports
                                 [option stx-param] ...))))])))
@@ -168,7 +170,7 @@
                     internal-internal-name-id
                     instance-static-infos
                     call-statinfo-indirect index-statinfo-indirect
-                    index-set-statinfo-indirect append-statinfo-indirect
+                    index-set-statinfo-indirect append-statinfo-indirect compare-statinfo-indirect
                     super-call-statinfo-indirect]
           exports
           [option stx-param] ...)
@@ -216,6 +218,9 @@
          (able-method-status 'set #f supers method-mindex method-vtable method-private))
        (define-values (appendable? here-appendable? public-appendable?)
          (able-method-status 'append #f supers method-mindex method-vtable method-private))
+       (define-values (comparable? here-comparable? public-comparable?)
+         (able-method-status 'compare #f supers method-mindex method-vtable method-private
+                             #:name 'compare_to))
 
        (define (temporary template #:name [name #'name])
          (and name
@@ -273,7 +278,7 @@
                (build-interface-desc supers parent-names options
                                      method-mindex method-names method-vtable method-results method-private dots
                                      internal-name
-                                     callable? indexable? setable? appendable?
+                                     callable? indexable? setable? appendable? comparable?
                                      primitive-properties
                                      #'(name name-extends prop:name name-ref name-ref-or-error
                                              prop:internal-name internal-name? internal-name-ref
@@ -289,6 +294,7 @@
                                      #'index-statinfo-indirect indexable?
                                      #'index-set-statinfo-indirect setable?
                                      #'append-statinfo-indirect appendable?
+                                     #'compare-statinfo-indirect comparable?
                                      #'super-call-statinfo-indirect))))
            #`(begin . #,defns)))])))
 
@@ -342,7 +348,7 @@
 (define-for-syntax (build-interface-desc supers parent-names options
                                          method-mindex method-names method-vtable method-results method-private dots
                                          internal-name
-                                         callable? indexable? setable? appendable?
+                                         callable? indexable? setable? appendable? comparable?
                                          primitive-properties
                                          names)
   (with-syntax ([(name name-extends prop:name name-ref name-ref-or-error
@@ -397,7 +403,8 @@
                                (if callable? '(call) '())
                                (if indexable? '(get) '())
                                (if setable? '(set) '())
-                               (if appendable? '(append) '()))
+                               (if appendable? '(append) '())
+                               (if comparable? '(compare) '()))
                            ;; ----------------------------------------
                            (quote-syntax name)
                            #,(and internal-name

--- a/rhombus/private/keyword.rkt
+++ b/rhombus/private/keyword.rkt
@@ -4,13 +4,28 @@
          "provide.rkt"
          "name-root.rkt"
          "define-arity.rkt"
-         (submod "annotation.rkt" for-class))
+         "call-result-key.rkt"
+         "compare-key.rkt"
+         (submod "annotation.rkt" for-class)
+         "realm.rkt")
 
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
                      Keyword))
 
-(define-annotation-syntax Keyword (identifier-annotation #'keyword? #'()))
+(module+ for-static-info
+  (provide (for-syntax keyword-static-infos)))
+
+(define-for-syntax keyword-static-infos
+  #'((#%compare ((< keyword<?)
+                 (<= keyword<=?)
+                 (= keyword=?)
+                 (!= keyword!=?)
+                 (>= keyword>=?)
+                 (> keyword>?)))))
+
+(define-annotation-syntax Keyword
+  (identifier-annotation #'keyword? keyword-static-infos))
 
 (define-name-root Keyword
   #:fields
@@ -18,7 +33,33 @@
    from_symbol))
 
 (define/arity (from_string s)
+  #:static-infos ((#%call-result #,keyword-static-infos))
   (string->keyword s))
 
 (define/arity (from_symbol s)
+  #:static-infos ((#%call-result #,keyword-static-infos))
   (string->keyword (symbol->immutable-string s)))
+
+(define (check-keywords who a b)
+  (unless (and (keyword? a) (keyword? b))
+    (raise-argument-error* who rhombus-realm "Keyword" (if (keyword? a) b a))))
+
+(define (keyword<=? a b)
+  (check-keywords '<= a b)
+  (or (eq? a b) (keyword<? a b)))
+
+(define (keyword=? a b)
+  (check-keywords '= a b)
+  (eq? a b))
+
+(define (keyword!=? a b)
+  (check-keywords '!= a b)
+  (not (eq? a b)))
+
+(define (keyword>=? a b)
+  (check-keywords '>= a b)
+  (or (eq? a b) (keyword<? b a)))
+
+(define (keyword>? a b)
+  (check-keywords '> a b)
+  (keyword<? b a))

--- a/rhombus/private/list.rkt
+++ b/rhombus/private/list.rkt
@@ -30,7 +30,8 @@
          "define-arity.rkt"
          "class-primitive.rkt"
          "rhombus-primitive.rkt"
-         "rest-bind.rkt")
+         "rest-bind.rkt"
+         "number.rkt")
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -289,11 +290,13 @@
 (define/method (List.length l)
   #:inline
   #:primitive (treelist-length)
+  #:static-infos ((#%call-result #,int-static-infos))
   (treelist-length l))
 
 (define/method (PairList.length l)
   #:inline
   #:primitive (length)
+  #:static-infos ((#%call-result #,int-static-infos))
   (length l))
 
 (define/method (List.reverse l)

--- a/rhombus/private/literal.rkt
+++ b/rhombus/private/literal.rkt
@@ -4,7 +4,8 @@
                      shrubbery/print
                      "annotation-string.rkt")
          "binding.rkt"
-         "static-info.rkt")
+         "static-info.rkt"
+         "number.rkt")
 
 (provide literal-infoer
          ;; useful for other binding patterns:
@@ -67,13 +68,21 @@
 
 (define-for-syntax string-static-infos #f)
 (define-for-syntax bytes-static-infos #f)
+(define-for-syntax char-static-infos #f)
 (define-for-syntax (install-literal-static-infos! kind static-infos)
   (case kind
     [(string) (set! string-static-infos static-infos)]
     [(bytes) (set! bytes-static-infos static-infos)]
+    [(char) (set! char-static-infos static-infos)]
     [else (error "unrecognized kind" kind)]))
 
 (define-for-syntax (literal-static-infos d-stx)
   (define d (syntax-e d-stx))
   (or (and (string? d) string-static-infos)
-      (and (bytes? d) bytes-static-infos)))
+      (and (bytes? d) bytes-static-infos)
+      (and (exact-integer? d) int-static-infos)
+      (and (flonum? d) flonum-static-infos)
+      (and (rational? d) rational-static-infos)
+      (and (real? d) real-static-infos)
+      (and (number? d) number-static-infos)
+      (and (char? d) char-static-infos)))

--- a/rhombus/private/map.rkt
+++ b/rhombus/private/map.rkt
@@ -45,7 +45,8 @@
          "rest-bind.rkt"
          "hash-remove.rkt"
          "key-comp.rkt"
-         "key-comp-property.rkt")
+         "key-comp-property.rkt"
+         "number.rkt")
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -762,6 +763,7 @@
 (define/method (Map.length ht)
   #:inline
   #:primitive (hash-count)
+  #:static-infos ((#%call-result #,int-static-infos))
   (hash-count ht))
 
 (define/method (Map.keys ht [try-sort? #f])

--- a/rhombus/private/number.rkt
+++ b/rhombus/private/number.rkt
@@ -1,0 +1,4 @@
+#lang racket/base
+(require (submod "arithmetic.rkt" static-infos))
+
+(provide (all-from-out (submod "arithmetic.rkt" static-infos)))

--- a/rhombus/private/range.rkt
+++ b/rhombus/private/range.rkt
@@ -6,9 +6,11 @@
          "parse.rkt"
          (prefix-in rhombus-a: "arithmetic.rkt")
          "sequence-constructor-key.rkt"
+         "sequence-element-key.rkt"
          "treelist.rkt"
          (submod "list.rkt" for-listable)
-         "realm.rkt")
+         "realm.rkt"
+         "number.rkt")
 
 (provide ..
          ..=)
@@ -45,7 +47,8 @@
    'none))
 
 (define-for-syntax (wrap-as-static-sequence stx)
-  (wrap-static-info stx #'#%sequence-constructor #'#t))
+  (wrap-static-info (wrap-static-info stx #'#%sequence-constructor #'#t)
+                    #'#%sequence-element int-static-infos))
 
 (struct listable-range (range)
   #:property prop:sequence (lambda (r) (listable-range-range r))

--- a/rhombus/private/set.rkt
+++ b/rhombus/private/set.rkt
@@ -37,7 +37,8 @@
          "class-primitive.rkt"
          "rest-bind.rkt"
          "hash-remove.rkt"
-         "key-comp.rkt")
+         "key-comp.rkt"
+         "number.rkt")
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -223,6 +224,7 @@
     (raise-argument-error* who rhombus-realm "ReadableSet" s)))
 
 (define/method (Set.length s)
+  #:static-infos ((#%call-result #,int-static-infos))
   (check-readable-set who s)
   (hash-count (set-ht s)))
 

--- a/rhombus/private/symbol.rkt
+++ b/rhombus/private/symbol.rkt
@@ -3,13 +3,29 @@
          "provide.rkt"
          "name-root.rkt"
          "define-arity.rkt"
-         (submod "annotation.rkt" for-class))
+         (submod "annotation.rkt" for-class)
+         "compare-key.rkt"
+         "call-result-key.rkt"
+         "realm.rkt")
 
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
                      Symbol))
 
-(define-annotation-syntax Symbol (identifier-annotation #'symbol? #'()))
+(module+ for-static-info
+  (provide (for-syntax symbol-static-infos)))
+
+(define-for-syntax symbol-static-infos
+  #'((#%compare ((< symbol<?)
+                 (<= symbol<=?)
+                 (= symbol=?)
+                 (!= symbol!=?)
+                 (>= symbol>=?)
+                 (> symbol>?)))))
+
+(define-annotation-syntax Symbol
+  (identifier-annotation #'symbol?
+                         symbol-static-infos))
 
 (define-name-root Symbol
   #:fields
@@ -19,15 +35,42 @@
    gen))
 
 (define/arity (from_string s)
+  #:static-infos ((#%call-result #,symbol-static-infos))
   (string->symbol s))
 
 (define/arity (uninterned_from_string s)
+  #:static-infos ((#%call-result #,symbol-static-infos))
   (string->uninterned-symbol s))
 
 (define/arity (unreadable_from_string s)
+  #:static-infos ((#%call-result #,symbol-static-infos))
   (string->unreadable-symbol s))
 
 (define/arity gen
   (case-lambda
     [(s) (gensym s)]
     [() (gensym)]))
+
+(define (check-symbols who a b)
+  (unless (and (symbol? a) (symbol? b))
+    (raise-argument-error* who rhombus-realm "Symbol" (if (symbol? a) b a))))
+
+(define (symbol<=? a b)
+  (check-symbols '<= a b)
+  (or (eq? a b) (symbol<? a b)))
+
+(define (symbol=? a b)
+  (check-symbols '= a b)
+  (eq? a b))
+
+(define (symbol!=? a b)
+  (check-symbols '!= a b)
+  (not (eq? a b)))
+
+(define (symbol>=? a b)
+  (check-symbols '>= a b)
+  (or (eq? a b) (symbol<? b a)))
+
+(define (symbol>? a b)
+  (check-symbols '> a b)
+  (symbol<? b a))

--- a/rhombus/private/veneer.rkt
+++ b/rhombus/private/veneer.rkt
@@ -108,6 +108,7 @@
                        index-statinfo-indirect-id
                        index-set-statinfo-indirect-id
                        append-statinfo-indirect-id
+                       compare-statinfo-indirect-id
 
                        super-call-statinfo-indirect-id
 
@@ -129,6 +130,7 @@
                      [index-statinfo-indirect index-statinfo-indirect-id]
                      [index-set-statinfo-indirect index-set-statinfo-indirect-id]
                      [append-statinfo-indirect append-statinfo-indirect-id]
+                     [compare-statinfo-indirect compare-statinfo-indirect-id]
                      [super-call-statinfo-indirect super-call-statinfo-indirect-id]
                      [indirect-static-infos indirect-static-infos]
                      [instance-static-infos instance-static-infos])
@@ -144,7 +146,8 @@
                          name name-extends tail-name
                          name? name-convert check?
                          name-instance
-                         call-statinfo-indirect index-statinfo-indirect index-set-statinfo-indirect append-statinfo-indirect
+                         call-statinfo-indirect index-statinfo-indirect index-set-statinfo-indirect
+                         append-statinfo-indirect compare-statinfo-indirect
                          super-call-statinfo-indirect
                          indirect-static-infos
                          instance-static-infos
@@ -159,7 +162,8 @@
                     name name-extends tail-name
                     name? name-convert check?
                     name-instance
-                    call-statinfo-indirect index-statinfo-indirect index-set-statinfo-indirect append-statinfo-indirect
+                    call-statinfo-indirect index-statinfo-indirect index-set-statinfo-indirect
+                    append-statinfo-indirect compare-statinfo-indirect
                     super-call-statinfo-indirect
                     indirect-static-infos
                     instance-static-infos
@@ -224,6 +228,9 @@
          (able-method-status 'set super interfaces method-mindex method-vtable method-private))
        (define-values (appendable? here-appendable? public-appendable?)
          (able-method-status 'append super interfaces method-mindex method-vtable method-private))
+       (define-values (comparable? here-comparable? public-comparable?)
+         (able-method-status 'compare super interfaces method-mindex method-vtable method-private
+                             #:name 'compare_to))
 
        (define (temporary template)
          ((make-syntax-introducer) (datum->syntax #f (string->symbol (format template (syntax-e #'name))))))
@@ -305,6 +312,7 @@
                                   public-indexable?
                                   public-setable?
                                   public-appendable?
+                                  public-comparable?
                                   #'(name name-extends class:name constructor-maker-name name-defaults name-ref
                                           name? name-convert check? converter?
                                           dot-provider-name prefab-guard-name
@@ -318,8 +326,10 @@
                                      #'index-statinfo-indirect indexable?
                                      #'index-set-statinfo-indirect setable?
                                      #'append-statinfo-indirect appendable?
+                                     #'compare-statinfo-indirect comparable?
                                      #'super-call-statinfo-indirect
-                                     #:checked-append? #f))))
+                                     #:checked-append? #f
+                                     #:checked-compare? #f))))
            #`(begin . #,defns)))])))
 
 (define-for-syntax (build-veneer-annotation converter? names)
@@ -494,6 +504,7 @@
                                       public-indexable?
                                       public-setable?
                                       public-appendable?
+                                      public-comparable?
                                       names)
   (with-syntax ([(name name-extends class:name constructor-maker-name name-defaults name-ref
                        name? name-convert check? converter?
@@ -505,7 +516,8 @@
           [method-result-expr (build-method-result-expression method-results)]
           [flags #`(#,@(if public-indexable? '(get) null)
                     #,@(if public-setable? '(set) null)
-                    #,@(if public-appendable? '(append) null))]
+                    #,@(if public-appendable? '(append) null)
+                    #,@(if public-comparable? '(compare) null))]
           [interface-names (interface-names->quoted-list interface-names all-interfaces private-interfaces 'public)])
       (list
        (build-syntax-definition/maybe-extension

--- a/rhombus/scribblings/ref-appendable.scrbl
+++ b/rhombus/scribblings/ref-appendable.scrbl
@@ -9,8 +9,9 @@
 @title{Appendables}
 
 An @deftech{appendable} value is one that supports @rhombus(++). Maps,
-lists, arrays, sets, strings, and byte strings are all indexable, as are
-instances of classes that implement @rhombus(Appendable, ~class).
+@tech{lists}, @tech{arrays}, @tech{sets}, @tech{strings}, and @tech{byte
+ strings} are all appendable, as are instances of classes that implement
+@rhombus(Appendable, ~class).
 
 @doc(
   ~nonterminal:
@@ -51,7 +52,7 @@ instances of classes that implement @rhombus(Appendable, ~class).
  @rhombus(append, ~datum) method.
 
  The @rhombus(use_static) declaration constrains @rhombus(++) to work
- only when the left-hand argument static information indicating that it
+ only when the left-hand argument has static information indicating that it
  satisfies @rhombus(Appendable, ~annot).
 
 @examples(

--- a/rhombus/scribblings/ref-bytes.scrbl
+++ b/rhombus/scribblings/ref-bytes.scrbl
@@ -30,6 +30,8 @@ and @rhombus(ImmutableBytes, ~annot) require one or the other.
   bstr.locale_string(arg, ...)
 )
 
+Byte strings are @tech{comparable}, which means that generic operations
+like @rhombus(<) and @rhombus(>) work on byte strings.
 
 @doc(
   annot.macro 'Bytes'

--- a/rhombus/scribblings/ref-char.scrbl
+++ b/rhombus/scribblings/ref-char.scrbl
@@ -8,6 +8,8 @@
 
 A @deftech{character} is Unicode code point.
 
+Characters are @tech{comparable}, which means that generic operations
+like @rhombus(<) and @rhombus(>) work on characters.
 
 @doc(
   annot.macro 'Char'
@@ -151,5 +153,26 @@ A @deftech{character} is Unicode code point.
 
  See also @rhombus(String.grapheme_span) and
  @rhombus(String.grapheme_count).
+
+}
+
+
+
+@doc(
+  annot.macro 'CharCI'
+){
+
+ A @tech{veneer} for a character that redirects @tech{comparable}
+ operations like @rhombus(<) and @rhombus(>) to case-insensitive
+ comparisons, equivalent to using @rhombus(Char.foldcase) on each
+ character before comparing.
+
+ As always for a veneer, @rhombus(CharCI, ~annot) normally should be used in
+ static mode to help ensure that it has the intended effect.
+
+@examples(
+  "a"[0] < "B"[0]
+  ("a"[0] :: CharCI) < ("B"[0] :: CharCI)
+)
 
 }

--- a/rhombus/scribblings/ref-comparable.scrbl
+++ b/rhombus/scribblings/ref-comparable.scrbl
@@ -1,0 +1,134 @@
+#lang scribble/rhombus/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@(def dots = @rhombus(..., ~bind))
+@(def dots_expr = @rhombus(...))
+
+@title{Comparables}
+
+A @deftech{comparable} value is one that supports @rhombus(<),
+@rhombus(<=), @rhombus(>=),@rhombus(>=), @rhombus(compares_equal), and
+@rhombus(compares_unequal). Real numbers, @tech{characters},
+@tech{strings}, @tech{byte strings}, @tech{symbols}, and @tech{keywords}
+are all comparable, as are instances of classes that implement
+@rhombus(Comparable, ~class).
+
+@doc(
+  operator ((v1 :: Comparable) < (v2 :: Comparable)) :: Boolean
+  operator ((v1 :: Comparable) > (v2 :: Comparable)) :: Boolean
+  operator ((v1 :: Comparable) <= (v2 :: Comparable)) :: Boolean
+  operator ((v1 :: Comparable) >= (v2 :: Comparable)) :: Boolean
+  operator ((v1 :: Comparable) compares_equal (v2 :: Comparable))
+    :: Boolean
+  operator ((v1 :: Comparable) compares_unequal (v2 :: Comparable))
+    :: Boolean
+){
+
+ Compares @rhombus(v1) and @rhombus(v2), which uses a primitive
+ comparison operation for real numbers, characters, strings, byte string,
+ symbols, and keywords, or it calls the @rhombus(compare_to, ~datum)
+ method for a @rhombus(Comparable, ~class) instance.
+
+ See also @rhombus(.<), @rhombus(.>), @rhombus(.<=), @rhombus(.>=),
+ @rhombus(.=), and @rhombus(.!=), which are specific to numbers.
+
+ The difference between @rhombus(compares_equal) and @rhombus(==) is
+ that the former uses @rhombus(Comparable, ~class) while the latter uses
+ @rhombus(Equatable, ~class). The results tend to be the same, but they
+ are different in the case of numbers: two numbers are @rhombus(==) only
+ when they have the same exactness, but @rhombus(compares_equal)
+ corresponds to @rhombus(.=).
+
+ The @rhombus(use_static) declaration constrains @rhombus(<), etc., to
+ work only when the left-hand argument or right-hand argument has static
+ information indicating that it satisfies @rhombus(Comparable, ~annot).
+ If both expressions provide static information, the
+ @rhombus(Comparable, ~annot) specifications must be compatible: both
+ identifying the same operation, or one specifying the generic
+ @rhombus(Comparable, ~class) operation.
+
+@examples(
+  ~repl:
+    1 < 2
+    "apple" <= "banana"
+    #'banana >= #'apple
+    #'~banana > #'~apple
+  ~repl:
+    use_static
+    ~error:
+      1 < "apple"
+)
+
+}
+
+
+
+@doc(
+  interface Comparable
+){
+
+@provided_interface_and_other_annotation_only()
+
+ An interface that a class can implement (publicly or privately) to make
+ instances of the class work with @rhombus(<), @rhombus(>), etc. As an
+ annotation, @rhombus(Comparable, ~annot) matches all @tech{comparable}
+ objects, not just instances of classes that publicly implement the
+ @rhombus(Comparable, ~class) interface.
+
+ The interface has one abstract method, @rhombus(compare_to, ~datum),
+ and six methods that use @rhombus(compare_to, ~datum) by default but can
+ be individually overridden:
+
+@itemlist(
+
+ @item{@rhombus(#,(@rhombus(compare_to, ~datum))(#,(@rhombus(other, ~var))))
+  --- the @rhombus(other, ~var) value is the right-hand argument to a
+  comparison, and it is always an instance of the same class or a subclass
+  that inherits the same @rhombus(compare_to, ~datum) implementation. The
+  result must be an integer: negative if the object is less than the
+  @rhombus(other, ~var), positive if the object is greater than
+  @rhombus(other, ~var), and zero if they are equal.}
+
+ @item{@rhombus(#,(@rhombus(less, ~datum))(#,(@rhombus(other, ~var))))
+  --- takes the same kind of argument as @rhombus(compare_to, ~datum), but
+  returns a boolean to indicate whether the object is less than
+  @rhombus(other, ~var), and with the further constraint that the two
+  objects have the same @rhombus(less, ~datum) implementation. This is the
+  method called to implement @rhombus(<), but the default implementation
+  of this method uses @rhombus(compare_to, ~datum).}
+
+ @item{@rhombus(#,(@rhombus(less_or_equal, ~datum))(#,(@rhombus(other, ~var))))
+  --- like @rhombus(less, ~datum), but for @rhombus(<=).}
+
+ @item{@rhombus(#,(@rhombus(greater, ~datum))(#,(@rhombus(other, ~var))))
+  --- like @rhombus(less, ~datum), but for @rhombus(>).}
+
+ @item{@rhombus(#,(@rhombus(greater_or_equal, ~datum))(#,(@rhombus(other, ~var))))
+  --- like @rhombus(less, ~datum), but for @rhombus(>=).}
+
+ @item{@rhombus(#,(@rhombus(compares_equal, ~datum))(#,(@rhombus(other, ~var))))
+  --- like @rhombus(less, ~datum), but for @rhombus(compares_equal).}
+
+ @item{@rhombus(#,(@rhombus(compares_unequal, ~datum))(#,(@rhombus(other, ~var))))
+  --- like @rhombus(less, ~datum), but for @rhombus(compares_unequal).}
+
+)
+
+@examples(
+  ~defn:
+    class Posn(x, y):
+      private implements Comparable
+      private override method compare_to(other :: Posn):
+        let delta = x - other.x
+        if delta == 0
+        | y - other.y
+        | delta
+  ~repl:
+    Posn(1, 2) < Posn(2, 1)
+    Posn(1, 2) < Posn(1, 3)
+    Posn(1, 2) < Posn(1, 0)
+)
+
+}

--- a/rhombus/scribblings/ref-equal.scrbl
+++ b/rhombus/scribblings/ref-equal.scrbl
@@ -56,18 +56,20 @@
 
 @doc(
   operator ((x :: Number) .= (y :: Number)) :: Boolean
+  operator ((x :: Number) .!= (y :: Number)) :: Boolean
 ){
 
- Reports whether @rhombus(x) and @rhombus(y) are numerically equal,
- where inexact numbers are effectively coerced to exact for
+ Reports whether @rhombus(x) and @rhombus(y) are numerically equal or
+ unequal, where inexact numbers are effectively coerced to exact for
  comparisons to exact numbers. The value @rhombus(#nan) is not
- @rhombus(.=) to itself (but @rhombus(#nan) is @rhombus(==) to
- itself).
+ @rhombus(.=) to itself (but @rhombus(#nan) is @rhombus(==) to itself).
 
 @examples(
   1 .= 1
   1 .= 2
   1.0 .= 1
+  1 .!= 2
+  1 .!= 1.0
 )
 
 }

--- a/rhombus/scribblings/ref-indexable.scrbl
+++ b/rhombus/scribblings/ref-indexable.scrbl
@@ -9,9 +9,10 @@
 @title{Indexables}
 
 An @deftech{indexable} value is one that supports @brackets afterward to
-extract an element at the index within @brackets. Maps, lists, arrays,
-sets, strings, and byte strings are all indexable, as are instances of
-classes that implement @rhombus(Indexable, ~class).
+extract an element at the index within @brackets. @tech{Maps},
+@tech{lists}, @tech{arrays}, @tech{sets}, @tech{strings}, and @tech{byte
+ strings} are all indexable, as are instances of classes that implement
+@rhombus(Indexable, ~class).
 
 @doc(
   ~nonterminal:

--- a/rhombus/scribblings/ref-keyword.scrbl
+++ b/rhombus/scribblings/ref-keyword.scrbl
@@ -11,6 +11,11 @@ equal by @rhombus(==) only when they are equal by @rhombus(===).
 
 See also @rhombus(#'), which works for keywords as well as symbols.
 
+Keywords are @tech{comparable}, which means that generic operations like
+@rhombus(<) and @rhombus(>) work on keywords. Comparsion of two keywords
+is the same as comparing the string forms of the keywords.
+
+
 @doc(
   annot.macro 'Keyword'
 ){

--- a/rhombus/scribblings/ref-number.scrbl
+++ b/rhombus/scribblings/ref-number.scrbl
@@ -6,6 +6,10 @@
 
 @title{Numbers}
 
+Numbers are @tech{comparable}, which means that generic operations like
+@rhombus(<) and @rhombus(>) work on numbers, while specialized
+operations like @rhombus(.<) and @rhombus(.>) work only on numbers.
+
 @doc(
   annot.macro 'Number'
 ){
@@ -243,17 +247,19 @@
 
 
 @doc(
-  operator ((x :: Number) > (y :: Number)) :: Boolean
-  operator ((x :: Number) >= (y :: Number)) :: Boolean
-  operator ((x :: Number) < (y :: Number)) :: Boolean
-  operator ((x :: Number) <= (y :: Number)) :: Boolean
+  operator ((x :: Number) .> (y :: Number)) :: Boolean
+  operator ((x :: Number) .>= (y :: Number)) :: Boolean
+  operator ((x :: Number) .< (y :: Number)) :: Boolean
+  operator ((x :: Number) .<= (y :: Number)) :: Boolean
 ){
 
- The usual comparsion operators on numbers. See also @rhombus(.=).
+ The usual comparsion operators on numbers prefixed with @litchar{.} to
+ distinsguish them from generic operations like @rhombus(<) on
+ @tech{comparable} values. See also @rhombus(.=) and @rhombus(.!=).
 
 @examples(
-  1 < 2
-  3 >= 3.0
+  1 .< 2
+  3 .>= 3.0
 )
 
 }

--- a/rhombus/scribblings/ref-set.scrbl
+++ b/rhombus/scribblings/ref-set.scrbl
@@ -8,7 +8,7 @@
 
 @title{Sets}
 
-Immutable sets can be constructed using the syntax
+Immutable @deftech{sets} can be constructed using the syntax
 @rhombus({#,(@rhombus(val_expr, ~var)), ...}),
 which creates a set containing the values of the @rhombus(val_expr, ~var)s.
 More precisely, a use of curly braces with no preceding expression is

--- a/rhombus/scribblings/ref-string.scrbl
+++ b/rhombus/scribblings/ref-string.scrbl
@@ -43,6 +43,9 @@ immutable strings.
   str.grapheme_count(arg, ...)
 )
 
+Strings are @tech{comparable}, which means that generic operations like
+@rhombus(<) and @rhombus(>) work on strings.
+
 @doc(
   annot.macro 'String'
   annot.macro 'ReadableString'
@@ -314,5 +317,26 @@ immutable strings.
 
  The @rhombus(start) and @rhombus(end) arguments must be valid indices as
  for @rhombus(String.substring).
+
+}
+
+@doc(
+  annot.macro 'StringCI'
+  annot.macro 'ReadableStringCI'
+){
+
+ A @tech{veneer} for a string that redirects @tech{comparable}
+ operations like @rhombus(<) and @rhombus(>) to case-insensitive
+ comparisons, equivalent to using @rhombus(String.foldcase) on each
+ string before comparing.
+
+ As always for a veneer, @rhombus(StringCI, ~annot) and
+ @rhombus(ReadableStringCI, ~annot) normally should be used in static
+ mode to help ensure that they have the intended effect.
+
+@examples(
+  "apple" < "BANANA"
+  ("apple" :: StringCI) < ("BANANA" :: StringCI)
+)
 
 }

--- a/rhombus/scribblings/ref-symbol.scrbl
+++ b/rhombus/scribblings/ref-symbol.scrbl
@@ -12,6 +12,10 @@ symbol is similar to a string, but symbols are typically interned and
 they are equal by @rhombus(==) only when they are equal by
 @rhombus(===). The @rhombus(#') operator can produce a symbol value.
 
+Symbols are @tech{comparable}, which means that generic operations like
+@rhombus(<) and @rhombus(>) work on symbols. Comparsion of two symbols
+is the same as comparing the string forms of the symbols.
+
 @doc(
   annot.macro 'Symbol'
 ){

--- a/rhombus/scribblings/ref-veneer.scrbl
+++ b/rhombus/scribblings/ref-veneer.scrbl
@@ -42,7 +42,7 @@
 ){
 
  Similar to @rhombus(class), but binds @rhombus(id_name) as a static
- class veneer over an existing representation, instead of creating a new
+ class @deftech{veneer} over an existing representation, instead of creating a new
  representation like @rhombus(class) does. The existing reprsentation is
  indicated by the @rhombus(annot) written after the @rhombus(this)
  pseudo-field (in parentheses after @rhombus(id_name)); this

--- a/rhombus/scribblings/reference.scrbl
+++ b/rhombus/scribblings/reference.scrbl
@@ -55,6 +55,7 @@
 @include_section("ref-listable.scrbl")
 @include_section("ref-sequence.scrbl")
 @include_section("ref-appendable.scrbl")
+@include_section("ref-comparable.scrbl")
 @include_section("ref-path.scrbl")
 @include_section("ref-srcloc.scrbl")
 @include_section("ref-void.scrbl")

--- a/rhombus/tests/char.rhm
+++ b/rhombus/tests/char.rhm
@@ -48,3 +48,28 @@ check:
   Char.foldcase("A"[0]) ~is "a"[0]
   Char.titlecase("a"[0]) ~is "A"[0]
   Char.grapheme_step("a"[0], 0) ~is values(#false, 1)
+
+block:
+  use_static
+  let a :: CharCI = "a"[0]
+  let A :: CharCI = "A"[0]
+  let b :: CharCI = "b"[0]
+  let B :: CharCI = "B"[0]
+  check:
+    a < B ~is #true
+    b < A ~is #false
+    a <= B ~is #true
+    a <= A ~is #true
+    b <= A ~is #false
+    a >= B ~is #false
+    a >= A ~is #true
+    b >= A ~is #true
+    a > B ~is #false
+    a > A ~is #false
+    b > A ~is #true
+    a compares_equal a ~is #true
+    a compares_equal A ~is #true
+    a compares_equal B ~is #false
+    a compares_unequal a ~is #false
+    a compares_unequal A ~is #false
+    a compares_unequal B ~is #true

--- a/rhombus/tests/comparable.rhm
+++ b/rhombus/tests/comparable.rhm
@@ -1,0 +1,452 @@
+#lang rhombus
+
+use_static
+
+check 1 < 2 ~is #true
+check 1 <= 2 ~is #true
+check 1 compares_equal 2 ~is #false
+check 1 compares_unequal 2 ~is #true
+check 1 >= 2 ~is #false
+check 2 >= 2 ~is #true
+check 1 > 2 ~is #false
+check 10 < 2 ~is #false
+check 10 <= 2 ~is #false
+check 10 <= 10 ~is #true
+check 10 compares_equal 10 ~is #true
+check 10 compares_unequal 10 ~is #false
+check 10 >= 2 ~is #true
+check 10 > 2 ~is #true
+  
+check 1/2 < 2 ~is #true
+check 1/2 <= 2 ~is #true
+check 1/2 compares_equal 2 ~is #false
+check 1/2 compares_unequal 2 ~is #true
+check 1/2 >= 2 ~is #false
+check 1/2 > 2 ~is #false
+  
+check "a"[0] < "b"[0] ~is #true
+check "a"[0] <= "b"[0] ~is #true
+check "a"[0] compares_equal "b"[0] ~is #false
+check "a"[0] compares_unequal "b"[0] ~is #true
+check "a"[0] >= "b"[0] ~is #false
+check "a"[0] >= "a"[0] ~is #true
+check "a"[0] > "b"[0] ~is #false
+check "a"[0] < "B"[0] ~is #false
+check "a"[0] <= "B"[0] ~is #false
+check "a"[0] <= "a"[0] ~is #true
+check "a"[0] compares_equal "a"[0] ~is #true
+check "a"[0] compares_unequal "a"[0] ~is #false
+check "a"[0] >= "B"[0] ~is #true
+check "a"[0] > "B"[0] ~is #true
+  
+check "a" < "b" ~is #true
+check "a" <= "b" ~is #true
+check "a" compares_equal "b" ~is #false
+check "a" compares_unequal "b" ~is #true
+check "a" >= "b" ~is #false
+check "a" >= "a" ~is #true
+check "a" > "b" ~is #false
+check "a" < "B" ~is #false
+check "a" <= "B" ~is #false
+check "a" <= "a" ~is #true
+check "a" compares_equal "a" ~is #true
+check "a" compares_unequal "a" ~is #false
+check "a" >= "B" ~is #true
+check "a" > "B" ~is #true
+  
+check #"a" < #"b" ~is #true
+check #"a" <= #"b" ~is #true
+check #"a" compares_equal #"b" ~is #false
+check #"a" >= #"b" ~is #false
+check #"a" >= #"a" ~is #true
+check #"a" > #"b" ~is #false
+check #"a" < #"B" ~is #false
+check #"a" <= #"B" ~is #false
+check #"a" <= #"a" ~is #true
+check #"a" compares_equal #"a" ~is #true
+check #"a" >= #"B" ~is #true
+check #"a" > #"B" ~is #true
+
+check #'a < #'b ~is #true
+check #'a <= #'b ~is #true
+check #'a compares_equal #'b ~is #false
+check #'a compares_unequal #'b ~is #true
+check #'a >= #'b ~is #false
+check #'a >= #'a ~is #true
+check #'a > #'b ~is #false
+check #'a < #'B ~is #false
+check #'a <= #'B ~is #false
+check #'a <= #'a ~is #true
+check #'a compares_equal #'a ~is #true
+check #'a compares_unequal #'a ~is #false
+check #'a >= #'B ~is #true
+check #'a > #'B ~is #true
+
+check #'~a < #'~b ~is #true
+check #'~a <= #'~b ~is #true
+check #'~a compares_equal #'~b ~is #false
+check #'~a compares_unequal #'~b ~is #true
+check #'~a >= #'~b ~is #false
+check #'~a >= #'~a ~is #true
+check #'~a > #'~b ~is #false
+check #'~a < #'~B ~is #false
+check #'~a <= #'~B ~is #false
+check #'~a <= #'~a ~is #true
+check #'~a compares_equal #'~a ~is #true
+check #'~a compares_unequal #'~a ~is #false
+check #'~a >= #'~B ~is #true
+check #'~a > #'~B ~is #true
+
+// checks static-info intersection:
+check (if #true | 1 | 2.0) < (if #false | 3/2 | 4+5) ~is #true
+// checks static-info union:
+block:
+  let a :: Real = 5
+  check a <= a ~is #true
+
+block:
+  use_dynamic
+  check dynamic(1) < dynamic(2) ~is #true
+  check dynamic(#{#\a}) < dynamic(#{#\b}) ~is #true
+  check dynamic("a") < dynamic("b") ~is #true
+  check dynamic(#"a") < dynamic(#"b") ~is #true
+  check dynamic(#'a) < dynamic(#'b) ~is #true
+  check dynamic(#'~a) < dynamic(#'~b) ~is #true
+
+  check dynamic(1) <= dynamic(2) ~is #true
+  check dynamic(#{#\a}) <= dynamic(#{#\b}) ~is #true
+  check dynamic("a") <= dynamic("b") ~is #true
+  check dynamic(#"a") <= dynamic(#"b") ~is #true
+  check dynamic(#'a) <= dynamic(#'b) ~is #true
+  check dynamic(#'~a) <= dynamic(#'~b) ~is #true
+
+  check dynamic(1) >= dynamic(2) ~is #false
+  check dynamic(#{#\a}) >= dynamic(#{#\b}) ~is #false
+  check dynamic("a") >= dynamic("b") ~is #false
+  check dynamic(#"a") >= dynamic(#"b") ~is #false
+  check dynamic(#'a) >= dynamic(#'b) ~is #false
+  check dynamic(#'~a) >= dynamic(#'~b) ~is #false
+
+  check dynamic(1) > dynamic(2) ~is #false
+  check dynamic(#{#\a}) > dynamic(#{#\b}) ~is #false
+  check dynamic("a") > dynamic("b") ~is #false
+  check dynamic(#"a") > dynamic(#"b") ~is #false
+  check dynamic(#'a) > dynamic(#'b) ~is #false
+  check dynamic(#'~a) > dynamic(#'~b) ~is #false
+
+  check dynamic(1) compares_equal dynamic(2) ~is #false
+  check dynamic(#{#\a}) compares_equal dynamic(#{#\b}) ~is #false
+  check dynamic("a") compares_equal dynamic("b") ~is #false
+  check dynamic(#"a") compares_equal dynamic(#"b") ~is #false
+  check dynamic(#'a) compares_equal dynamic(#'b) ~is #false
+  check dynamic(#'~a) compares_equal dynamic(#'~b) ~is #false
+
+  check dynamic(1) compares_unequal dynamic(2) ~is #true
+  check dynamic(#{#\a}) compares_unequal dynamic(#{#\b}) ~is #true
+  check dynamic("a") compares_unequal dynamic("b") ~is #true
+  check dynamic(#"a") compares_unequal dynamic(#"b") ~is #true
+  check dynamic(#'a) compares_unequal dynamic(#'b) ~is #true
+  check dynamic(#'~a) compares_unequal dynamic(#'~b) ~is #true
+
+class A(v):
+  nonfinal
+  implements Comparable
+  override method compare_to(other :~ A):
+    v - other.v
+
+class B():
+  nonfinal
+  extends A
+  override method compare_to(other :~ A):
+    other.v - v
+
+class C():
+  extends B
+
+interface I3:
+  extends Comparable
+
+class A3(v):
+  implements I3
+  override method compare_to(other :~ A3):
+    v - other.v
+
+class A4(v):
+  private implements Comparable
+  private override method compare_to(other :~ A4):
+    v - 2 * other.v
+
+veneer S(this :: Flonum):
+  private implements Comparable
+  private override method compare_to(other :~ Flonum):
+    math.exact(math.round(this - 2 * other))
+
+check:
+  A(1) < A(2) ~is #true
+  A(1) < A(1) ~is #false
+  A(1) < A(-1) ~is #false
+  A(1) <= A(2) ~is #true
+  A(1) <= A(1) ~is #true
+  A(1) <= A(-1) ~is #false
+  A(1) compares_equal A(1) ~is #true
+  A(1) compares_equal A(2) ~is #false
+  A(1) compares_unequal A(2) ~is #true
+  A(1) compares_unequal A(1) ~is #false
+  A(2) >= A(1) ~is #true
+  A(1) >= A(1) ~is #true
+  A(-1) >= A(1) ~is #false
+  A(2) > A(1) ~is #true
+  A(1) > A(1) ~is #false
+  A(-1) > A(1) ~is #false
+
+  B(2) < B(1) ~is #true
+  B(2) > B(1) ~is #false
+
+  C(2) < C(1) ~is #true
+  C(2) > C(1) ~is #false
+
+  C(2) < B(1) ~is #true
+  B(2) > C(1) ~is #false
+
+  A3(2) < A3(4) ~is #true
+  A3(2) > A3(4) ~is #false
+
+  A4(2) < A4(2) ~is #true
+  A4(2) > A4(2) ~is #false
+
+  S(2.0) < S(2.0) ~is #true
+  S(2.0) > S(2.0) ~is #false
+
+  (if #true | C(2) | B(2)) < B(1) ~is #true
+
+  A(1).compare_to(A(2)) compares_equal A(1).compare_to(A(2)) ~is #true
+
+block:
+  use_dynamic
+  check:
+    dynamic(A(1)) < B(1) ~throws values(
+      "cannot compare a comparable object and other comparable object",
+      "two comparable objects must share the same `compare_to` implementation",
+    )
+
+check:
+  A(1) is_a Comparable ~is #true
+  B(1) is_a Comparable ~is #true
+  C(1) is_a Comparable ~is #true
+  A4(1) is_a Comparable ~is #true
+
+  { 1: 2 } is_a Comparable ~is #false
+  { 1, 2 } is_a Comparable ~is #false
+  [1, 2] is_a Comparable ~is #false
+  1 is_a Comparable ~is #true
+  1/2 is_a Comparable ~is #true
+  1.0 is_a Comparable ~is #true
+  #inf is_a Comparable ~is #true
+  math.sqrt(-1) is_a Comparable ~is #false
+  "apple" is_a Comparable ~is #true
+  #"apple" is_a Comparable ~is #true
+  #'apple is_a Comparable ~is #true
+  #'~apple is_a Comparable ~is #true
+
+check:
+  (MutableMap{ 1: 2 } :~ Appendable)
+    ++ MutableMap{ 3: 4 } ~throws values(
+    "contract violation",
+    "expected: Appendable",
+    "MutableMap{1: 2}",
+  )
+  (MutableSet{ 1, 2 } :~ Appendable)
+    ++ MutableSet{ 3, 4 } ~throws values(
+    "contract violation",
+    "expected: Appendable",
+    "MutableSet{1, 2}",
+  )
+
+block:
+  use_dynamic
+  fun gen():
+    // check that generated `compare_to` method is fresh
+    class A():
+      implements Comparable
+      override method compare_to(other):
+        0
+    A()
+  check:
+    gen() < gen() ~throws values(
+      "cannot compare a comparable object and other comparable object",
+      "two comparable objects must share the same `compare_to` implementation",
+    )
+    dynamic(1) < 2 ~is #true
+    dynamic(#'a) > #'z ~is #false
+
+block:
+  class Broken():
+    implements Comparable
+    override method compare_to(other):
+      "no"
+  check Broken() < Broken() ~throws values(
+    "result does not satisfy annotation",
+    "Int",
+    "\"no\"",
+  )
+
+block:
+  class Broken():
+    implements Comparable
+    override method compare_to(other):
+      values("oops", "wow")
+  check Broken() < Broken() ~throws values(
+    "results do not satisfy annotation",
+    "Int",
+    "\"oops\"", "\"wow\"",
+  )
+  check (Broken() :: Comparable) < Broken() ~throws values(
+    "results do not satisfy annotation",
+    "Int",
+    "\"oops\"", "\"wow\"",
+  )
+  check Broken() < (Broken() :: Comparable) ~throws values(
+    "results do not satisfy annotation",
+    "Int",
+    "\"oops\"", "\"wow\"",
+  )
+
+check:
+  ~eval
+  use_static
+  1 < "a"
+  ~throws "incompatible specializations from arguments"
+
+check:
+  ~eval
+  use_static
+  "a" < 1
+  ~throws "incompatible specializations from arguments"
+
+check:
+  class A(v):
+    implements Comparable
+    override method compare_to(other :~ A):
+      v - other.v
+  class A2(v):
+    implements Comparable
+    override method compare_to(other :~ A2):
+      v - other.v
+  A(0) < A2(1)
+  ~throws "cannot compare a comparable object and other comparable object"
+
+check:
+  ~eval
+  use_static
+  class A(v):
+    implements Comparable
+    override method compare_to(other :~ A):
+      v - other.v
+  class A2(v):
+    implements Comparable
+    override method compare_to(other :~ A2):
+      v - other.v
+  fun (x): (if x | A(0) | A2(1)) < x
+  ~throws "specialization not known"
+
+check:
+  class A(v):
+    nonfinal
+    implements Comparable
+    override method compare_to(other :~ A):
+      v - other.v
+  class B():
+    nonfinal
+    extends A
+    override method compare_to(other :~ A):
+      other.v - v
+  A(0) < B(1)
+  ~throws "cannot compare a comparable object and other comparable object"
+
+block:
+  // says that 1 is < and > anything
+  class Weird(v):
+    implements Comparable
+    override method compare_to(other :~ Weird):
+      v - other.v
+    override method less(other):
+      if v == 1 | #true | compare_to(other) < 0
+    override method greater(other):
+      if v == 10 | #true | compare_to(other) > 0
+  check Weird(1) < Weird(0) ~is #true
+  check Weird(10) > Weird(20) ~is #true
+  check Weird(2) < Weird(0) ~is #false
+  check Weird(0) > Weird(20) ~is #false
+  check Weird(1) <= Weird(0) ~is #false
+  check Weird(1) >= Weird(2) ~is #false
+  check Weird(1) compares_equal Weird(0) ~is #false
+  check Weird(1) compares_unequal Weird(0) ~is #true
+
+block:
+  // says that 1 is <=, >=, =, and !=  anything
+  class Weird(v):
+    implements Comparable
+    override method compare_to(other :~ Weird):
+      v - other.v
+    override method less_or_equal(other):
+      if v == 1 | #true | compare_to(other) < 0
+    override method greater_or_equal(other):
+      if v == 10 | #true | compare_to(other) > 0
+    override method compares_equal(other):
+      if v == 100 | #true | compare_to(other) == 0
+    override method compares_unequal(other):
+      if v == 1000 | #true | compare_to(other) != 0
+  check Weird(1) <= Weird(0) ~is #true
+  check Weird(10) >= Weird(20) ~is #true
+  check Weird(100) compares_equal Weird(0) ~is #true
+  check Weird(1000) compares_unequal Weird(0) ~is #true
+  check Weird(1) < Weird(0) ~is #false
+  check Weird(1) > Weird(2) ~is #false
+  check Weird(2) <= Weird(0) ~is #false
+  check Weird(0) >= Weird(20) ~is #false
+  check Weird(200) compares_equal Weird(0) ~is #false
+  check Weird(0) compares_unequal Weird(0) ~is #false
+
+block:
+  // says that 1 is < and > anything, veneer variant
+  veneer Weird(this :: Int):
+    implements Comparable
+    override method compare_to(other :~ Weird):
+      this - other
+    override method less(other):
+      if this == 1 | #true | compare_to(other) < 0
+    override method greater(other):
+      if this == 10 | #true | compare_to(other) > 0
+  check Weird(1) < Weird(0) ~is #true
+  check Weird(10) > Weird(20) ~is #true
+  check Weird(2) < Weird(0) ~is #false
+  check Weird(0) > Weird(20) ~is #false
+  check Weird(1) <= Weird(0) ~is #false
+  check Weird(1) >= Weird(2) ~is #false
+  check Weird(1) compares_equal Weird(0) ~is #false
+  check Weird(1) compares_unequal Weird(0) ~is #true
+
+block:
+  // says that 1 is <=, >=, =, and !=  anything, veneer variant
+  veneer Weird(this :: Int):
+    implements Comparable
+    override method compare_to(other :~ Weird):
+      this - other
+    override method less_or_equal(other):
+      if this == 1 | #true | compare_to(other) < 0
+    override method greater_or_equal(other):
+      if this == 10 | #true | compare_to(other) > 0
+    override method compares_equal(other):
+      if this == 100 | #true | compare_to(other) == 0
+    override method compares_unequal(other):
+      if this == 1000 | #true | compare_to(other) != 0
+  check Weird(1) <= Weird(0) ~is #true
+  check Weird(10) >= Weird(20) ~is #true
+  check Weird(100) compares_equal Weird(0) ~is #true
+  check Weird(1000) compares_unequal Weird(0) ~is #true
+  check Weird(1) < Weird(0) ~is #false
+  check Weird(1) > Weird(2) ~is #false
+  check Weird(2) <= Weird(0) ~is #false
+  check Weird(0) >= Weird(20) ~is #false
+  check Weird(200) compares_equal Weird(0) ~is #false
+  check Weird(0) compares_unequal Weird(0) ~is #false

--- a/rhombus/tests/equatable.rhm
+++ b/rhombus/tests/equatable.rhm
@@ -103,6 +103,9 @@ block:
   check AnythingGoesConcrete(0) == AnythingGoesConcrete(1) ~is #true
   check Equatable.hash(AnythingGoesConcrete(2)) ~is 3
 
+  // check for static info on `hash_code` result
+  check AnythingGoesConcrete(2).hash_code(values) compares_equal AnythingGoesConcrete(2).hash_code(values) ~is #true
+
 block:
   class AnythingGoesAbstract():
     nonfinal
@@ -117,3 +120,6 @@ block:
 
   check AnythingGoesConcrete(0) == AnythingGoesConcrete(1) ~is #true
   check Equatable.hash(AnythingGoesConcrete(2)) ~is 4
+
+  // check for static info on `hash` result
+  check Equatable.hash(AnythingGoesConcrete(2)) compares_equal Equatable.hash(AnythingGoesConcrete(2)) ~is #true

--- a/rhombus/tests/for.rhm
+++ b/rhombus/tests/for.rhm
@@ -657,3 +657,9 @@ version_guard.at_least "8.11.1.4":
       each day_str: [fun (): today, fun (): today]
       [day_str(), today]
     ~is [["Friday", "Friday"], ["Friday", "Friday"]]
+
+check:
+  use_static
+  for List (i: 0..2):
+    i < 1
+  ~is [#true, #false]

--- a/rhombus/tests/keyword.rhm
+++ b/rhombus/tests/keyword.rhm
@@ -10,3 +10,8 @@ check:
   #'~a :: Keyword ~is #'~a
   Keyword.from_string("a") ~is #'~a
   Keyword.from_symbol(#'a) ~is #'~a
+
+check:
+  use_static
+  Keyword.from_string("a") < Keyword.from_symbol(#'a) 
+  ~completes

--- a/rhombus/tests/ref.rhm
+++ b/rhombus/tests/ref.rhm
@@ -154,7 +154,7 @@ fun
 | is_sorted([]): #true
 | is_sorted([head]): #true
 | is_sorted([head, next, tail, ...]):
-   head <= next && is_sorted([next, tail, ...])
+   head .<= next && is_sorted([next, tail, ...])
 
 check:
   is_sorted([1, 2, 30, 4, 5])

--- a/rhombus/tests/sequenceable.rhm
+++ b/rhombus/tests/sequenceable.rhm
@@ -177,7 +177,7 @@ check:
         ~recur_binds:
           i = 0,
         ~head_guard:
-          i < nr[0],
+          i .< nr[0],
         ~inner_binds:
           $lhs = df[i], // :~ List here would not propagate to body
         ~recur_args:

--- a/rhombus/tests/string.rhm
+++ b/rhombus/tests/string.rhm
@@ -139,3 +139,53 @@ block:
     to_string(copy("hello")) ~is "hello"
     to_string("hello", ~mode: #'expr) ~is "\"hello\""
     to_string(copy("hello"), ~mode: #'expr) ~is "racket.#{string-copy}(\"hello\")"
+
+block:
+  use_static
+  let a :: StringCI = "a"
+  let A :: StringCI = "A"
+  let b :: StringCI = "b"
+  let B :: StringCI = "B"
+  check:
+    a < B ~is #true
+    b < A ~is #false
+    a <= B ~is #true
+    a <= A ~is #true
+    b <= A ~is #false
+    a >= B ~is #false
+    a >= A ~is #true
+    b >= A ~is #true
+    a > B ~is #false
+    a > A ~is #false
+    b > A ~is #true
+    a compares_equal a ~is #true
+    a compares_equal A ~is #true
+    a compares_equal B ~is #false
+    a compares_unequal a ~is #false
+    a compares_unequal A ~is #false
+    a compares_unequal B ~is #true
+
+block:
+  use_static
+  let a :: ReadableStringCI = "a"
+  let A :: ReadableStringCI = "A"
+  let b :: ReadableStringCI = "b"
+  let B :: ReadableStringCI = "B"
+  check:
+    a < B ~is #true
+    b < A ~is #false
+    a <= B ~is #true
+    a <= A ~is #true
+    b <= A ~is #false
+    a >= B ~is #false
+    a >= A ~is #true
+    b >= A ~is #true
+    a > B ~is #false
+    a > A ~is #false
+    b > A ~is #true
+    a compares_equal a ~is #true
+    a compares_equal A ~is #true
+    a compares_equal B ~is #false
+    a compares_unequal a ~is #false
+    a compares_unequal A ~is #false
+    a compares_unequal B ~is #true

--- a/rhombus/tests/symbol.rhm
+++ b/rhombus/tests/symbol.rhm
@@ -19,3 +19,9 @@ check:
   to_string(Symbol.unreadable_from_string("a")) ~is "a"
   Symbol.gen("a") ~completes
   Symbol.gen(#'a) ~completes
+
+check:
+  use_static
+  Symbol.from_string("a") < Symbol.uninterned_from_string("a")  
+  Symbol.from_string("a") < Symbol.unreadable_from_string("a")
+  ~completes


### PR DESCRIPTION
Change `<`, `<=`, `>`, and `>=` to be operations on comparable values (instead of just numbers), and add `compares_equal` and `compares_unequal` (which different from `==` and `!=` by going through the comparable protocol instead of the equatable protocol). Real numbers, characters, strings, byte strings, symbols, and keywords are comparable.

The only method of the `Comparable` interface is `compare_to`, which should produce an integer that is negative for less-than, 0 for equal-to, or positive for greater-than.

Static information now requires that operations like `<` on comparables can be statically resolved to a specific comparison operation. Unlike `++`, either argument to `<` can determine the specialization. If both arguments provide a specialization through static information, the two must be consistent.

Add/keep `.<`, `.<=`, `.>=`, `.>`, and `.!=` as number-specific operators. These dot-prefixed operators can be useful when it's not convenient to have an annotation on one of the arguments. They might also help in dynamic mode to be sure you're getting a number operation.

The `Number` annotation specifies real-number comparisons, even though not all numbers are comparable (i.e., complex numbers are not all real numbers). Attaching only to annotations like `Real` would be more precise, but then results for operations like `+` would be much more complex to track usefully.

To support case-insensitive string and character comparsions, the new veneers `CharCI`, `StringCI`, and `ReadableStringCI` are like `Char`, `String` and `ReadableString`, but with case-insiensitive comparison.