### PR TITLE
extend `statinfo_meta.dot_provider_key` to support subclasses

### DIFF
--- a/rhombus/private/class-annotation.rkt
+++ b/rhombus/private/class-annotation.rkt
@@ -21,6 +21,7 @@
   (with-syntax ([(name name-extends tail-name
                        name-instance name? name-of
                        internal-name-instance indirect-static-infos internal-indirect-static-infos
+                       dot-providers internal-dot-providers
                        make-converted-name make-converted-internal
                        constructor-name-fields constructor-public-name-fields super-name-fields super-public-name-fields
                        field-keywords public-field-keywords super-field-keywords super-public-field-keywords)
@@ -29,7 +30,8 @@
                            name-fields keywords
                            super-name-fields super-field-keywords
                            name-instance-stx
-                           make-converted-id indirect-static-infos-stx)
+                           make-converted-id indirect-static-infos-stx
+                           dot-providers-stx)
       (define len (length (syntax->list name-fields)))
       (with-syntax ([(constructor-name-field ...) name-fields]
                     [(field-keyword ...) keywords]
@@ -47,9 +49,9 @@
               ([accessors (list (quote-syntax super-name-field) ...
                                 (quote-syntax constructor-name-field) ...)])
               (quote-syntax name?)
-              #,(with-syntax ([name-instance name-instance-stx]
+              #,(with-syntax ([dot-providers dot-providers-stx]
                               [indirect-static-infos indirect-static-infos-stx])
-                  #`(quasisyntax ((#%dot-provider name-instance)
+                  #`(quasisyntax ((#%dot-provider dot-providers)
                                   . indirect-static-infos)))
               (quote #,(+ len (if no-super? 0 (length super-constructor-fields))))
               (super-field-keyword ... field-keyword ...)
@@ -75,7 +77,8 @@
                         #'super-name-fields #'super-field-keywords
                         #'internal-name-instance
                         #'make-converted-internal
-                        #'internal-indirect-static-infos)
+                        #'internal-indirect-static-infos
+                        #'internal-dot-providers)
          null)
      (cond
        [annotation-rhs
@@ -93,7 +96,8 @@
                        #'super-public-name-fields #'super-public-field-keywords
                        #'name-instance
                        #'make-converted-name
-                       #'indirect-static-infos)]))))
+                       #'indirect-static-infos
+                       #'dot-providers)]))))
 
 (define-for-syntax (make-class-instance-predicate accessors)
   (lambda (arg predicate-stxs)

--- a/rhombus/private/class-binding.rkt
+++ b/rhombus/private/class-binding.rkt
@@ -22,7 +22,7 @@
                                              names)
   (with-syntax ([(name name-extends tail-name
                        name-instance name?
-                       indirect-static-infos
+                       indirect-static-infos dot-providers
                        constructor-name-fields constructor-public-name-fields super-name-fields
                        constructor-field-static-infoss constructor-public-field-static-infoss super-field-static-infoss
                        field-keywords public-field-keywords super-field-keywords)
@@ -37,7 +37,7 @@
         #`(binding-transformer
            (make-composite-binding-transformer '#,(symbol->immutable-string (syntax-e #'name))
                                                (quote-syntax name?)
-                                               #:static-infos (quote-syntax ((#%dot-provider name-instance)
+                                               #:static-infos (quote-syntax ((#%dot-provider dot-providers)
                                                                              . indirect-static-infos))
                                                (list (quote-syntax super-name-field) ...
                                                      (quote-syntax constructor-name-field) ...)

--- a/rhombus/private/class-constructor.rkt
+++ b/rhombus/private/class-constructor.rkt
@@ -41,7 +41,7 @@
                        name-defaults
                        make-internal-name
                        name-instance
-                       indirect-static-infos
+                       indirect-static-infos dot-providers
                        [private-field-name ...]
                        [private-field-desc ...])
                  names])
