### PR TITLE
experiment: `_` shorthand for anonymous functions

### DIFF
--- a/rhombus/private/context-stx.rkt
+++ b/rhombus/private/context-stx.rkt
@@ -1,0 +1,26 @@
+#lang racket/base
+(require syntax/parse/pre
+         "pack.rkt"
+         "realm.rkt")
+
+(provide extract-ctx)
+
+(define (extract-ctx who ctx-stx
+                     #:false-ok? [false-ok? #t]
+                     #:update [update #f])
+  (and (or (not false-ok?) ctx-stx)
+       (let ([t (and (syntax? ctx-stx)
+                     (unpack-term ctx-stx #f #f))])
+         (unless t
+           (raise-argument-error* who rhombus-realm (if false-ok? "maybe(Term)" "Term") ctx-stx))
+         (syntax-parse t
+           #:datum-literals (op)
+           [((~and tag op) id) (if update
+                                   (datum->syntax t (list #'tag (update #'id)) t t)
+                                   #'id)]
+           [(head . tail) (if update
+                              (datum->syntax t (cons (update #'head) #'tail) t t)
+                              #'head)]
+           [_ (if update
+                  (update t)
+                  t)]))))

--- a/rhombus/private/core-derived.rkt
+++ b/rhombus/private/core-derived.rkt
@@ -10,4 +10,5 @@
         "described_as.rhm"
         "sequence.rhm"
         "class_together.rhm"
-        "enum.rhm")
+        "enum.rhm"
+        "pipeline.rhm")

--- a/rhombus/private/dot-parse.rkt
+++ b/rhombus/private/dot-parse.rkt
@@ -40,10 +40,11 @@
     (define (nary mask direct-id id)
       (ary mask
            (lambda (args reloc)
-             (define-values (proc tail)
+             (define-values (proc tail to-anon-function?)
                (parse-function-call direct-id (list lhs) #`(#,dot #,args)
                                     #:srcloc (reloc #'#false)
-                                    #:static? more-static?))
+                                    #:static? more-static?
+                                    #:can-anon-function? #t))
              proc)
            ;; return partially applied method
            (lambda (reloc)

--- a/rhombus/private/dynamic-static-name.rkt
+++ b/rhombus/private/dynamic-static-name.rkt
@@ -1,0 +1,29 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         "implicit.rkt"
+         "dot.rkt"
+         "parse.rkt"
+         "dynamic-static.rkt")
+
+(begin-for-syntax
+  (provide dynamic_call_name
+           dynamic_dot_name
+           dynamic_index_name)
+
+  (define dynamic_call_name #'#%call)
+  (define dynamic_dot_name #'|.|)
+  (define dynamic_index_name #'#%index))
+
+(define-syntax-rule (static)
+  (begin
+    (rhombus-definition (group use_static)) ;; defines `#%dynamism`
+    (begin-for-syntax
+      (provide static_call_name
+               static_dot_name
+               static_index_name)
+
+      (define static_call_name #'#%call)
+      (define static_dot_name #'|.|)
+      (define static_index_name #'#%index))))
+
+(static)

--- a/rhombus/private/is-static.rkt
+++ b/rhombus/private/is-static.rkt
@@ -17,7 +17,7 @@
 
 (define-syntax #%static invalid-as-expression)
 (define-syntax #%dynamic invalid-as-expression)
-  
+
 (define-for-syntax (is-static-context? tag)
   (free-identifier=? (datum->syntax tag '#%dynamism)
                      (expr-quote #%static)))

--- a/rhombus/private/pipeline.rhm
+++ b/rhombus/private/pipeline.rhm
@@ -1,0 +1,29 @@
+#lang rhombus/private/core
+import:
+  "core-meta.rkt" open
+
+use_static
+
+export:
+  |>
+
+expr.macro '$arg |> $func':
+  ~op_stx: self
+  ~weaker_than: ~other
+  // Convert to a dynamic or static call:
+  let call:
+    if statinfo_meta.is_static(self)
+    | statinfo_meta.static_call_name
+    | statinfo_meta.dynamic_call_name
+  // The expansion:
+  let expr:
+    'block:
+       let arg = $arg
+       $func $call (arg)'
+  // Propagate static information, if any, for the call result:
+  let ress = statinfo_meta.lookup(func, statinfo_meta.call_result_key)
+  let ress: if ress | statinfo_meta.unpack_call_result(ress) | []
+  let [_, unpacked_res]:
+    ress.find(fun ([mask, unpacked_info]): mask bits.and 2)
+      || [-1, '()']
+  statinfo_meta.wrap(expr, unpacked_res)

--- a/rhombus/private/syntax-object.rkt
+++ b/rhombus/private/syntax-object.rkt
@@ -24,7 +24,8 @@
          (submod "srcloc-object.rkt" for-static-info)
          (submod "string.rkt" static-infos)
          (submod "list.rkt" for-compound-repetition)
-         "parens.rkt")
+         "parens.rkt"
+         "context-stx.rkt")
 
 (provide (for-spaces (rhombus/namespace
                       rhombus/annot)
@@ -187,26 +188,6 @@
         (values #'(quote-syntax g) #'tail)]))))
 
 ;; ----------------------------------------
-
-(define (extract-ctx who ctx-stx
-                     #:false-ok? [false-ok? #t]
-                     #:update [update #f])
-  (and (or (not false-ok?) ctx-stx)
-       (let ([t (and (syntax? ctx-stx)
-                     (unpack-term ctx-stx #f #f))])
-         (unless t
-           (raise-argument-error* who rhombus-realm (if false-ok? "maybe(Term)" "Term") ctx-stx))
-         (syntax-parse t
-           #:datum-literals (op)
-           [((~and tag op) id) (if update
-                                   (datum->syntax t (list #'tag (update #'id)) t t)
-                                   #'id)]
-           [(head . tail) (if update
-                              (datum->syntax t (cons (update #'head) #'tail) t t)
-                              #'head)]
-           [_ (if update
-                  (update t)
-                  t)]))))
 
 (define (starts-alts? ds)
   (and (pair? ds)

--- a/rhombus/private/underscore.rkt
+++ b/rhombus/private/underscore.rkt
@@ -17,7 +17,9 @@
        [(form-id . tail)
         (raise-syntax-error #f
                             (string-append "not allowed as an expression;\n"
-                                           " only allowed as binding pattern or 'else' substitute")
+                                           " only allowed as binding pattern, 'else' substitute,"
+                                           " or anonymous-function\n"
+                                           " argument (and use isn't an allowed position to create a function)")
                             #'form-id)]))))
 
 (define-binding-syntax rhombus-_

--- a/rhombus/private/unquote-binding-primitive.rkt
+++ b/rhombus/private/unquote-binding-primitive.rkt
@@ -80,7 +80,7 @@
                            "syntax class expects arguments"
                            stx-class)]
       [else
-       (define-values (call empty-tail)
+       (define-values (call empty-tail to-anon-function?)
          (parse-function-call rator-in '() #`(#,stx-class #,class-args)
                               #:static? #t
                               #:rator-stx stx-class

--- a/rhombus/scribblings/datatype.scrbl
+++ b/rhombus/scribblings/datatype.scrbl
@@ -15,3 +15,4 @@ collections through repetition and iteration forms.
 @include_section("repetition.scrbl")
 @include_section("for.scrbl")
 @include_section("more-arguments.scrbl")
+@include_section("function-shorthand.scrbl")

--- a/rhombus/scribblings/function-shorthand.scrbl
+++ b/rhombus/scribblings/function-shorthand.scrbl
@@ -1,0 +1,84 @@
+#lang scribble/rhombus/manual
+@(import:
+    "common.rhm" open)
+
+@title(~tag: "function-shorthand"){Function Shorthand and Pipelines}
+
+Functions are values, and they can be passed to other functions. For
+example, the @rhombus(List.find) function (which can be called
+equivalently as a @rhombus(fiind) method on a list) takes a predicate as
+a function to determine which value to return, the @rhombus(List.map)
+function (or @rhombus(map) method) takes a function to apply to each
+element, and @rhombus(List.sort) (or @rhombus(sort) method), takes a
+comparison function to determine when one element should be before
+another.@margin_note{The @rhombus(List.map) method is about mapping a
+ function over a list to produce a new list, and not about the
+ @rhombus(Map, ~annot) datatype.}
+
+@examples(
+  List.find([1, 3, 2], fun (x): x > 2)
+  [1, 3, 2].find(fun (x): x > 2)
+  [1, 3, 2].map(fun (x): x + 1)
+  [1, 3, 2].sort(fun (x, y): x > y)
+)
+
+We cannot pass @rhombus(>) directly to @rhombus(sort), because the
+operator @rhombus(>) is not an expression by itself. Simple functions
+that use operators, however, can be written with a shorthand of
+@rhombus(_) within @parens:
+
+@examples(
+  List.find([1, 3, 2], (_ > 2))
+  [1, 3, 2].find((_ > 2))
+  [1, 3, 2].map((_ + 1))
+  [1, 3, 2].sort((_ > _))
+)
+
+Each immediate @rhombus(_) in a @parens expression is turned into a
+distinct argument for an anonymous function that replaces the
+parenthesized expression. ``Immediate'' here means that the @rhombus(_)
+is not nested more deeply within the @parens, such as being in a block
+or under more parentheses. As the last example above illustrates,
+@parens plus @rhombus(_) is a general way to turn on operator into a
+function.
+
+Another form of the @rhombus(_) shorthand is like a function call, but
+where at least one argument in the call is exactly @rhombus(_) (not
+combined with other terms). Similar to the conversion for @parens, each
+separate @rhombus(_) becomes an argument to the function.
+
+@examples(
+  [1, 3, 2].map(math.max(_, 2))
+  [[1, 3, 2], [6, 0, 5]].map(List.sort(_, fun (x, y): x > y))
+  [[1, 3, 2], [6, 0, 5]].map(List.sort(_, (_ > _)))
+)
+
+The @rhombus(_) shorthand notations are designed to be relatively
+unlikely to collide with an expression form, because @rhombus(_) by
+itself as an expression is a syntax error. For example,
+@rhombus(math.max(_, 2)) by itself is a syntax error. (Also,
+@rhombus(_, ~bind) as a binding form matches without binding a name, so
+@rhombus(_) is not easy to bind locally. The shorthand is limited,
+however, and intended only for the simplest of cases. Fall back to
+@rhombus(fun) at the first sign of trouble.
+
+@examples(
+  ~error:
+    [1, 3, 2].map(2 * (_ + 1))
+  [1, 3, 2].map(fun (x): 2 * (x + 1))
+)
+
+Function shorthands with @rhombus(_) can be particularly useful with the
+@rhombus(|>) operator, which takes an argument and a function and calls
+the function on the argument. The @rhombus(|>) operator is
+left-associative with low precedence, so it can form @deftech{pipelines}
+of function calls.
+
+@examples(
+  -1 |> math.abs
+  -1 |> math.abs |> (_ * 2)
+  [3, 1, 2]
+    |> List.sort(_)
+    |> ([0] ++ _ ++ [100])
+    |> (_.map(to_string))
+)

--- a/rhombus/scribblings/ref-function.scrbl
+++ b/rhombus/scribblings/ref-function.scrbl
@@ -59,6 +59,7 @@ normally bound to implement function calls.
 
   expr.macro '$fun_expr #%call ($arg, ...)'
   repet.macro '$fun_expr #%call ($repet_arg, ...)'
+  expr.macro '$fun_expr #%call ($arg, ..., _, $arg, ...)'
 
   grammar arg:
     $arg_expr
@@ -91,6 +92,11 @@ normally bound to implement function calls.
   keyword-value pairs are passed into the function as additional keyword
   arguments.
 
+ The case with an immediate @rhombus(_) group among other
+ @rhombus(arg)s is a special case for a function shorthand, and it takes
+ precedence over parsing the @rhombus(_) as an @rhombus(arg). See
+ @rhombus(_) for more information.
+
  See also @rhombus(use_static).
 
  @see_implicit(@rhombus(#%call), @parens, "expression", ~is_infix: #true)
@@ -98,6 +104,30 @@ normally bound to implement function calls.
 @examples(
   List.length([1, 2, 3])
   List.length #%call ([1, 2, 3])
+)
+
+}
+
+
+@doc(expr.macro '$arg |> $fun'){
+
+ The @rhombus(|>) operator applies its second argument as a function to
+ its first argument. That is, @rhombus(arg |> fun) is equivalent to
+ @rhombus(fun(arg)). The conversion is performed syntactically so that
+ static checking and propoagation of static information may apply, but
+ @rhombus(arg) and @rhombus(fun) are parsed as pressions before the
+ conversion. The @rhombus(|>) operator declares weaker precedence than
+ all other operators.
+
+ A @rhombus(_) function shorthand can be especially useful with
+ @rhombus(|>).
+
+@examples(
+  [1, 2, 3] |> List.length
+  [3, 1, 2]
+    |> List.sort(_)
+    |> ([0] ++ _ ++ [100])
+    |> to_string.map(_)
 )
 
 }
@@ -361,6 +391,10 @@ Only one @rhombus(~& map_bind) can appear in a @rhombus(rest) sequence.
     ~error:
       things_to_say("Nachos")
 )
+
+ See also @rhombus(_) for information about function shorthands using
+ @rhombus(_). For example, @rhombus((_ div _)) is a shorthand for
+ @rhombus(fun (x, y): x div y).
 
 }
 

--- a/rhombus/scribblings/ref-implicit.scrbl
+++ b/rhombus/scribblings/ref-implicit.scrbl
@@ -91,6 +91,7 @@ Here are all of the implicit forms:
   expr.macro '#%parens ($expr)'
   bind.macro '#%parens ($bind)'
   annot.macro '#%parens ($annot)'
+  expr.macro '#%parens ($term ... _ $term ...)'
 ){
 
 @provided_also_meta()
@@ -98,6 +99,11 @@ Here are all of the implicit forms:
  Produces the same value as @rhombus(expr), same binding as
  @rhombus(bind), and so on. Multiple expression, bindings, etc.,
  are disallowed.
+
+ The expression case with an immediate @rhombus(_) in parentheses among
+ other @rhombus(term)s is a special case for a function shorthand, and it
+ takes precedence over parsing the parenthesized sequence as an
+ @rhombus(expr). See @rhombus(_) for more information.
 
 @examples(
   (1+2)

--- a/rhombus/scribblings/ref-match.scrbl
+++ b/rhombus/scribblings/ref-match.scrbl
@@ -3,6 +3,9 @@
     "common.rhm" open
     "nonterminal.rhm" open)
 
+@(def var_term = @rhombus(term, ~var))
+@(def var_id = @rhombus(id, ~var))
+
 @title{Matching}
 
 @doc(
@@ -96,7 +99,6 @@
 
 }
 
-
 @doc(
   bind.macro '_'
 ){
@@ -111,6 +113,61 @@
 
 }
 
+
+@doc(
+  expr.macro '_'
+){
+
+ As an expression by itself, @rhombus(_) is a syntax error, but
+ @rhombus(_) is recognized by @rhombus(#%parens) and @rhombus(#%call) in
+ expression-like positions to trigger a function-shorthand conversion.
+
+ The @rhombus(#%parens) conversion applies when @parens are used in an
+ expression position, and at least one @rhombus(_) appears immediately
+ within the parentheses as in
+ @rhombus((#,(var_term) ... _ #,(var_term) ...)). An @defterm{immediate}
+ @rhombus(_) is one that is not more deeply nested in a term within the
+ parentheses. A single immediate @rhombus(_) is replaced by a fresh
+ identifier @var_id as an expression, and then the parenthesized sequence
+ is placed in the body of a function that uses the identifier as an
+ argument, as in
+ @rhombus((fun (#,(var_id)): #,(var_term) ... #,(var_id) #,(var_term) ...)).
+ If multiple immediate @rhombus(_)s are present, each one is replaced by
+ a distinct identifier, the identifiers are used as the arguments of the
+ generated function, and the arguments match the order of the
+ corresponding @rhombus(_).
+
+@examples(
+  ~repl:
+    def subtract = (_ - _)
+    subtract(2, 1)
+    [1, 2, 3].map((_ + 1))
+)
+
+ The @rhombus(#%call) conversion applies when @parens are used after an
+ expression, at least one @rhombus(_) appears by itself as an argument,
+ and no argument uses @rhombus(&) or is a repetition followed by a
+ @rhombus(...). Each @rhombus(_) argument is converted as in the
+ @rhombus(#%parens) conversion, but the conversion applies only for a
+ @rhombus(_) that appears by itself in the group for function-call
+ argument.
+
+@examples(
+  ~repl:
+    def low_bits = bits.field(_, 0, 3)
+    low_bits(15)
+    [1.25, 2.75, 3.0].map(math.round(_))
+)
+
+ A @rhombus(_) combined with other terms as a function-call
+ argument @emph{does not} trigger a function-shorthand conversion.
+
+@examples(
+  ~error:
+    [1, 2, 3].map(_ + 1)
+)
+
+}
 
 @doc(
   ~nonterminal:

--- a/rhombus/scribblings/ref-static-info.scrbl
+++ b/rhombus/scribblings/ref-static-info.scrbl
@@ -109,6 +109,32 @@
 
 }
 
+@doc(
+  fun statinfo_meta.pack_call_result([[arity_mask :: Int,
+                                       statinfo_stx :: Syntax],
+                                      ...])
+    :: Syntax
+  fun statinfo_meta.unpack_call_result(statinfo_stx :: Syntax)
+    :: matching([[_ :: Int, _ :: Syntax], ...])
+){
+
+ @provided_meta()
+
+ Analogous to @rhombus(statinfo_meta.pack) and
+ @rhombus(statinfo_meta.unpack), but for information that represents
+ function-call results, where a result may be specific to different
+ numbers of arguments. Information of this shape is used with
+ @rhombus(statinfo_meta.call_result_key).
+
+ Each @rhombus(arity_mask) has a bit set for each number of arguments
+ where the associated @rhombus(statinfo_stx) describes the function
+ result. For example, a @tech{property} or @tech{context parameter}
+ function may have a result that depends on the number of argument it
+ receives. A mask of @rhombus(-1) indicates a result that applies for any
+ number of arguments. Each @rhombus(statinfo_stx) represents static
+ information for the result in unpacked form.
+
+}
 
 @doc(
   fun statinfo_meta.lookup(expr_stx :: Syntax,
@@ -199,7 +225,6 @@
 }
 
 
-
 @doc(
   def statinfo_meta.call_result_key :: Identifier
   def statinfo_meta.index_result_key :: Identifier
@@ -220,9 +245,9 @@
 
  @itemlist(
 
-  @item{@rhombus(statinfo_meta.call_result_key) --- packed static
+  @item{@rhombus(statinfo_meta.call_result_key) --- packed, per-arity static
         information for the result value if the expression is used as
-        a function to call}
+        a function to call; see @rhombus(statinfo_meta.unpack_call_result)}
 
   @item{@rhombus(statinfo_meta.index_result_key) --- packed static information
         for the result value if the expression is used with
@@ -284,6 +309,35 @@
 
 }
 
+
+@doc(
+  fun statinfo_meta.is_static(context_stx :: Term) :: Boolean
+){
+
+ Reports whether the environment of @rhombus(context_stx) indicates
+ static or dynamic mode. See also @rhombus(use_static).
+
+}
+
+
+@doc(
+  def statinfo_meta.static_call_name :: Name
+  def statinfo_meta.static_dot_name :: Name
+  def statinfo_meta.static_index_name :: Name
+  def statinfo_meta.dynamic_call_name :: Name
+  def statinfo_meta.dynamic_dot_name :: Name
+  def statinfo_meta.dynamic_index_name :: Name
+){
+
+ @provided_meta()
+
+ Names that are bound to @rhombus(#%call), @rhombus(.), and
+ @rhombus(#%index) in static and dynamic modes, respectively. A macro
+ might select among these using @rhombus(statinfo_meta.is_static) or
+ using the @rhombus(~is_static) argument for a @rhombus(dot.macro)
+ definition.
+
+}
 
 @doc(
   class_clause.macro 'static_info: $body; ...'

--- a/rhombus/tests/underscore_fun.rhm
+++ b/rhombus/tests/underscore_fun.rhm
@@ -1,0 +1,60 @@
+#lang rhombus
+
+check:
+  (_ + _) ~is_a Function.of_arity(2)
+  (! _) ~is_a Function.of_arity(1)
+  List.cons(_, _) ~is_a Function.of_arity(2)
+  List(_, _, _) ~is_a Function.of_arity(3)
+
+check:
+  let plus = (_ + _)
+  plus(1, 2)
+  ~is 3
+
+check:
+  let three = List(_, _, _)
+  three(1, 2, 4)
+  ~is [1, 2, 4]
+
+check:
+  [1, 2, 3] |> List.reverse ~is [3, 2, 1]
+  100 |> (3 * _) ~is 300
+
+check:
+  [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    |> List.length
+    |> math.sqrt
+    |> to_string
+  ~is "3"
+
+check:
+  [1, 2, 3].map((- _)) ~is [-1, -2, -3]
+  (- _).map([1, 2, 3]) ~is [-1, -2, -3]
+  [1, 2, 3] |> (- _).map(_) ~is [-1, -2, -3]
+
+check:
+  ~eval
+  (_ . _)
+  ~throws ".: expected an identifier for a field or method name"
+
+check:
+  use_static
+  class Posn(x, y)
+  fun get(n) :~ Posn: Posn(1, 2)
+  (0 |> get).x
+  ~is 1
+
+check:
+  class Posn(x, y)
+  fun get(n, m) :~ Posn: Posn(1, 2)
+  (0 |> get).x
+  ~throws "arity mismatch"
+
+check:
+  ~eval
+  use_static
+  class Posn(x, y)
+  fun get(n, m) :~ Posn: Posn(1, 2)
+  (0 |> get).x
+  ~throws values("wrong number of arguments",
+                 "based on static information")


### PR DESCRIPTION
This is an implementation experiment (no docs, only a few illustrative tests) for an anonymous-function shorthand. I'm not especially attached to this proposal, but it seems like it could work, and maybe it will provoke better ideas.

In this experiment, two forms expand to a function:

* When the terms enclosed by an expression `()` include an immediate `_`, the `()` form (more precisely, the `#%parens` form) expands to an anonymous function, and each `_` is a distinct argument. So, for example `(_ + _)` is a function that takes two arguments and adds them.
* When a function-call expression form has an argument that is just `_`, then the function call (more precisely, the `#%call` form) expands to an anonymous function that contains the call, and each argument that is just `_` becomes an argument to that enclosing function. So, `List.cons(_, [1, 2, 3])` is a function equivalent to `fun (x): List.cons(x, [1, 2, 3])`. This conversion does not apply to a function call that has spliced arguments or `...`s.

The conversion in either case here works at the level of shrubbery, not parsed content. For example, `(1 2 % _)` will turn into something like `fun (x): (1 2 % x)` independent of whether a variable `x` makes sense after the `%` operator. However, that `x` to replace `_` is injected as an already parsed expression, so it won't be misused as a plain identifier or symbol. For example, `(_ . _)` or `(#' _)` expands into a syntax error, and not a function that looks up an field with an unspecified name or a quote form that returns a symbol with a name derived from a generated argument.

I think the function-call approach here is similar to mflatt/shrubbery-rhombus-0#4, but the operator approach is different.

There is no guarantee that the `_` conversion is unambiguous. For example, to get the same behavior from `(#' _)` before this patch, you might resort to `values(#' _)` to produce the symbol whose name is an underscore. As another potential example, suppose there's a `with` form using the syntax `with <bind> = <expr>: <body>`; in that case, `(with _ = ignored(): "result")` would not parse as intended. I don't think there are any forms that have a shape like `with` right now, and so we could conceivably just avoid creating forms that risk ambiguity, but I might have overlooked more interesting problems that exists already.

More examples:

 * `(1 + 2 * _)` is like `fun (x): 1 + 2 * x`
 * `((_ + 1) * 2)` would try to multiply a function by 2, so the shorthand just doesn't work
 * `(if _ | 1 | 2)` is like `fun (x): if x | 1 | 2`
 * `(if _ | _ | _)` is a syntax error, because the second and third `_` are inside blocks and not immediate in the shrubbery structure within the parentheses
 
The patch here also adds `~>` as a threading operator, since `_` shorthands are meant to play well with threading.
```
expr.macro '$arg ~> $func':
  '(fun (x): $func(x))($arg)'
```

So, `1 ~> (_ + 2)` produces 3, for example.