### PR TITLE
add `enum`

### DIFF
--- a/rhombus/pict/balloon.rhm
+++ b/rhombus/pict/balloon.rhm
@@ -6,7 +6,7 @@ import:
       Pict
       Find
       Color
-      MaybeColor
+      ColorMode
       LineWidth
       EpochAlignment
       DurationAlignment
@@ -50,8 +50,8 @@ fun pin(content :: Pict,
         ~dy: dy :: Real = bln.#{spike->dy}(spike),
         ~sprout: sprout :: Real = 0.5,
         ~thought: thought = #false,
-        ~fill: color :: MaybeColor = current_color(),
-        ~line: line_color :: MaybeColor = #false,
+        ~fill: color :: maybe(ColorMode) = current_color(),
+        ~line: line_color :: maybe(ColorMode) = #false,
         ~line_width: line_width :: LineWidth = #'inherit,
         ~epoch: epoch :: EpochAlignment = #'center,
         ~duration: duration :: DurationAlignment = #'sustain) :~ Pict:

--- a/rhombus/pict/private/anim.rhm
+++ b/rhombus/pict/private/anim.rhm
@@ -10,6 +10,8 @@ import:
       EpochAlignment
       HorizAlignment
       VertAlignment
+      TimeOrder
+      ColorMode
   "static.rhm"!private:
     expose:
       Pict
@@ -41,17 +43,12 @@ namespace bend:
   fun fast_edges(n :: Real.in(0, 1)):
     rkt.#{fast-edges}(n)
 
-annot.macro 'SequentialJoin':
-  annot_meta.pack_predicate('is_seq_join', '()')
-fun is_seq_join(v):
-  match v
-  | #'step || #'splice: #true
-  | ~else: #false
+enum SequentialJoin:  step splice
 
 fun animate(proc :: Function.of_arity(1),
             ~bend: bend = rkt.#{fast-middle},
             ~extent: extent :: NonnegReal = 0.5,
-            ~sustain_edge: sustain_edge :: matching(#'before || #'after) = #'after) :~ Pict:
+            ~sustain_edge: sustain_edge :: matching(TimeOrder) = #'after) :~ Pict:
   let proc = fun (n): proc(bend(n))
   AnimPict(proc, ~extent: extent, ~sustain_edge: sustain_edge)
 
@@ -351,7 +348,7 @@ class AnimPict(_epochs :~ List.of(PictEpoch),
   | _pad(left :: Real, top :: Real, right :: Real, bottom :: Real) :~ AnimPict:
       anim_pict_adjust(this, fun (p :~ StaticPict): p._pad(left, top, right, bottom))
 
-  override method time_clip(~keep: keep :: maybe(matching(#'before || #'after)) = #false,
+  override method time_clip(~keep: keep :: maybe(TimeOrder) = #false,
                             ~nonsustaining: nonsustaining = keep != #'after) :~ AnimPict:
     anim_pict_like(this,
                    ~epochs:
@@ -504,7 +501,7 @@ class AnimPict(_epochs :~ List.of(PictEpoch),
   override method shear(horiz :: Real, vert :: Real) :~ Pict:
     anim_pict_adjust(this, fun (p :~ StaticPict): p.shear(horiz, vert))
 
-  override method colorize(c :: (Color || String)) :~ Pict:
+  override method colorize(c :: Color || String) :~ Pict:
     anim_pict_adjust(this, fun (p :~ StaticPict): p.colorize(c))
   override method line_width(w :: NonnegReal) :~ Pict:
     anim_pict_adjust(this, fun (p :~ StaticPict): p.line_width(w))
@@ -816,7 +813,7 @@ private.set_convert(
               {})
 )
 
-fun switch(~splice: splice :: maybe(matching(#'before || #'after)) = #false,
+fun switch(~splice: splice :: maybe(matching(TimeOrder)) = #false,
            ~join: join :: SequentialJoin = if splice | #'splice | #'step,
            p :: Pict, ...) :~ Pict:
   let ps = (for List (p: [p, ...]):

--- a/rhombus/pict/private/static.rhm
+++ b/rhombus/pict/private/static.rhm
@@ -10,13 +10,18 @@ import:
 
 export:
   Color
-  MaybeColor
+  ColorMode
   LineWidth
   HorizAlignment
   VertAlignment
   EpochAlignment
   DurationAlignment
   OverlayOrder
+  TimeOrder
+  ConnectStyle
+  ArcDirection
+  Refocus
+  Rounded
 
   Pict:
     only_space namespace annot
@@ -60,50 +65,23 @@ module private:
     static_instance
     remove_nothings
 
-annot.macro 'MaybeColor':
-  annot_meta.pack_predicate('is_maybe_color', '()')
-fun is_maybe_color(v):
-  !v || (v is_a Color) || (v is_a String) || v == #'inherit
+enum ColorMode:
+  ~is_a Color
+  ~is_a String
+  inherit
 
-annot.macro 'LineWidth':
-  annot_meta.pack_predicate('is_line_width', '()')
-fun is_line_width(v):
-  (v is_a Real) || v == #'inherit
+enum LineWidth:
+  ~is_a Real
+  inherit
 
-annot.macro 'HorizAlignment':
-  annot_meta.pack_predicate('is_horiz_aign', '()')
-fun is_horiz_aign(v):
-  match v
-  | #'left || #'center || #'right: #true
-  | ~else: #false
-
-annot.macro 'VertAlignment':
-  annot_meta.pack_predicate('is_vert_aign', '()')
-fun is_vert_aign(v):
-  match v
-  | #'top || #'topline || #'center || #'baseline || #'bottom: #true
-  | ~else: #false
-
-annot.macro 'EpochAlignment':
-  annot_meta.pack_predicate('is_epoch_align', '()')
-fun is_epoch_align(v):
-  match v
-  | #'early || #'center || #'stretch || #'late: #true
-  | ~else: #false
-
-annot.macro 'DurationAlignment':
-  annot_meta.pack_predicate('is_sustain_align', '()')
-fun is_sustain_align(v):
-  match v
-  | #'sustain || #'pad: #true
-  | ~else: #false
-
-annot.macro 'OverlayOrder':
-  annot_meta.pack_predicate('is_overlay_order', '()')
-fun is_overlay_order(v):
-  match v
-  | #'front || #'back: #true
-  | ~else: #false
+enum HorizAlignment: left center right
+enum VertAlignment: top topline center baseline bottom
+enum EpochAlignment: early center stretch late
+enum DurationAlignment: sustain pad
+enum OverlayOrder: front back
+enum TimeOrder: before after
+enum ConnectStyle: line arrow arrows
+enum ArcDirection: cw ccw
 
 def empty_instances = []
 
@@ -192,7 +170,7 @@ class Pict():
   abstract method freeze(~scale: scale :: Real = 2.0) :~ Pict
 
   abstract method _time_pad(before :: Int, after :: Int) :~ Pict
-  abstract method time_clip(~keep: keep :: maybe(matching(#'before || #'after)) = #false) :~ Pict
+  abstract method time_clip(~keep: keep :: maybe(TimeOrder) = #false) :~ Pict
   method delay(n :: NonnegInt) :~ Pict: time_clip(~keep: #'after).time_pad(~before: 1)
   abstract method sustain(n :: Int = 1) :~ Pict
   abstract method nonsustaining() :~ Pict
@@ -302,7 +280,7 @@ class StaticPict(private _handle,
   override method freeze(~scale: scale :: Real = 2.0):
     static_pict(rkt.freeze(_handle), this, _instances)
   
-  override method time_clip(~keep: keep :: maybe(matching(#'before || #'after)) = #false) :~ Pict:
+  override method time_clip(~keep: keep :: maybe(TimeOrder) = #false) :~ Pict:
     convert([this], #'center, #'pad, fun (ps :~ List): ps[0]).time_clip(~keep: keep)
 
   override method _time_pad(before :: Int, after :: Int) :~ Pict:
@@ -393,7 +371,7 @@ class NothingPict():
 
   override method clip(): this
 
-  override method time_clip(~keep: keep :: maybe(matching(#'before || #'after)) = #false): this
+  override method time_clip(~keep: keep :: maybe(TimeOrder) = #false): this
 
   override method _time_pad(before :: Int, after :: Int): this
   override method sustain(n :: Int = 1): this
@@ -674,7 +652,7 @@ fun make_dc_pict(draw_it, w, h, a, d, line, line_width, fill):
 
 fun line(~dx: dx :: Real = 0,
          ~dy: dy :: Real = 0,
-         ~line: color :: Color || String || matching(#'inherit) = #'inherit,
+         ~line: color :: ColorMode = #'inherit,
          ~line_width: width :: LineWidth = #'inherit) :~ Pict:
   let ln:
     cond
@@ -713,15 +691,23 @@ fun maybe_pad(p :~ Pict, dw, dh):
   | p
   | p.pad(~horiz: dw/2, ~vert: dh/2)
 
+enum Rounded:
+  ~is_a Real
+  default
+
+enum Refocus:
+  ~is_a Pict
+  around
+
 fun rectangle(~around: around :: maybe(Pict) = #false,
               ~width: width :: Real: if around | Pict.width(around) | 32,
               ~height: height :: Real: if around | Pict.height(around) | width,
-              ~fill: fill :: MaybeColor = #false,
-              ~line: line :: MaybeColor = !fill && #'inherit,
+              ~fill: fill :: maybe(ColorMode) = #false,
+              ~line: line :: maybe(ColorMode) = !fill && #'inherit,
               ~line_width: line_width :: LineWidth = #'inherit,
-              ~rounded: rounded :: maybe(Real || matching(#'default)) = #false,
+              ~rounded: rounded :: maybe(Rounded) = #false,
               ~order: order :: OverlayOrder = #'front,
-              ~refocus: refocus :: maybe(Pict || matching(#'around)) = #'around,
+              ~refocus: refocus :: maybe(Refocus) = #'around,
               ~epoch: epoch :: EpochAlignment = #'center,
               ~duration: duration :: DurationAlignment = #'sustain) :~ Pict:
   recur retry(around = around, width = width, height = height, ghosted = #false):
@@ -799,11 +785,11 @@ fun convert_some([around, width, height], epoch, duration, retry):
         
 fun square(~around: around :: maybe(Pict) = #false,
            ~size: size :: Real: if around | math.max(Pict.width(around), Pict.width(around)) | 32,
-           ~fill: fill :: MaybeColor = #false,
-           ~line: line :: MaybeColor = !fill && #'inherit,
+           ~fill: fill :: maybe(ColorMode) = #false,
+           ~line: line :: maybe(ColorMode) = !fill && #'inherit,
            ~line_width: line_width :: LineWidth = #'inherit,
            ~order: order :: OverlayOrder = #'front,
-           ~refocus: refocus :: maybe(Pict || matching(#'around)) = #'around,              
+           ~refocus: refocus :: maybe(Refocus) = #'around,
            ~epoch: epoch :: EpochAlignment = #'center,
            ~duration: duration :: DurationAlignment = #'sustain) :~ Pict:
   let size:
@@ -826,14 +812,14 @@ fun square(~around: around :: maybe(Pict) = #false,
 fun ellipse(~around: around :: maybe(Pict) = #false,
             ~width: width :: Real: if around | Pict.width(around) | 32,
             ~height: height :: Real: if around | Pict.height(around) | width,
-            ~arc: arc :: maybe(matching(#'cw || #'ccw)) = #false,
+            ~arc: arc :: maybe(ArcDirection) = #false,
             ~start: start :: Real = 0,
             ~end: end :: Real = 2 * math.pi,
-            ~fill: fill :: MaybeColor = #false,
-            ~line: line :: MaybeColor = !fill && #'inherit,
+            ~fill: fill :: maybe(ColorMode) = #false,
+            ~line: line :: maybe(ColorMode) = !fill && #'inherit,
             ~line_width: line_width :: LineWidth = #'inherit,
             ~order: order :: OverlayOrder = #'front,
-            ~refocus: refocus :: maybe(Pict || matching(#'around)) = #'around,
+            ~refocus: refocus :: maybe(Refocus) = #'around,
             ~epoch: epoch :: EpochAlignment = #'center,
             ~duration: duration :: DurationAlignment = #'sustain) :~ Pict:
   recur retry(around = around, width = width, height = height, ghosted = #false):
@@ -891,14 +877,14 @@ fun ellipse(~around: around :: maybe(Pict) = #false,
 
 fun circle(~around: around :: maybe(Pict) = #false,
            ~size: size :: Real: if around | math.max(Pict.width(around), Pict.width(around)) | 32,
-           ~arc: arc :: maybe(matching(#'cw || #'ccw)) = #false,
+           ~arc: arc :: maybe(ArcDirection) = #false,
            ~start: start :: Real = 0,
            ~end: end :: Real = 2 * math.pi,
            ~clockwise: clockwise :: Boolean = #false,
-           ~fill: fill :: MaybeColor = #false,
-           ~line: line :: MaybeColor = !fill && #'inherit,
+           ~fill: fill :: maybe(ColorMode) = #false,
+           ~line: line :: maybe(ColorMode) = !fill && #'inherit,
            ~line_width: line_width :: LineWidth = #'inherit,
-           ~refocus: refocus :: maybe(Pict || matching(#'around)) = #'around,
+           ~refocus: refocus :: maybe(Refocus) = #'around,
            ~epoch: epoch :: EpochAlignment = #'center,
            ~duration: duration :: DurationAlignment = #'sustain) :~ Pict:
   let size = match size | p :: Pict: math.max(p.width, p.height) | ~else: size
@@ -916,8 +902,8 @@ fun circle(~around: around :: maybe(Pict) = #false,
           ~duration: duration)
 
 fun polygon([pt :: draw.PointLike.to_point, ...],
-            ~fill: fill :: MaybeColor = #false,
-            ~line: line :: MaybeColor = !fill && #'inherit,
+            ~fill: fill :: maybe(ColorMode) = #false,
+            ~line: line :: maybe(ColorMode) = !fill && #'inherit,
             ~line_width: line_width :: LineWidth = #'inherit) :~ Pict:
   let w = math.max(pt.x, ...)
   let h = math.max(pt.y, ...)
@@ -940,8 +926,8 @@ fun dc(draw :: Function.of_arity(3),
        ~height: height :: Real,
        ~ascent: ascent :: Real = height,
        ~descent: descent :: Real = 0,
-       ~fill: fill :: MaybeColor = #false,
-       ~line: line :: MaybeColor = !fill && #'inherit,
+       ~fill: fill :: maybe(ColorMode) = #false,
+       ~line: line :: maybe(ColorMode) = !fill && #'inherit,
        ~line_width: line_width :: LineWidth = #'inherit) :~ Pict:
   static_pict(make_dc_pict(draw,
                            width,
@@ -1102,8 +1088,8 @@ def_find bottom_right: #{rb-find}
 fun connect(~on: p :: Pict,
             from :: Find,
             to :: Find,
-            ~style: style :: matching(#'line || #'arrow || #'arrows) = #'line,
-            ~line: color :: Color || String || matching(#'inherit) = #'inherit,
+            ~style: style :: ConnectStyle = #'line,
+            ~line: color :: ColorMode = #'inherit,
             ~line_width: width :: LineWidth = #'inherit,
             ~order: order :: OverlayOrder = #'front,
             ~arrow_size: arrow_size :: Real = 16,
@@ -1190,12 +1176,12 @@ fun table(rows :: List.of(List.of(Pict)),
           ~hsep: hsep :: Real || List.of(Real) = 32,
           ~vsep: vsep :: Real || List.of(Real) = 1,
           ~pad: ins :: matching((_ :: Real) || [_ :: Real, _ :: Real] || [_ :: Real, _ :: Real, _ :: Real, _ :: Real]) = 0,
-          ~line: line_c :: maybe(String || Color || matching(#'inherit)) = #false,
+          ~line: line_c :: maybe(ColorMode) = #false,
           ~line_width: line_width :: LineWidth = #'inherit,
           ~order: order :: OverlayOrder = #'front,
-          ~hline: hline :: maybe(String || Color || matching(#'inherit)) = line_c,
+          ~hline: hline :: maybe(ColorMode) = line_c,
           ~hline_width: hline_width :: LineWidth = line_width,
-          ~vline: vline :: maybe(String || Color || matching(#'inherit)) = line_c,
+          ~vline: vline :: maybe(ColorMode) = line_c,
           ~vline_width: vline_width :: LineWidth = line_width) :~ Pict:
   match rows
   | [[elem :~ _StaticPict, ...], ...]:

--- a/rhombus/pict/radial.rhm
+++ b/rhombus/pict/radial.rhm
@@ -50,8 +50,8 @@ class Radial(~points,
              ~rotate):
   method path() :~ draw.Path:
     radial_path(this)
-  method pict(~fill: fill :: MaybeColor = #false,
-              ~line: line :: MaybeColor = !fill && #'inherit,
+  method pict(~fill: fill :: maybe(ColorMode) = #false,
+              ~line: line :: maybe(ColorMode) = !fill && #'inherit,
               ~line_width: line_width :: LineWidth = #'inherit,
               ~bound: bound :: BoundingBoxMode = #'unit) :~ Pict:
     radials_pict([this],
@@ -123,8 +123,8 @@ fun radial_path(Radial(~points: n,
   p
 
 fun radials_pict([r :: Radial, ...],
-                 ~fill: fill :: MaybeColor = #false,
-                 ~line: line :: MaybeColor = !fill && #'inherit,
+                 ~fill: fill :: maybe(ColorMode) = #false,
+                 ~line: line :: maybe(ColorMode) = !fill && #'inherit,
                  ~line_width: line_width :: LineWidth = #'inherit,
                  ~bound: bound :: BoundingBoxMode = #'unit) :~ Pict:
   if [r, ...].length() == 0
@@ -175,8 +175,8 @@ defn.macro 'def_radial:
     fun $pict($pt_kw: $pt_name $pt_rhs ...,
               $kw: $name $rhs ...,
               ...,
-              ~fill: fill :: MaybeColor = #false,
-              ~line: line :: MaybeColor = !fill && #'inherit,
+              ~fill: fill :: maybe(ColorMode) = #false,
+              ~line: line :: maybe(ColorMode) = !fill && #'inherit,
               ~line_width: line_width :: LineWidth = #'inherit,
               ~bound: bound :: BoundingBoxMode = #'unit,
               $extra_arg,
@@ -396,8 +396,8 @@ fun arrow(~length: length :: Real = 64,
           ~head: head :: Real = (if tail .= 0 | 1 | 0.5),
           ~indent: indent = (if tail .= 0 | 0.3 | 0),
           ~rotate: spin :: Real = 0,
-          ~fill: fill :: MaybeColor = #false,
-          ~line: line :: MaybeColor = !fill && #'inherit,
+          ~fill: fill :: maybe(ColorMode) = #false,
+          ~line: line :: maybe(ColorMode) = !fill && #'inherit,
           ~line_width: line_width :: LineWidth = #'inherit,
           ~bound: bound :: ArrowBoundingBoxMode = #'unit) :~ Pict:
   let p = arrow_path(~length: length,

--- a/rhombus/pict/scribblings/balloon.scrbl
+++ b/rhombus/pict/scribblings/balloon.scrbl
@@ -37,8 +37,8 @@
     ~dy: dy :: Real = spike_to_dy(spike),
     ~sprout: sprout :: Real = 0.5,
     ~thought: thought = #false,
-    ~fill: fill :: MaybeColor = current_color(),
-    ~line: line :: MaybeColor = #false,
+    ~fill: fill :: maybe(ColorMode) = current_color(),
+    ~line: line :: maybe(ColorMode) = #false,
     ~line_width: line_width :: LineWidth = #'inherit,
     ~epoch: epoch :: EpochAlignment = #'center,
     ~duration: duration :: DurationAlignment = #'sustain

--- a/rhombus/pict/scribblings/combine.scrbl
+++ b/rhombus/pict/scribblings/combine.scrbl
@@ -139,9 +139,9 @@
     ~on: on_pict :: Pict,
     from :: Find,
     to :: Find,
-    ~style: style :: matching(#'line || #'arrow || #'arrows) = #'line,
-    ~line: color :: Color || String || matching(#'inherit) = #'inherit,
-    ~line_width: width :: Real || matching(#'inherit) = #'inherit,
+    ~style: style :: ConnectStyle = #'line,
+    ~line: color :: ConnectMode = #'inherit,
+    ~line_width: width :: LineWidth = #'inherit,
     ~order: order :: OverlayOrder = #'front,
     ~arrow_size: arrow_size :: Real = 16,
     ~arrow_solid: solid = #true,
@@ -187,12 +187,12 @@
                             || [_ :: Real, _ :: Real]
                             || [_ :: Real, _ :: Real, _ :: Real, _ :: Real])
             = 0,
-    ~line: line_c :: maybe(String || Color || matching(#'inherit)) = #false,
-    ~line_width: line_width :: Real || matching(#'inherit) = #'inherit,
-    ~hline: hline :: maybe(String || Color || matching(#'inherit)) = line_c,
-    ~hline_width: hline_width :: Real || matching(#'inherit) = line_width,
-    ~vline: vline :: maybe(String || Color || matching(#'inherit)) = line_c,
-    ~vline_width: vline_width :: Real || matching(#'inherit) = line_width
+    ~line: line_c :: maybe(ColorMode) = #false,
+    ~line_width: line_width :: LineWidth = #'inherit,
+    ~hline: hline :: maybe(ColorMode) = line_c,
+    ~hline_width: hline_width :: LineWidth = line_width,
+    ~vline: vline :: maybe(ColorMode) = line_c,
+    ~vline_width: vline_width :: LineWidth = line_width
   ) :: Pict
 ){
 
@@ -220,7 +220,7 @@
 
 @doc(
   fun switch(
-    ~splice: splice :: maybe(matching(#'before || #'after)) = #false,
+    ~splice: splice :: maybe(TimeOrder) = #false,
     ~join: join :: SequentialJoin = if splice | #'splice | #'step,
     pict :: Pict, ...
   ) :: Pict
@@ -296,7 +296,8 @@
     ~combine: combine :: Function.of_arity(1),
     ~duration: duration_align :: DurationAlignment = #'sustain,
     ~epoch: epoch_align :: EpochAlignment = #'center,
-    ~non_sustain_combine: non_sustain_combine :: Function.of_arity(1) = combine
+    ~non_sustain_combine: non_sustain_combine :: Function.of_arity(1)
+                            = combine
   ) :: Pict
 ){
 
@@ -377,58 +378,79 @@
 }
 
 @doc(
-  annot.macro 'HorizAlignment'
+  enum HorizAlignment:
+    left
+    center
+    right
 ){
 
- Recognizes an option for horizontal alignment, which is either
- @rhombus(#'left), @rhombus(#'center), or @rhombus(#'right).
+ Options for horizontal alignment.
 
 }
 
 @doc(
-  annot.macro 'VertAlignment'
+  enum VertAlignment:
+    top
+    topline
+    center
+    baseline
+    bottom
 ){
 
- Recognizes an option for vertical alignment, which is either
- @rhombus(#'top), @rhombus(#'topline), @rhombus(#'center),
- @rhombus(#'baseline), or @rhombus(#'bottom).
+ Options for vertical alignment.
 
 }
 
 @doc(
-  annot.macro 'DurationAlignment'
+  enum DurationAlignment:
+    sustain
+    pad
 ){
 
- Recognizes an option for duration alignment, which is either
- @rhombus(#'sustain) or @rhombus(#'pad).
+ Options for duration alignment.
 
 }
 
 @doc(
-  annot.macro 'EpochAlignment'
+  enum EpochAlignment:
+    early
+    center
+    stretch
+    late
 ){
 
- Recognizes an option for epoch alignment, which is either
- @rhombus(#'early), @rhombus(#'center), @rhombus(#'stretch), or
- @rhombus(#'late).
+ Options for epoch alignment.
 
 }
 
 @doc(
-  annot.macro 'SequentialJoin'
+  enum SequentialJoin:
+    step
+    splice
 ){
 
- Recognizes an option for sequential joining, which is either
- @rhombus(#'step) or @rhombus(#'splice).
+ Options for sequential joining.
 
 }
 
 
 @doc(
-  annot.macro 'OverlayOrder'
+  enum OverlayOrder:
+    front
+    back
 ){
 
- Recognizes an option for overlaying, which is either
- @rhombus(#'front) or @rhombus(#'back).
+ Options for overlaying.
+
+}
+
+@doc(
+  enum ConnectStyle:
+    line
+    arrow
+    arrows
+){
+
+ Options for a @rhombus(connect) style.
 
 }

--- a/rhombus/pict/scribblings/pict.scrbl
+++ b/rhombus/pict/scribblings/pict.scrbl
@@ -61,7 +61,8 @@
 
 @doc(
   method (pict :: Pict).snapshot() :: StaticPict
-  method (pict :: Pict).snapshot(epoch :: Int, n :: Real.in(0, 1)) :: StaticPict
+  method (pict :: Pict).snapshot(epoch :: Int, n :: Real.in(0, 1))
+    :: StaticPict
 ){
 
  Converts an @tech{animated pict} to a @tech{static pict}. The 0-argument
@@ -180,7 +181,8 @@
 }
 
 @doc(
-  method (pict :: Pict).shear(x_factor :: Real, y_factor :: Real) :: Pict
+  method (pict :: Pict).shear(x_factor :: Real,
+                              y_factor :: Real) :: Pict
 ){
 
  Returns a @tech{pict} that is like @rhombus(pict), but its drawing is
@@ -230,7 +232,7 @@
 
 @doc(
   method (pict :: Pict).time_clip(
-    ~keep: keep :: maybe(matching(#'before || #'after)) = #false,
+    ~keep: keep :: maybe(TimeOrder) = #false,
     ~nonsustaining: nonsustaining = keep != #'after
   ) :: Pict
 ){
@@ -245,7 +247,7 @@
 }
 
 @doc(
-  method (pict :: Pict).colorize(c :: (Color || String)) :: Pict
+  method (pict :: Pict).colorize(c :: Color || String) :: Pict
   method (pict :: Pict).line_width(w :: NonnegReal) :: Pict
 ){
 
@@ -296,5 +298,15 @@
  @rhombus(overlay), the combination's metadata is formed by merging
  metadata maps from the combined picts, and later picts in the
  combination take precedence.
+
+}
+
+@doc(
+  enum TimeOrder:
+    before
+    after
+){
+
+ Options for time directions.
 
 }

--- a/rhombus/pict/scribblings/radial.scrbl
+++ b/rhombus/pict/scribblings/radial.scrbl
@@ -67,8 +67,8 @@
     ~flat_outer_edge: flat_outer_edge = #false,
     ~outer_pull: outer_pull :: Real = 0,
     ~inner_pull: inner_pull :: Real = 0,
-    ~fill: fill :: MaybeColor = #false,
-    ~line: line :: MaybeColor = !fill && #'inherit,
+    ~fill: fill :: maybe(ColorMode) = #false,
+    ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit,
     ~bound: bound :: BoundingBoxMode = #'unit
   ) :: Pict
@@ -218,8 +218,8 @@
 
 @doc(
   method (radial :: Radial).pict(
-    ~fill: fill :: MaybeColor = #false,
-    ~line: line :: MaybeColor = !fill && #'inherit,
+    ~fill: fill :: maybe(ColorMode) = #false,
+    ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit,
     ~bound: bound :: BoundingBoxMode = #'unit
   ) :: Pict
@@ -243,8 +243,8 @@
 @doc(
   fun radials_pict(
     radial :: Radial, ...,
-    ~fill: fill :: MaybeColor = #false,
-    ~line: line :: MaybeColor = !fill && #'inherit,
+    ~fill: fill :: maybe(ColorMode) = #false,
+    ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit,
     ~bound: bound :: BoundingBoxMode = #'unit
   ) :: Pict
@@ -270,8 +270,8 @@
     ~head: head :: Real = (if tail .= 0 | 1 | 0.5),
     ~indent: indent = (if tail .= 0 | 0.3 | 0),
     ~rotate: rotate :: Real = 0,
-    ~fill: fill :: MaybeColor = #false,
-    ~line: line :: MaybeColor = !fill && #'inherit,
+    ~fill: fill :: maybe(ColorMode) = #false,
+    ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit,
     ~bound: bound :: ArrowBoundingBoxMode = #'unit
   ) :: Pict

--- a/rhombus/pict/scribblings/shape.scrbl
+++ b/rhombus/pict/scribblings/shape.scrbl
@@ -35,12 +35,11 @@
     ~around: around :: maybe(Pict) = #false,
     ~width: width :: Real: if around | Pict.width(around) | 32,
     ~height: height :: Real: if around | Pict.height(around) | width,
-    ~fill: fill :: MaybeColor = #false,
-    ~line: line :: MaybeColor = !fill && #'inherit,
+    ~fill: fill :: maybe(ColorMode) = #false,
+    ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit,
-    ~rounded: rounded :: maybe(Real || matching(#'default)) = #false,
     ~order: order :: OverlayOrder = #'back,
-    ~refocus: refocus_on :: maybe(Pict || matching(#'around)) = #'around,
+    ~refocus: refocus_on :: maybe(Refocus) = #'#,(@rhombus(around, ~value)),
     ~epoch: epoch_align :: EpochAlignment = #'center,
     ~duration: duration_align :: DurationAlignment = #'sustain
   ) :: Pict
@@ -67,7 +66,7 @@
  When the @rhombus(refocus_on) argument is a pict, then
  @rhombus(Pict.refocus) is used on the resulting pict with
  @rhombus(refocus_on) as the second argument. If @rhombus(refocus) is
- @rhombus(#'around) and @rhombus(around) is not @rhombus(#false), then the
+ @rhombus(#'#,(@rhombus(around, ~value))) and @rhombus(around) is not @rhombus(#false), then the
  pict is refocused on @rhombus(around), and then padded if necessary to
  make the width and height match @rhombus(width) and @rhombus(height).
 
@@ -95,11 +94,11 @@
     ~size: size :: Real: if around
                          | math.max(Pict.width(around), Pict.width(around))
                          | 32,
-    ~fill: fill :: MaybeColor = #false,
-    ~line: line :: MaybeColor = !fill && #'inherit,
+    ~fill: fill :: maybe(ColorMode) = #false,
+    ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit,
     ~order: order :: OverlayOrder = #'back,
-    ~refocus: refocus_on :: maybe(Pict || matching(#'around)) = #'around,
+    ~refocus: refocus_on :: maybe(Refocus) = #'#,(@rhombus(around, ~value)),
     ~epoch: epoch_align :: EpochAlignment = #'center,
     ~duration: duration_align :: DurationAlignment = #'sustain
   ) :: Pict
@@ -120,15 +119,14 @@
     ~around: around :: maybe(Pict) = #false,
     ~width: width :: Real: if around | Pict.width(around) | 32,
     ~height: height :: Real: if around | Pict.height(around) | width,
-    ~arc: arc :: maybe(matching(#'cw || #'ccw)) = #false,
+    ~arc: arc :: maybe(ArcDirection) = #false,
     ~start: start :: Real = 0,
     ~end: end :: Real = 2 * math.pi,
-    ~fill: fill :: MaybeColor = #false,
-    ~line: line :: MaybeColor = !fill && #'inherit,
+    ~fill: fill :: maybe(ColorMode) = #false,
+    ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit,
-    ~rounded: rounded :: maybe(Real || matching(#'default)) = #false,
     ~order: order :: OverlayOrder = #'back,
-    ~refocus: refocus_on :: maybe(Pict || matching(#'around)) = #'around,
+    ~refocus: refocus_on :: maybe(Refocus) = #'#,(@rhombus(around, ~value)),
     ~epoch: epoch_align :: EpochAlignment = #'center,
     ~duration: duration_align :: DurationAlignment = #'sustain
   ) :: Pict
@@ -151,15 +149,14 @@
     ~size: size :: Real: if around
                          | math.max(Pict.width(around), Pict.width(around))
                          | 32,
-    ~arc: arc :: maybe(matching(#'cw || #'ccw)) = #false,
+    ~arc: arc :: maybe(ArcDirection) = #false,
     ~start: start :: Real = 0,
     ~end: end :: Real = 2 * math.pi,
-    ~fill: fill :: MaybeColor = #false,
-    ~line: line :: MaybeColor = !fill && #'inherit,
+    ~fill: fill :: maybe(ColorMode) = #false,
+    ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit,
-    ~rounded: rounded :: maybe(Real || matching(#'default)) = #false,
     ~order: order :: OverlayOrder = #'back,
-    ~refocus: refocus_on :: maybe(Pict || matching(#'around)) = #'around,
+    ~refocus: refocus_on :: maybe(Refocus) = #'#,(@rhombus(around, ~value)),
     ~epoch: epoch_align :: EpochAlignment = #'center,
     ~duration: duration_align :: DurationAlignment = #'sustain
   ) :: Pict
@@ -177,8 +174,8 @@
 @doc(
   fun polygon(
     [pt :: draw.PointLike.to_point, ...],
-    ~fill: fill :: MaybeColor = #false,
-    ~line: line :: MaybeColor = !fill && #'inherit,
+    ~fill: fill :: maybe(ColorMode) = #false,
+    ~line: line :: maybe(ColorMode) = !fill && #'inherit,
     ~line_width: line_width :: LineWidth = #'inherit
   ) :: Pict
 ){
@@ -197,7 +194,7 @@
   fun line(
     ~dx: dx :: Real = 0,
     ~dy: dy :: Real = 0,
-    ~line: color :: MaybeColor = #'inherit,
+    ~line: color :: maybe(ColorMode) = #'inherit,
     ~line_width: width :: LineWidth = #'inherit
   ) :: Pict
 ){
@@ -268,7 +265,7 @@
     proc :: Function.of_arity(1),
     ~extent: extent :: NonnegReal = 0.5,
     ~bend: bend = bend.fast_middle,
-    ~sustain_edge: sustain_edge :: matching(#'before || #'after) = #'before
+    ~sustain_edge: sustain_edge :: TimeOrder = #'before
   ) :: Pict
 ){
 
@@ -287,19 +284,55 @@
 }
 
 @doc(
-  annot.macro 'MaybeColor'
+  enum ColorMode:
+    ~is_a Color
+    ~is_a String
+    inherit
 ){
 
- A color specification, either @rhombus(#false), a string, a
- @rhombus(draw.Color) object, or @rhombus(#'inherit).
+ A color specification, where @rhombus(#'inherit) allows the color to be
+ configured externally, such as through @rhombus(Pict.colorize).
 
 }
 
 @doc(
-  annot.macro 'LineWidth'
+  enum LineWidth:
+    ~is_a Real
+    inherit
 ){
 
- A line width specification, either a @rhombus(Real) or
- @rhombus(#'inherit).
+ A line-width specification, where @rhombus(#'inherit) allows the color
+ to be configured externally, such as through @rhombus(Pict.line_width).
+
+}
+
+@doc(
+  enum Refocus:
+    ~is_a Pict
+    around
+){
+
+ Refocusing options for functions like @rhombus(rectangle).
+
+}
+
+
+@doc(
+  enum Rounded:
+    ~is_a Real
+    default
+){
+
+ Corner-rounding options for @rhombus(rectangle).
+
+}
+
+@doc(
+  enum ArcDirection:
+    cw
+    ccw
+){
+
+ Arc directions, clockwise or counterclockwise.
 
 }

--- a/rhombus/pict/scribblings/text.scrbl
+++ b/rhombus/pict/scribblings/text.scrbl
@@ -91,7 +91,7 @@ paragraph typesetting.
 
 @doc(
   fun strikethrough(content :: TextContent, ...,
-                    ~line: line :: MaybeColor = #'inherit,
+                    ~line: line :: ColorMode = #'inherit,
                     ~line_width: line_width :: LineWidth = 3,
                     ~dy: dy = 0) :: Pict
 ){
@@ -148,7 +148,7 @@ paragraph typesetting.
 @doc(
   fun para(content :: TextContent, ...,
            ~width: width = current_para_width(),
-           ~horiz: horiz :: pict.HorizAlignment = #'left,
+           ~horiz: horiz :: HorizAlignment = #'left,
            ~full: full = #false,
            ~decode: decode = #true) :: Pict
 ){
@@ -213,12 +213,12 @@ paragraph typesetting.
   fun item(content :: TextContent, ...,
            ~bullet: bullet :: maybe(Pict) = #false,
            ~width: width = current_para_width(),
-           ~horiz: align :: pict.HorizAlignment = #'left,
+           ~horiz: align :: HorizAlignment = #'left,
            ~full: full = #false) :: Pict
   fun subitem(content :: TextContent, ...,
               ~bullet: bullet :: maybe(Pict) = #false,
               ~width: width = current_para_width(),
-              ~horiz: align :: pict.HorizAlignment = #'left,
+              ~horiz: align :: HorizAlignment = #'left,
               ~full: full = #false) :: Pict
 ){
 

--- a/rhombus/pict/text.rhm
+++ b/rhombus/pict/text.rhm
@@ -6,7 +6,7 @@ import:
     expose:
       Pict
       HorizAlignment
-      MaybeColor
+      ColorMode
       LineWidth
   lib("pict/main.rkt") as rkt_pict
   lib("racket/string.rkt")
@@ -132,7 +132,7 @@ fun superscript(arg :: TextContent, ...) :~ Pict:
   let p = t(arg, ...)
   p.lift(p.height/3).scale(0.75)
 
-fun strikethrough(~line: line :: MaybeColor = #'inherit,
+fun strikethrough(~line: line :: ColorMode = #'inherit,
                   ~line_width: line_width :: LineWidth = 3,
                   ~dy: dy = 0,
                   arg :: TextContent, ...) :~ Pict:

--- a/rhombus/private/core-derived.rkt
+++ b/rhombus/private/core-derived.rkt
@@ -9,4 +9,5 @@
         "where.rhm"
         "described_as.rhm"
         "sequence.rhm"
-        "class_together.rhm")
+        "class_together.rhm"
+        "enum.rhm")

--- a/rhombus/private/enum.rhm
+++ b/rhombus/private/enum.rhm
@@ -1,0 +1,59 @@
+#lang rhombus/private/core
+import:
+  "core-meta.rkt" open
+  "symbol.rkt"!#{for-static-info}.#{symbol-static-infos}
+
+use_static
+
+export:
+  enum
+
+defn.macro 'enum $(name :: IdentifierName):
+              $clause
+              ...':
+  ~all_stx: stx
+  let [[sym, ...], ...]:
+    for List (c: [clause, ...]):
+      match c
+      | '~is_a: $ann; ...': []
+      | '~is_a $ann': []
+      | '$(sym :: Identifier) ...': [sym, ...]
+      | ~else:
+          syntax_meta.error("enumeration body form not an identifier sequence of `~satisfying` clause",
+                            stx,
+                            c)
+  let [[ann, ...], ...]:
+    for List (c: [clause, ...]):
+      match c
+      | '~is_a: $(ann :: annot_meta.Parsed); ...': [ann, ...]
+      | '~is_a $(ann :: annot_meta.Parsed)': [ann]
+      | ~else: []
+  for values(accum :~ Set = Set.by(===){}) (sym: [sym, ..., ...]):
+    if accum[sym.unwrap()]
+    | syntax_meta.error("duplicate enum identifier", stx, sym)
+    | accum ++ { sym.unwrap() }
+  '«namespace $name:
+      export:
+        names:
+          $sym
+          ...
+          ...
+      def $sym = #' $sym
+      ...
+      ...
+      bind.macro '$sym': '#'$sym'
+      ...
+      ...
+    fun is_enum(v):
+      match v
+      | #'$sym: #true
+      | ...
+      | ...
+      | _ :: $ann: #true
+      | ...
+      | ...
+      | ~else: #false
+    annot.macro '$name':
+      annot_meta.pack_predicate('is_enum',
+                                statinfo_meta.unpack(#{symbol-static-infos}))
+    »'

--- a/rhombus/scribblings/ref-enum.scrbl
+++ b/rhombus/scribblings/ref-enum.scrbl
@@ -1,0 +1,48 @@
+#lang scribble/rhombus/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@title{Enumerations}
+
+@doc(
+  defn.macro 'enum $id_name:
+                $enum_clause
+                ...'
+  grammar enum_clause:
+    $id ...
+    ~is_a: $annot; ...
+    ~is_a $annot
+){
+
+ Defines @rhombus(id_name) as a @tech{predicate annotation} and as a
+ namespace, where the namespace exports each @rhombus(id) as the symbol
+ @rhombus(#'id) and as a binding form that matches the symbol
+ @rhombus(#'id). The annotation is satisfied by each symbol
+ @rhombus(#'id) and by values satisfying any of the @rhombus(annot)s
+ specified with @rhombus(~is_a).
+
+@examples(
+  ~defn:
+    enum Mouse:
+      itchy
+      mickey minnie
+      jerry
+  ~repl:
+    Mouse.itchy
+    #'itchy is_a Mouse
+    #'scratchy is_a Mouse
+    match #'jerry
+    | Mouse.itchy: "scratchy"
+    | Mouse.jerry: "tom"
+  ~defn:
+    enum Cat:
+      ~is_a String
+      scratchy
+      tom
+  ~repl:
+    Cat.tom is_a Cat
+    "Felix" is_a Cat
+)
+
+}

--- a/rhombus/scribblings/reference.scrbl
+++ b/rhombus/scribblings/reference.scrbl
@@ -64,6 +64,8 @@
 @include_section("ref-dot.scrbl")
 @include_section("ref-values.scrbl")
 @include_section("ref-annotation.scrbl")
+@include_section("ref-enum.scrbl")
+
 @include_section("ref-io.scrbl")
 @include_section("ref-eval.scrbl")
 @include_section("ref-stxobj.scrbl")

--- a/rhombus/slideshow.rhm
+++ b/rhombus/slideshow.rhm
@@ -66,7 +66,11 @@ fun titlet(a, ...) :~ Pict:
 
 // ----------------------------------------
 
-annot.macro 'SlideLayout': 'matching(#'auto || #'center || #'top || #'tall)'
+enum SlideLayout:
+  auto
+  center
+  top
+  tall
 
 fun slide(~title: title :: maybe(String || Pict) = #false,
           ~name: name = title,

--- a/rhombus/slideshow/scribblings/slide.scrbl
+++ b/rhombus/slideshow/scribblings/slide.scrbl
@@ -210,12 +210,15 @@
 }
 
 @doc(
-  annot.macro 'SlideLayout'
+  enum SlideLayout:
+    auto
+    center
+    top
+    tall
 ){
 
- Recognizes a slide layout that is used with @rhombus(slide) and
- @rhombus(current_assembler): @rhombus(#'auto), @rhombus(#'center),
- @rhombus(#'top), or @rhombus(#'tall).
+ Slide layout options used with @rhombus(slide) and
+ @rhombus(current_assembler).
 
 }
 

--- a/rhombus/tests/enum.rhm
+++ b/rhombus/tests/enum.rhm
@@ -1,0 +1,82 @@
+#lang rhombus
+
+enum RainbowColor:
+  red
+  orange
+  yellow
+  green
+  blue
+  indigo
+  violet
+
+check RainbowColor.red ~is #'red
+check RainbowColor.violet ~is #'violet
+
+check #'red is_a RainbowColor ~is #true
+check #'pink is_a RainbowColor ~is #false
+check "red" is_a RainbowColor ~is #false
+
+check:
+  match #'red
+  | _ :: RainbowColor: "yes"
+  | ~else: "no"
+  ~is "yes"
+
+check:
+  match #'pink
+  | _ :: RainbowColor: "yes"
+  | ~else: "no"
+  ~is "no"
+
+check:
+  match "red"
+  | _ :: RainbowColor: "yes"
+  | ~else: "no"
+  ~is "no"
+
+check:
+  match #'red
+  | RainbowColor.red: "yes"
+  | ~else: "no"
+  ~is "yes"
+
+check:
+  match #'blue
+  | RainbowColor.red: "yes"
+  | ~else: "no"
+  ~is "no"
+
+check:
+  match #'blue
+  | RainbowColor.red: "yes"
+  | RainbowColor.blue: "now yes"
+  | ~else: "no"
+  ~is "now yes"
+
+enum CrayonColor:
+  ~is_a RainbowColor
+  black
+  white
+
+check #'red is_a CrayonColor ~is #true
+check #'pink is_a CrayonColor ~is #false
+check "red" is_a CrayonColor ~is #false
+check #'white is_a CrayonColor ~is #true
+check #'white is_a RainbowColor ~is #false
+
+check:
+  match #'white
+  | _ :: RainbowColor: "rainbow"
+  | _ :: CrayonColor: "crayon"
+  ~is "crayon"
+
+check:
+  match #'blue
+  | _ :: RainbowColor: "rainbow"
+  | _ :: CrayonColor: "crayon"
+  ~is "rainbow"
+
+check:
+  match #'white
+  | CrayonColor.white: "crayon"
+  ~is "crayon"

--- a/scribble/private/doc.rkt
+++ b/scribble/private/doc.rkt
@@ -22,11 +22,22 @@
   (provide (property-out doc-transformer)
            make-doc-transformer)
 
-  (property doc-transformer (extract-desc
-                             extract-space-sym
-                             extract-defined
-                             extract-metavariables
-                             extract-typeset))
+  ;; For each function in a `doc-transformer`, a `*` means that
+  ;; the value can be one of those, or it can be a list. Values
+  ;; must all be either one of those of a list, and lists need
+  ;; to have the same length. When a list is returned by
+  ;; `extract-space-sym`, only the first element is bounced back,
+  ;; since bouncing back is just a convenience for abstracting over
+  ;; those other handlers.
+  (property doc-transformer (extract-desc       ; stx -> (kind-str)*
+                             extract-space-sym  ; stx -> (space-sym-or-#f)*  ; only first result bounced back
+                             extract-defined    ; stx space-sym-or-#f -> (def-name)* ; see below
+                             extract-metavariables ; stx space-sym-or-#f sym-set -> sym-set ; adds to given set
+                             extract-typeset))  ; stx (space-sym-of-#f)* (stx -> stx)* -> stx
+  ;; A `def-name` as returned by `extract-defined` is one of
+  ;;  - identifier                 ; normal reference in relevant space
+  ;;  - (list root-id typeset-id)  ; `typeset-id` within namespace `root-id`
+  ;;  - (list root-id typeset-id key-str) ; ditto, but key for indexing is `key-str`, not raw-string form of `typeset-id`
 
   (define (make-doc-transformer #:extract-desc extract-desc 
                                 #:extract-space-sym extract-space-sym

--- a/scribble/private/rhombus-spacer.rhm
+++ b/scribble/private/rhombus-spacer.rhm
@@ -49,6 +49,7 @@ export:
     $
     pattern
     Parameter
+    enum
 
 module for_doc:
   export:
@@ -992,3 +993,22 @@ spacer.bridge pattern(self, tail, context, esc):
 spacer.bridge Parameter.def(self, tail, context, esc):
   ~in: ~defn
   '$self $(adjust_field(tail, esc))'
+
+spacer.bridge enum(self, tail, context, esc):
+  ~in: ~defn
+  match tail
+  | '$e ...: $(body :: Block)':
+      let [new_clause, ...]:
+        match body
+        | ': $clause; ...':
+            for List (clause: [clause, ...]):
+              match clause
+              | '$(tag && '~is_a'): $(b :: Block)':
+                 '$tag $(spacer.adjust_term(b, #'~annot, esc))'.relocate(clause)
+              | '$(tag && '~is_a') $seq':
+                 '$tag $(spacer.adjust_sequence(seq, #'~annot, esc))'.relocate(clause)
+              | ~else:
+                  spacer.set_group(clause, #'~datum)
+      let new_body = ': $new_clause; ...'.relocate(body)
+      '$self $e ... $new_body'
+  | ~else: '$self $tail'

--- a/scribble/private/spacer.rhm
+++ b/scribble/private/spacer.rhm
@@ -13,11 +13,12 @@ export:
     adjust_multi
     rename:
       set_space as set
+      set_group_space as set_group
   bridge
   typeset_meta.typeset
     
 meta:
-  fun set_space(stx, context):
+  fun set_space(stx, context) :~ Syntax:
     let context:
       match context
       | context :: Keyword:
@@ -31,6 +32,15 @@ meta:
         Syntax.property(stx, #'#{typeset-space-name}, context, #true)
     | '$(t :: Term) ...':
         '$(Syntax.property(t, #'#{typeset-space-name}, context, #true)) ...'.relocate(stx)
+
+  fun set_group_space(stx, context) :~ Syntax:
+    match stx
+    | '$(_ :: Term)':
+        // `set_space` won't relocate group
+        match set_space(stx, context)
+        | '$(g :: Group)': g.relocate(stx)
+    | ~else:
+        set_space(stx, context)
 
   fun find_relevant_context(context, in_contexts :~ List):
     let nows :~ PairList = #{full-space-names}(context)

--- a/scribble/private/typeset-help.rkt
+++ b/scribble/private/typeset-help.rkt
@@ -33,9 +33,10 @@
                   t))
   (syntax-raw-prefix-property t/s (syntax-raw-prefix-property pre)))
 
-;; returns #f or (list target rest space-name)
+;; returns #f or (hash 'taget target 'remains rest 'space space-name 'raw default-raw)
 (define-for-syntax (resolve-name-ref space-names root fields
-                                     #:parens [ptag #f])
+                                     #:parens [ptag #f]
+                                     #:raw [given-raw #f])
   (let loop ([root root] [fields fields])
     (cond
       [(null? fields) #f]
@@ -78,7 +79,7 @@
                                             (or (syntax-raw-suffix-property p) '())
                                             (syntax-raw-tail-suffix-property ptag)))
              p))
-       (define (add-rest p) (and p (list p (cdr fields) space-name)))
+       (define (add-rest p) (and p (hash 'target p 'remains (cdr fields) 'space space-name 'raw raw)))
        (cond
          [dest
           (define loc-stx
@@ -89,7 +90,7 @@
           (define named-dest
             (transfer-parens-suffix
              (syntax-raw-property (datum->syntax dest (syntax-e dest) loc-stx loc-stx)
-                                  raw)))
+                                  (or given-raw raw))))
           (or (loop named-dest (cdr fields))
               (add-rest named-dest))]
          [else
@@ -102,6 +103,6 @@
                                                  'loc-stx
                                                  (append-consecutive-syntax-objects 'loc-stx root #'dot)
                                                  field))
-                                 raw))])
+                                 (or given-raw raw)))])
                  (or (loop named-id (cdr fields))
                      (add-rest named-id))))])])))

--- a/scribble/private/typeset-rhombus.rkt
+++ b/scribble/private/typeset-rhombus.rkt
@@ -520,19 +520,19 @@
                         (extract-ptag a)))])))
      (define use-space-names (id-space-name (car elems) space-names
                                             #:as-list? #t))
-     (define target+rest+space (resolve-name-ref use-space-names
+     (define resolved (resolve-name-ref use-space-names
                                                  (if (pair? (cdr elems))
                                                      (add-space (car elems)
                                                                 'rhombus/namespace)
                                                      (car elems))
                                                  dotted-elems
                                                  #:parens ptag))
-     (define target (and target+rest+space (car target+rest+space)))
+     (define target (and resolved (hash-ref resolved 'target)))
      (cond
        [target
-        (define skip (add1 (* 2 (- (length dotted-elems) (length (cadr target+rest+space))))))
+        (define skip (add1 (* 2 (- (length dotted-elems) (length (hash-ref resolved 'remains))))))
         (define id (car elems))
-        (define space-name (caddr target+rest+space))
+        (define space-name (hash-ref resolved 'space))
         (cons (datum->syntax target
                              (element tt-style
                                (make-id-element (add-space id (if (pair? (cdr elems))

--- a/scribble/tests/rhombus-spacer.rhm
+++ b/scribble/tests/rhombus-spacer.rhm
@@ -50,6 +50,9 @@ defn.macro '(def_unquote.full) $name':
 
 def_unquote none: #false
 def_unquote datum: #false
+namespace datum:
+  export: explicit
+  def_unquote explicit: #'#{datum}
 def_unquote value: #'#{value}
 
 def body_spaces = PairList[#'#{rhombus/defn}, #false]
@@ -1416,3 +1419,35 @@ check_spacer:
   Parameter.def color
     :: String:
       "red"
+
+check_spacer:
+  enum Mouse:
+    itchy
+    mickey minnie
+    jerry
+  $(defn.full) $none:
+    $(datum.explicit)
+    $(datum.explicit) $(datum.explicit)
+    $(datum.explicit)
+
+check_spacer:
+  enum Cat:
+    ~is_a String
+    scratchy
+    tom
+  $(defn.full) $none:
+    ~is_a $annot
+    $(datum.explicit)
+    $(datum.explicit)
+
+check_spacer:
+  enum Cat:
+    ~is_a:
+      String
+    scratchy
+    tom
+  $(defn.full) $none:
+    ~is_a:
+      $annot
+    $(datum.explicit)
+    $(datum.explicit)


### PR DESCRIPTION
As an example,

```
HorizAlignment:
  left
  center
  right
```

defines `HorizAlignment` as an annotaton that is satisfied by `#'left`, `#'center`, and `#'right`, and it also defines `HorizAlignment.left`, `HorizAlignment.center`, and `HorizAlignment.right` as expressions bound to those symbols and as binding forms that match those symbols.

Sometimes, enumerated symbols are combined with other datatypes. Although a union of an enumerated datatype with other annotations could cover that case, `enum` provides direct support through `~is_a` clauses that add other annotations directly to the enumeration. Here's an example:

```
enum LineWidth:
  ~is_a Real
  inherit
```

The `pict` and `slideshow` libraries now use `enum` for various enumerations instead of a hand-rolled annotation.