@@ -165,7 +165,7 @@
                          (quote-syntax (#:c #,(wrap-static-info
                                                #'make-name
                                                #'#%call-result
-                                               (let ([si #`((#%dot-provider name-instance)
+                                               (let ([si #`((#%dot-provider dot-providers)
                                                             . indirect-static-infos)])
                                                  (if super
                                                      #`((#%call-result #,si))

--- a/rhombus/private/class-dot-transformer.rkt
+++ b/rhombus/private/class-dot-transformer.rkt
@@ -47,7 +47,7 @@
             (proc packed-form dot (no-srcloc #`(#,group-tag lhs dot-op name)) static? packed-tail)]))))
     (syntax->list ids-stx))))
 
-(define-for-syntax (wrap-class-dot-via-class proc name pred instance)
+(define-for-syntax (wrap-class-dot-via-class proc name pred dot-provider)
   (make-expression-prefix-operator
    #'ignored
    '((default . stronger))
@@ -62,7 +62,7 @@
                                         (check-instance '#,name #,pred o)
                                         o)
                                     #'#%dot-provider
-                                    instance))
+                                    dot-provider))
                          |.|
                          #,name))
         (define orig-tail (pack-tail #'tail))

--- a/rhombus/private/class-parse.rkt
+++ b/rhombus/private/class-parse.rkt
@@ -65,6 +65,7 @@
    id
    super-id
    class:id
+   instance-dot-providers ; `#%dot-provider` value, only for non-final
    ref-id
    fields                ; (list (list symbol accessor-id mutator-id static-infos constructor-arg) ...)
    all-fields            ; #f or (list a-field ...), includes private fields; see below for a-field

--- a/rhombus/private/class-primitive.rkt
+++ b/rhombus/private/class-primitive.rkt
@@ -246,6 +246,13 @@
                                  (quote-syntax Name)
                                  #,(and (syntax-e #'Parent) #'(quote-syntax Parent))
                                  (quote-syntax struct_name)
+                                 (quote-syntax #,(if super
+                                                     (cons #'name-instance
+                                                           (let ([dps (class-desc-instance-dot-providers super)])
+                                                             (if (identifier? dps)
+                                                                 (list dps)
+                                                                 dps)))
+                                                     #'name-instance))
                                  #f ; `ref-id` would only used by the normal class dot provider
                                  (list (list 'super-field-name
                                              (quote-syntax super-name-field)

--- a/rhombus/private/class-reconstructor.rkt
+++ b/rhombus/private/class-reconstructor.rkt
@@ -63,7 +63,7 @@
                                               reconstructor-rhs method-private
                                               names)
   (with-syntax ([(name name? constructor-name name-instance
-                       indirect-static-infos reconstructor-name
+                       indirect-static-infos dot-providers reconstructor-name
                        [(con-field-name con-field-arg con-acc) ...]
                        [private-field-name ...]
                        [private-field-desc ...]
@@ -85,7 +85,7 @@
          (list
           #`(define-update-syntax name-instance
               (make-update-syntax (quote-syntax (name #,(and direct? #'constructor-name)
-                                                      name-instance indirect-static-infos))))))
+                                                      dot-providers indirect-static-infos))))))
         null)))
 
 (define-for-syntax (make-reconstructor super constructor-name names args accs)
@@ -110,12 +110,12 @@
        (raise-syntax-error #f "no default `with` for class with a custom constructor" with-id))
      (define-values (desc constructor-id static-infos direct?)
        (syntax-parse constructor-info
-         [(name constructor-id name-instance indirect-static-infos)
+         [(name constructor-id dot-providers indirect-static-infos)
           (define desc (syntax-local-value* (in-class-desc-space #'name) class-desc-ref))
           (unless desc (error "cannot find annotation binding for update provider"))
           (values desc
                   #'constructor-id
-                  #'((#%dot-provider name-instance) . indirect-static-infos)
+                  #'((#%dot-provider dot-providers) . indirect-static-infos)
                   (syntax-e #'constructor-id))]))
      (define (recon-field-name f) (car f))
      (define (recon-field-arg f) (cadr f))

--- a/rhombus/private/dot-provider-key.rkt
+++ b/rhombus/private/dot-provider-key.rkt
@@ -1,7 +1,54 @@
 #lang racket/base
 (require (for-syntax racket/base)
-         "static-info.rkt")
+         "static-info.rkt"
+         "dot-space.rkt")
+
+(provide (for-syntax extract-dot-provider-id))
 
 (define-static-info-key-syntax/provide #%dot-provider
-  (static-info-key static-info-identifier-union
-                   static-info-identifier-intersect))
+  (static-info-key (lambda (a b)
+                     (cond
+                       [(and (identifier? a) (identifier? b))
+                        (static-info-identifier-union a b)]
+                       [else
+                        ;; use `b` if it's more information than `a`, otherwise use `a`:
+                        (let ([as (if (identifier? a) (list a) (syntax->list a))]
+                              [bs (if (identifier? b) (list b) (syntax->list b))])
+                          (or (and as
+                                   bs
+                                   (let ([a-len (length as)]
+                                         [b-len (length bs)])
+                                     (and (> b-len a-len)
+                                          (for/or ([a (in-list as)]
+                                                   [b (in-list (list-tail bs (- b-len a-len)))])
+                                            (free-identifier=? (in-dot-provider-space a)
+                                                               (in-dot-provider-space b)))))
+                                   b)
+                              a))]))
+                   (lambda (a b)
+                     (let ([as (if (identifier? a) (list a) (syntax->list a))]
+                           [bs (if (identifier? b) (list b) (syntax->list b))])
+                       (and as
+                            bs
+                            (let ([a-len (length as)]
+                                  [b-len (length bs)])
+                              (let ([common
+                                     (let loop ([rev-as (reverse (list-tail as (max 0 (- a-len b-len))))]
+                                                [rev-bs (reverse (list-tail bs (max 0 (- b-len a-len))))])
+                                       (cond
+                                         [(null? rev-as) null]
+                                         [(free-identifier=? (in-dot-provider-space (car rev-as))
+                                                             (in-dot-provider-space (car rev-bs)))
+                                          (cons (car rev-as) (loop (cdr rev-as) (cdr rev-bs)))]
+                                         [else null]))])
+                                (and (pair? common)
+                                     (if (null? (cdr common))
+                                         (car common)
+                                         common)))))))))
+
+(define-for-syntax (extract-dot-provider-id dp-id/s)
+  (cond
+    [(not dp-id/s) #false]
+    [(identifier? dp-id/s) dp-id/s]
+    [(pair? (syntax-e dp-id/s)) (car (syntax-e dp-id/s))]
+    [else #f]))

--- a/rhombus/private/dot-space.rkt
+++ b/rhombus/private/dot-space.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     "introducer.rkt"))
+
+(provide (for-syntax in-dot-provider-space))
+
+(begin-for-syntax
+  (define in-dot-provider-space (make-interned-syntax-introducer/add 'rhombus/dot)))

--- a/rhombus/private/veneer-parse.rkt
+++ b/rhombus/private/veneer-parse.rkt
@@ -9,6 +9,8 @@
   (id
    super-id
    predicate-id    ; #f if not checked
-   convert-id))    ; #f if predicate-based
+   convert-id      ; #f if predicate-based
+   instance-dot-providers)) ; `#%dot-provider` value, only for non-final
+
 
 (define (veneer-desc-ref v) (and (veneer-desc? v) v))

--- a/rhombus/private/with.rkt
+++ b/rhombus/private/with.rkt
@@ -43,10 +43,11 @@
        #:datum-literals (group)
        [(with-id (_::parens (group name:id _::equal rhs ...) ...) . tail)
         (let ([form1 (rhombus-local-expand orig-form1)])
-          (define update-id
+          (define update-id/s
             (syntax-parse form1
               [dp::update-provider #'dp.id]
               [_ #f]))
+          (define update-id (extract-dot-provider-id update-id/s))
           (define updater
             (and update-id
                  (syntax-local-value* (in-update-space update-id) update-transformer-ref)))

--- a/rhombus/scribblings/ref-static-info.scrbl
+++ b/rhombus/scribblings/ref-static-info.scrbl
@@ -246,9 +246,13 @@
         arguments share the same @rhombus(append, ~datum) implementation}
 
   @item{@rhombus(statinfo_meta.dot_provider_key) --- an identifier
-        bound to a @rhombus(dot.macro) or
-        @rhombus(dot.macro_more_static) to implement the expression's
-        behavior as a @tech{dot provider}}
+        bound by @rhombus(dot.macro) @rhombus(dot.macro_more_static) to
+        implement the expression's behavior as a @tech{dot provider},
+        or a packed sequence of such identifiers. In the case of a sequence, the
+        first identifier is used, but the rest is relevant for an
+        intersection of two sequences, which produces the shared tail,
+        and the union of two sequences, which picks the longer of two
+        sequences when one is a tail of the other.}
 
   @item{@rhombus(statinfo_meta.sequence_constructor_key) --- an identifier
         bound as a variable or a macro that is wrapped around an expression

--- a/rhombus/tests/cond.rhm
+++ b/rhombus/tests/cond.rhm
@@ -50,7 +50,6 @@ check:
   (cond | #true: [1] | ~else: "one")[0]
   ~throws "specialization not known"
 
-
 check:
   ~eval
   use_static
@@ -59,4 +58,32 @@ check:
            | Posn(1, 2)
            | #void)
   p.x
+  ~throws "no such field or method"
+
+check:
+  class Posn(x, y):
+    nonfinal
+    method d(): x + y
+  class Posn3D(z):
+    extends Posn
+    override method d(): x + y + z
+  def p = (if #false
+           | Posn(1, 2)
+           | Posn3D(1, 2, 3))
+  p.d() + p.x + p.y
+  ~is 9
+
+check:
+  ~eval
+  use_static
+  class Posn(x, y):
+    nonfinal
+    method d(): x + y
+  class Posn3D(z):
+    extends Posn
+    override method d(): x + y + z
+  def p = (if #false
+           | Posn(1, 2)
+           | Posn3D(1, 2, 3))
+  p.z
   ~throws "no such field or method"


### PR DESCRIPTION
Change the use of `statinfo_meta.dot_provider_key` values to allow a sequence of identifiers, instead of just one identifier, where the first identifier of a sequence is used, but intersection on sequences finds a shared tail. That encoding allows an `if` with branches that instantiate different classes to get dot information for a shared superclass.

To keep things simple, this works only for single-inheritance cases — so superclasses and supervaneers, but not superinterfaces.