### PR TITLE
Add `WeakMutableMap` and `WeakMutableSet`; also add `later_of` and `now_of`

### DIFF
--- a/rhombus/private/annotation.rkt
+++ b/rhombus/private/annotation.rkt
@@ -320,6 +320,11 @@
          #`(#,@(info-maker c-static-infoss)
             . #,static-infos))]
        [(c::annotation-binding-form ...)
+        (unless (identifier? binding-maker-id)
+          (raise-syntax-error #f
+                              (or binding-maker-id
+                                  "argument converter annotations are not supported")
+                              new-stx))
         (define c-static-infoss (syntax->list #'(c.static-infos ...)))
         (annotation-binding-form
          (binding-form #'annotation-of-infoer

--- a/rhombus/private/key-comp-primitive.rkt
+++ b/rhombus/private/key-comp-primitive.rkt
@@ -14,34 +14,42 @@
   (key-comp '== #'equal-always-hash?
             #'Map-build #'Map-pair-build #'list->map
             #'mutable-equal-always-hash? #'MutableMap-build
+            #'weak-mutable-equal-always-hash? #'WeakMutableMap-build
             #'#hashalw()
             #'immutable-equal-always-set?
             #'Set-build #'Set-build* #'list->set
-            #'mutable-equal-always-set? #'MutableSet-build))
+            #'mutable-equal-always-set? #'MutableSet-build
+            #'weak-mutable-equal-always-set? #'WeakMutableSet-build))
 
 (define-key-comp-syntax ===
   (key-comp '=== #'object-hash?
             #'ObjectMap-build #'ObjectMap-pair-build #'list->object-map
             #'mutable-object-hash? #'MutableObjectMap-build
+            #'weak-mutable-object-hash? #'WeakMutableObjectMap-build
             #'#hasheq()
             #'immutable-object-set?
             #'ObjectSet-build #'ObjectSet-build* #'list->object-set
-            #'mutable-object-set? #'MutableObjectSet-build))
+            #'mutable-object-set? #'MutableObjectSet-build
+            #'weak-mutable-object-set? #'WeakMutableObjectSet-build))
 
 (define-key-comp-syntax is_now
   (key-comp 'is_now #'now-hash?
             #'NowMap-build #'NowMap-pair-build #'list->now-map
             #'mutable-now-hash? #'MutableNowMap-build 
+            #'weak-mutable-now-hash? #'WeakMutableNowMap-build 
             #'#hash()
             #'immutable-now-set?
             #'NowSet-build #'NowSet-build* #'list->now-set
-            #'mutable-now-set? #'MutableNowSet-build))
+            #'mutable-now-set? #'MutableNowSet-build
+            #'weak-mutable-now-set? #'WeakMutableNowSet-build))
 
 (define-key-comp-syntax is_same_number_or_object
   (key-comp 'is_same_number_or_object #'number-or-object-hash?
             #'NumberOrObjectMap-build #'NumberOrObjectMap-pair-build #'list->number-or-object-map
             #'mutable-number-or-object-hash? #'MutableNumberOrObjectMap-build 
+            #'weak-mutable-number-or-object-hash? #'WeakMutableNumberOrObjectMap-build 
             #'#hasheqv()
             #'immutable-number-or-object-set?
             #'NumberOrObjectSet-build #'NumberOrObjectSet-build* #'list->number-or-object-set
-            #'mutable-number-or-object-set? #'MutableNumberOrObjectSet-build))
+            #'mutable-number-or-object-set? #'MutableNumberOrObjectSet-build
+            #'weak-mutable-number-or-object-set? #'WeakMutableNumberOrObjectSet-build))

--- a/rhombus/private/key-comp-property.rkt
+++ b/rhombus/private/key-comp-property.rkt
@@ -4,12 +4,14 @@
          custom-map
          custom-map-name
          custom-map-copy
+         custom-map-weak-copy
          custom-map-snapshot)
 
 (define-values (prop:custom-map custom-map? custom-map-ref)
   (make-impersonator-property 'custom-map))
 
-(define (custom-map name copy snapshot) (vector name copy snapshot))
+(define (custom-map name copy weak-copy snapshot) (vector name copy weak-copy snapshot))
 (define (custom-map-name cm) (vector-ref cm 0))
 (define (custom-map-copy cm) (vector-ref cm 1))
-(define (custom-map-snapshot cm) (vector-ref cm 2))
+(define (custom-map-weak-copy cm) (vector-ref cm 2))
+(define (custom-map-snapshot cm) (vector-ref cm 3))

--- a/rhombus/private/key-comp.rkt
+++ b/rhombus/private/key-comp.rkt
@@ -15,10 +15,12 @@
   (struct key-comp (name-sym map?-id
                              map-build-id map-pair-build-id list->map-id
                              mutable-map?-id mutable-map-build-id
+                             weak-mutable-map?-id weak-mutable-map-build-id
                              empty-stx
                              set?-id
                              set-build-id set-build*-id list->set-id
-                             mutable-set?-id mutable-set-build-id))
+                             mutable-set?-id mutable-set-build-id
+                             weak-mutable-set?-id weak-mutable-set-build-id))
 
   (define (key-comp-ref v) (and (key-comp? v) v)))
 

--- a/rhombus/private/print.rkt
+++ b/rhombus/private/print.rkt
@@ -290,13 +290,17 @@
         (pretty-listlike
          (pretty-text (cond
                         [(mutable-hash? v)
-                         (cond
-                           [(hash-eq? v) "MutableMap.by(===){"]
-                           [(hash-eqv? v) "MutableMap.by(is_same_number_or_object){"]
-                           [(custom-map-ref v #f)
-                            => (lambda (cm) (format "MutableMap.by(~a){" (custom-map-name cm)))]
-                           [(hash-equal? v) "MutableMap.by(is_now){"]
-                           [else "MutableMap{"])]
+                         (string-append
+                          (if (hash-ephemeron? v)
+                              "Weak"
+                              "")
+                          (cond
+                            [(hash-eq? v) "MutableMap.by(===){"]
+                            [(hash-eqv? v) "MutableMap.by(is_same_number_or_object){"]
+                            [(custom-map-ref v #f)
+                             => (lambda (cm) (format "MutableMap.by(~a){" (custom-map-name cm)))]
+                            [(hash-equal? v) "MutableMap.by(is_now){"]
+                            [else "MutableMap{"]))]
                         [(hash-eq? v) "Map.by(===){"]
                         [(custom-map-ref v #f)
                          => (lambda (cm) (format "Map.by(~a){" (custom-map-name cm)))]
@@ -318,13 +322,17 @@
         (pretty-listlike
          (pretty-text (cond
                         [(mutable-set? v)
-                         (cond
-                           [(hash-eq? (set-ht v)) "MutableSet.by(===){"]
-                           [(custom-map-ref (set-ht v) #f)
-                            => (lambda (cm) (format "MutableSet.by(~a){" (custom-map-name cm)))]
-                           [(hash-equal? (set-ht v)) "MutableSet.by(is_now){"]
-                           [(hash-eqv? (set-ht v)) "MutableSet.by(is_same_number_or_object){"]
-                           [else "MutableSet{"])]
+                         (string-append
+                          (if (hash-weak? (set-ht v))
+                              "Weak"
+                              "")
+                          (cond
+                            [(hash-eq? (set-ht v)) "MutableSet.by(===){"]
+                            [(custom-map-ref (set-ht v) #f)
+                             => (lambda (cm) (format "MutableSet.by(~a){" (custom-map-name cm)))]
+                            [(hash-equal? (set-ht v)) "MutableSet.by(is_now){"]
+                            [(hash-eqv? (set-ht v)) "MutableSet.by(is_same_number_or_object){"]
+                            [else "MutableSet{"]))]
                         [(hash-eq? (set-ht v)) "Set.by(===){"]
                         [(custom-map-ref (set-ht v) #f)
                          => (lambda (cm) (format "Set.by(~a){" (custom-map-name cm)))]

--- a/rhombus/scribblings/ref-map.scrbl
+++ b/rhombus/scribblings/ref-map.scrbl
@@ -62,9 +62,11 @@ in an unspecified order.
   annot.macro 'Map.of($key_annot, $val_annot)'
   annot.macro 'ReadableMap'
   annot.macro 'MutableMap'
+  annot.macro 'WeakMutableMap'
   annot.macro 'Map.by($key_comp)'
   annot.macro 'Map.by($key_comp).of($key_annot, $val_annot)'
   annot.macro 'MutableMap.by($key_comp)'
+  annot.macro 'WeakMutableMap.by($key_comp)'
 ){
 
  The @rhombus(Map, ~annot) annotation matches any immutable map in the
@@ -75,10 +77,13 @@ in an unspecified order.
  @rhombus(ReadableMap, ~annot) matches both mutable and immutable maps,
  while @rhombus(MutableMap, ~annot) matches mutable maps (created with,
  for example, the @rhombus(MutableMap) constructor).
+ @rhombus(MutableMap, ~annot) matches weak mutable maps (created with, for
+ example, the @rhombus(WeakMutableMap) constructor).
 
- The @rhombus(Map.by, ~annot) and @rhombus(MutableMap.by, ~annot)
- annotation variants match only maps that use the hash and equality
- procedures specified by @rhombus(key_comp).
+ The @rhombus(Map.by, ~annot), @rhombus(MutableMap.by, ~annot), and
+ @rhombus(WeakMutableMap.by, ~annot) annotation variants match only maps
+ that use the hash and equality procedures specified by
+ @rhombus(key_comp).
 
  Static information associated by @rhombus(Map, ~annot), etc., makes an
  expression acceptable as a sequence to @rhombus(for) in static mode.
@@ -338,6 +343,25 @@ in an unspecified order.
 
 
 @doc(
+  ~nonterminal:
+    key_expr: block expr
+    val_expr: block expr
+  expr.macro 'WeakMutableMap{key_expr: val_expr, ...}'
+  fun WeakMutableMap([key :: Any, val :: Any] :: Listable.to_list, ...)
+    :: WeakMutableMap
+  expr.macro 'WeakMutableMap.by($key_comp){key_expr: val_expr, ...}'
+  expr.macro 'WeakMutableMap.by($key_comp)'
+){
+
+ Like @rhombus(MutableMap), but creates a map where a key is removed
+ from the map by a garbage collection when the key is reachable only by
+ enumerating the map's keys. A key is not considered reachable merely
+ because it is reachable through the value mapped from the key.
+
+}
+
+
+@doc(
   def Map.empty :: Map = {}
   bind.macro 'Map.empty'
   def ReadableMap.empty :: ReadableMap = {}
@@ -354,7 +378,7 @@ in an unspecified order.
 
  Corresponding to the binding forms, @rhombus(Map.empty) and
  @rhombus(ReadableMap.empty) are bound to @rhombus({}) with
- approapriate static information.
+ appropriate static information.
 
 @examples(
   Map.empty

--- a/rhombus/scribblings/ref-map.scrbl
+++ b/rhombus/scribblings/ref-map.scrbl
@@ -60,8 +60,11 @@ in an unspecified order.
     key_annot: :: annot
   annot.macro 'Map'
   annot.macro 'Map.of($key_annot, $val_annot)'
+  annot.macro 'Map.later_of($key_annot, $val_annot)'
   annot.macro 'ReadableMap'
   annot.macro 'MutableMap'
+  annot.macro 'MutableMap.now_of($key_annot, $val_annot)'
+  annot.macro 'MutableMap.later_of($key_annot, $val_annot)'
   annot.macro 'WeakMutableMap'
   annot.macro 'Map.by($key_comp)'
   annot.macro 'Map.by($key_comp).of($key_annot, $val_annot)'
@@ -69,16 +72,29 @@ in an unspecified order.
   annot.macro 'WeakMutableMap.by($key_comp)'
 ){
 
- The @rhombus(Map, ~annot) annotation matches any immutable map in the
- form without @rhombus(of). The @rhombus(of) variants match an immutable
- map whose keys satisfy @rhombus(key_annot) and whose values satisfy
- @rhombus(val_annot).
-
+ The @rhombus(Map, ~annot) annotation matches any immutable map.
  @rhombus(ReadableMap, ~annot) matches both mutable and immutable maps,
  while @rhombus(MutableMap, ~annot) matches mutable maps (created with,
  for example, the @rhombus(MutableMap) constructor).
- @rhombus(MutableMap, ~annot) matches weak mutable maps (created with, for
- example, the @rhombus(WeakMutableMap) constructor).
+ @rhombus(WeakMutableMap, ~annot) matches weak mutable maps (created with,
+ for example, the @rhombus(WeakMutableMap) constructor).
+
+ The @rhombus(of) and @rhombus(now_of) annotation variants match a map
+ whose keys satisfy @rhombus(key_annot) and whose values satisfy
+ @rhombus(val_annot), where satisfaction of the annotation is confirmed
+ by immediately checking all keys and values. No future obligation is
+ attached to a map satisfying the annotation, so in the case of
+ @rhombus(MutableMap.now_of), no static information is associated with
+ value access using @brackets.
+
+ The @rhombus(later_of) annotation variants create a @tech{converter
+  annotation} given annotations for keys and values; satisfaction of those
+ annotations is confirmed only on demand, both for keys and values that
+ are extracted from the map and for keys and values added or appended to
+ the map. For @rhombus(Map.later_of), the key and value annotations must
+ be @tech{predicate annotations}. Since a value annotation is checked on
+ every access, its static information is associated with access using
+ @brackets.
 
  The @rhombus(Map.by, ~annot), @rhombus(MutableMap.by, ~annot), and
  @rhombus(WeakMutableMap.by, ~annot) annotation variants match only maps

--- a/rhombus/scribblings/ref-set.scrbl
+++ b/rhombus/scribblings/ref-set.scrbl
@@ -57,9 +57,11 @@ it supplies its elements in an unspecified order.
   annot.macro 'Set.of($annot)'
   annot.macro 'ReadableSet'
   annot.macro 'MutableSet'
+  annot.macro 'WeakMutableSet'
   annot.macro 'Set.by($key_comp)'
   annot.macro 'Set.by($key_comp).of($annot)'
   annot.macro 'MutableSet.by($key_comp)'
+  annot.macro 'WeakMutableSet.by($key_comp)'
 ){
 
  The @rhombus(Set, ~annot) annotation matches any set. The @rhombus(of)
@@ -68,6 +70,8 @@ it supplies its elements in an unspecified order.
  @rhombus(ReadableSet, ~annot) matches both mutable and immutable maps,
  while @rhombus(MutableSet, ~annot) matches mutable maps (created with,
  for example, the @rhombus(MutableSet) constructor).
+ @rhombus(MutableSet, ~annot) matches weak mutable sets (created with, for
+ example, the @rhombus(WeakMutableSet) constructor).
 
  The @rhombus(Set.by, ~annot) and @rhombus(MutableSet.by, ~annot)
  annotation variants match only sets that use the hash and equality
@@ -218,6 +222,24 @@ it supplies its elements in an unspecified order.
 
 }
 
+
+@doc(
+  ~nonterminal:
+    val_expr: block expr
+  expr.macro 'WeakMutableSet{$val_expr, ...}'
+  fun WeakMutableSet(val :: Any, ...) :: MutableSet
+  expr.macro 'WeakMutableSet.by($key_comp){$val_expr, ...}'
+  expr.macro 'WeakMutableSet.by($key_comp)'
+){
+
+
+ Like @rhombus(MutableSet), but creates a set where an element is
+ removed from the set by a garbage collection when the element is
+ reachable only by enumerating the set's elements.
+
+}
+
+
 @doc(
   def Set.empty :: Set = Set{}
   bind.macro 'Set.empty'
@@ -234,7 +256,7 @@ it supplies its elements in an unspecified order.
 
  Corresponding to the binding forms, @rhombus(Set.empty) and
  @rhombus(ReadableSet.empty) are bound to @rhombus(Set{}) with
- approapriate static information.
+ appropriate static information.
 
 @examples(
   Set.empty

--- a/rhombus/scribblings/ref-set.scrbl
+++ b/rhombus/scribblings/ref-set.scrbl
@@ -55,23 +55,40 @@ it supplies its elements in an unspecified order.
 @doc(
   annot.macro 'Set'
   annot.macro 'Set.of($annot)'
+  annot.macro 'Set.later_of($annot)'
   annot.macro 'ReadableSet'
   annot.macro 'MutableSet'
   annot.macro 'WeakMutableSet'
+  annot.macro 'MutableSet.now_of($annot)'
+  annot.macro 'MutableSet.later_of($annot)'
   annot.macro 'Set.by($key_comp)'
   annot.macro 'Set.by($key_comp).of($annot)'
   annot.macro 'MutableSet.by($key_comp)'
   annot.macro 'WeakMutableSet.by($key_comp)'
 ){
 
- The @rhombus(Set, ~annot) annotation matches any set. The @rhombus(of)
- variants match a set whose values satisfy @rhombus(annot).
-
+ The @rhombus(Set, ~annot) annotation matches any set.
  @rhombus(ReadableSet, ~annot) matches both mutable and immutable maps,
  while @rhombus(MutableSet, ~annot) matches mutable maps (created with,
  for example, the @rhombus(MutableSet) constructor).
- @rhombus(MutableSet, ~annot) matches weak mutable sets (created with, for
+ @rhombus(WeakMutableSet, ~annot) matches weak mutable sets (created with, for
  example, the @rhombus(WeakMutableSet) constructor).
+
+ The @rhombus(of) and @rhombus(now_of) annotation variants match a set
+ whose elements satisfy @rhombus(annot), where satisfaction of the
+ annotation is confirmed by immediately checking all elements. No future
+ obligation is attached to a set satisfying the annotation, so in the
+ case of @rhombus(MutableSet.now_of), no static information is associated
+ with value access using @brackets.
+
+ The @rhombus(later_of) annotation variants create a @tech{converter
+  annotation} given an annotations for elements; satisfaction of those
+ annotations is confirmed only on demand, both for elements that are
+ extracted from the set and for elements added or appended to the set.
+ For @rhombus(Set.later_of), the key and value annotations must be
+ @tech{predicate annotations}. Since an element annotation is checked on
+ every access, its static information is associated with access using
+ @brackets.
 
  The @rhombus(Set.by, ~annot) and @rhombus(MutableSet.by, ~annot)
  annotation variants match only sets that use the hash and equality

--- a/rhombus/tests/list.rhm
+++ b/rhombus/tests/list.rhm
@@ -150,6 +150,25 @@ block:
     ~is [2, 3, 4]
 
 block:
+  use_static
+  def lst :: List.later_of(String) = ["a", "b", 3]
+  check lst[0] ~is "a"
+  check lst[1] ~is "b"
+  check lst[2] ~throws "current element does not satisfy annotation"
+  check (lst ++ ["d", "e"])[3] ~is "d"
+  check (["z"] ++ lst)[0] ~is "z"
+  check (["z"] ++ lst)[3] ~throws "current element does not satisfy annotation"
+  check lst ++ ["d", 5] ~throws "appended element does not satisfy annotation"
+  check [0] ++ lst ~throws "appended element does not satisfy annotation"
+  check lst.add("z")[3] ~is "z"
+  check lst.add(100) ~throws "new element does not satisfy annotation"
+
+check:
+  ~eval
+  [] :: List.later_of(ReadableString.to_string)
+  ~throws "converter annotation not supported for elements"
+
+block:
   check:
     dynamic([1, 2, 3]).length()
     ~is 3

--- a/rhombus/tests/map.rhm
+++ b/rhombus/tests/map.rhm
@@ -546,6 +546,49 @@ check:
   ~is "#0=MutableMap{1: #0#, 3: 4}"
 
 block:
+  def orig = MutableMap{"x": 1, 2: 5}
+  check orig :: MutableMap.now_of(String, Int) ~throws "value does not satisfy annotation" // "value" is the map
+  check orig :: MutableMap.now_of(Any, Int) ~is orig
+  check orig :: MutableMap.now_of(Any, matching(1)) ~throws "value does not satisfy annotation"
+  check (orig :: MutableMap.now_of(Any, Int))["x"] := "1" ~is #void
+  check orig ~is_now MutableMap{"x": "1", 2: 5}
+
+block:
+  def orig = MutableMap{"x": 1, 2: 5}
+  def m :: MutableMap.later_of(String, Int) = orig
+  check m["x"] ~is 1
+  check m[2] ~throws "key does not satisfy annotation"
+  check m["x"] := "1" ~throws "value does not satisfy annotation"
+  check to_string(m) ~throws "key does not satisfy annotation"
+  check m["x"] := 10 ~is #void
+  check m["y"] := 11 ~is #void
+  check orig[2] ~is 5
+  check orig["x"] ~is 10
+  check orig["y"] ~is 11
+  check m.delete(2) ~throws "key does not satisfy annotation"
+  check m.delete("y") ~is #void
+  check orig.delete(2) ~is #void
+  check to_string(m) ~is "MutableMap{\"x\": 10}"
+
+check:
+  use_static
+  def m :: MutableMap.later_of(Int, String) = MutableMap{100: "1"}
+  m[100] ++ "!"
+  ~is "1!"
+
+block:
+  def m :: Map.later_of(String, Int) = Map{"x": 1, 2: 5}
+  check m["x"] ~is 1
+  check m[2] ~throws "key does not satisfy annotation"
+  check m ++ {"x": "1"} ~throws "value does not satisfy annotation"
+  check to_string(m) ~throws "key does not satisfy annotation"
+  check m ++ {"x": 10} ~is_a Map
+  check m ++ {"y": 11} ~is_a Map
+  check m.remove(2) ~throws "key does not satisfy annotation"
+  check m.remove("x") ~is_a Map
+  check m.remove("y") ~is_a Map
+
+block:
   class Posn(x, y)
   let a = Posn(1, 2)
   let b = Posn(1, 2)

--- a/rhombus/tests/map.rhm
+++ b/rhombus/tests/map.rhm
@@ -1,6 +1,7 @@
 #lang rhombus
 import:
   "version_guard.rhm"
+  rhombus/runtime
 
 block:
   import "static_arity.rhm"
@@ -535,6 +536,8 @@ check:
   to_string(Map{1: 2, 3: 4}) ~is "{1: 2, 3: 4}"
   to_string(MutableMap{}) ~is "MutableMap{}"
   to_string(MutableMap{1: 2, 3: 4}) ~is "MutableMap{1: 2, 3: 4}"
+  to_string(WeakMutableMap{}) ~is "WeakMutableMap{}"
+  to_string(WeakMutableMap{1: 2, 3: 4}) ~is "WeakMutableMap{1: 2, 3: 4}"
 
 check:
   def m = MutableMap{1: 2, 3: 4}
@@ -623,10 +626,34 @@ block:
        check MutableMap.by($key_comp){ "x": 1 } is_now MutableMap{ "x": 1 } ~is is_equals
        check MutableMap.by($key_comp){ "x": 1 } is_now MutableMap.by(is_now){ "x": 1 } ~is is_is_now
        check MutableMap{ "x": 1 }is_now MutableMap.by($key_comp){ "x": 1 } ~is is_equals
-       check MutableMap.by(is_now){ "x": 1 }  is_now MutableMap.by($key_comp){ "x": 1 } ~is is_is_now
+       check MutableMap.by(is_now){ "x": 1 } is_now MutableMap.by($key_comp){ "x": 1 } ~is is_is_now
        check [MutableMap.by($key_comp){ x: x }, $('...')] ~is_now [MutableMap.by($key_comp){ 1: 1 },
                                                                    MutableMap.by($key_comp){ 2: 2 },
-                                                                   MutableMap.by($key_comp){ 3: 3 }]'
+                                                                   MutableMap.by($key_comp){ 3: 3 }]
+       class Boson(v)
+       let m5 = WeakMutableMap.by($key_comp){}
+       let mutable boson = Boson("plus")
+       m5[boson] := 1
+       check m5[boson] ~is 1
+       check m5 ~is_now WeakMutableMap.by($key_comp){ boson: 1 }
+       check m5 ~is_now WeakMutableMap.by($key_comp)([boson, 1])
+       check m5 ~is_a WeakMutableMap.by($key_comp)
+       check m5 ~is_a MutableMap.by($key_comp)
+       check m5 is_a WeakMutableMap.by(==) ~is is_equals
+       check m5 is_a WeakMutableMap.by(is_now) ~is is_is_now
+       check WeakMutableMap.by($key_comp){ boson: 1 } is_now WeakMutableMap{ boson: 1 } ~is is_equals
+       check WeakMutableMap.by($key_comp){ boson: 1 } is_now WeakMutableMap.by(is_now){ boson: 1 } ~is is_is_now
+       check WeakMutableMap{ boson: 1 }is_now WeakMutableMap.by($key_comp){ boson: 1 } ~is is_equals
+       check WeakMutableMap.by(is_now){ boson: 1 } is_now WeakMutableMap.by($key_comp){ boson: 1 } ~is is_is_now
+       check [WeakMutableMap.by($key_comp){ x: x }, $('...')] ~is_now [WeakMutableMap.by($key_comp){ 1: 1 },
+                                                                       WeakMutableMap.by($key_comp){ 2: 2 },
+                                                                       WeakMutableMap.by($key_comp){ 3: 3 }]
+       // make sure the map is weak:
+       m5[boson] := boson
+       check m5[boson] ~is boson
+       boson := #false
+       runtime.gc()
+       check m5.length() ~is 0'
   check_map_by ==
   check_map_by ===
   check_map_by is_now

--- a/rhombus/tests/set.rhm
+++ b/rhombus/tests/set.rhm
@@ -471,6 +471,40 @@ check:
   ~is "#0=MutableSet{#0#}"
 
 block:
+  def orig = MutableSet{"x", 2}
+  check orig :: MutableSet.now_of(String) ~throws "value does not satisfy annotation"
+  check orig :: MutableSet.now_of(Any) ~is orig
+  check (orig :: MutableSet.now_of(Any))["y"] := #true ~is #void
+  check orig ~is_now MutableSet{"x", "y", 2}
+
+block:
+  def orig = MutableSet{"x", 2}
+  def m :: MutableSet.later_of(String) = orig
+  check m["x"] ~is #true
+  check m[2] ~throws "element does not satisfy annotation"
+  check m[2] := #true ~throws "element does not satisfy annotation"
+  check to_string(m) ~throws "element does not satisfy annotation"
+  check m["x"] := #true ~is #void
+  check m["y"] := #true ~is #void
+  check orig[2] ~is #true
+  check orig["x"] ~is #true
+  check orig["y"] ~is #true
+  check orig["z"] ~is #false
+  check m.delete(2) ~throws "element does not satisfy annotation"
+  check m.delete("y") ~is #void
+  check orig.delete(2) ~is #void
+  check to_string(m) ~is "MutableSet{\"x\"}"
+
+block:
+  def m :: Set.later_of(String) = Set{"x", 2}
+  check m["x"] ~is #true
+  check m[2] ~throws "element does not satisfy annotation"
+  check to_string(m) ~throws "element does not satisfy annotation"
+  check m.remove(2) ~throws "element does not satisfy annotation"
+  check m.remove("x") ~is_a Set
+  check to_string(m) ~throws "element does not satisfy annotation"
+
+block:
   class Posn(x, y)
   let a = Posn(1, 2)
   let b = Posn(1, 2)

--- a/rhombus/tests/set.rhm
+++ b/rhombus/tests/set.rhm
@@ -1,6 +1,7 @@
 #lang rhombus
 import:
   "version_guard.rhm"
+  rhombus/runtime
 
 block:
   import "static_arity.rhm"
@@ -460,6 +461,8 @@ check:
   to_string(Set{1, 2, 3}) ~is "{1, 2, 3}"
   to_string(MutableSet{}) ~is "MutableSet{}"
   to_string(MutableSet{1, 2, 3}) ~is "MutableSet{1, 2, 3}"
+  to_string(WeakMutableSet{}) ~is "WeakMutableSet{}"
+  to_string(WeakMutableSet{1, 2, 3}) ~is "WeakMutableSet{1, 2, 3}"
 
 check:
   def s = MutableSet{}
@@ -549,10 +552,31 @@ block:
        check MutableSet.by($key_comp){ "x" } is_now MutableSet{ "x" } ~is is_equals
        check MutableSet.by($key_comp){ "x" } is_now MutableSet.by(is_now){ "x" } ~is is_is_now
        check MutableSet{ "x" }is_now MutableSet.by($key_comp){ "x" } ~is is_equals
-       check MutableSet.by(is_now){ "x" }  is_now MutableSet.by($key_comp){ "x" } ~is is_is_now
+       check MutableSet.by(is_now){ "x" } is_now MutableSet.by($key_comp){ "x" } ~is is_is_now
        check [MutableSet.by($key_comp){ x }, $('...')] ~is_now [MutableSet.by($key_comp){ 1 },
                                                                 MutableSet.by($key_comp){ 2 },
-                                                                MutableSet.by($key_comp){ 3 }]'
+                                                                MutableSet.by($key_comp){ 3 }]
+       class Boson(v)
+       let m5 = WeakMutableSet.by($key_comp){}
+       let mutable boson = Boson("plus")
+       m5[boson] := #true
+       check m5[boson] ~is #true
+       check m5 ~is_now WeakMutableSet.by($key_comp){ boson }
+       check m5 ~is_now WeakMutableSet.by($key_comp)(boson)
+       check m5 ~is_a WeakMutableSet.by($key_comp)
+       check m5 is_a WeakMutableSet.by(==) ~is is_equals
+       check m5 is_a WeakMutableSet.by(is_now) ~is is_is_now
+       check WeakMutableSet.by($key_comp){ boson } is_now WeakMutableSet{ boson } ~is is_equals
+       check WeakMutableSet.by($key_comp){ boson } is_now WeakMutableSet.by(is_now){ boson } ~is is_is_now
+       check WeakMutableSet{ boson }is_now WeakMutableSet.by($key_comp){ boson } ~is is_equals
+       check WeakMutableSet.by(is_now){ boson } is_now WeakMutableSet.by($key_comp){ boson } ~is is_is_now
+       check [WeakMutableSet.by($key_comp){ x }, $('...')] ~is_now [WeakMutableSet.by($key_comp){ 1 },
+                                                                    WeakMutableSet.by($key_comp){ 2 },
+                                                                    WeakMutableSet.by($key_comp){ 3 }]
+       // make sure the set is weak:
+       boson := #false
+       runtime.gc()
+       check m5.length() ~is 0'
   check_set_by ==
   check_set_by ===
   check_set_by is_now


### PR DESCRIPTION
A weak mutable map is an ephemeron map at the Racket level. Although there are uses that need a non-epheneron weak hash table, they're pretty low-level and related to memory management. Meanwhile, Racket CS's ephemeron-hash performance is about the same as for a weak hash table. So, there's doesn't appear to be a need for non-ephemeron weak maps.
    
A weak set uses a non-ephemeron hash table, though, since it's equivalent to an ephemeron hash table for boolean values, and it's a little simpler for the GC to manage.
