### PR TITLE
Try an implementation of integer range objects

### DIFF
--- a/design/range/range.md
+++ b/design/range/range.md
@@ -1,0 +1,279 @@
+# Ranges
+
+## Summary
+This proposal discusses ranges, discrete or continuous, with or
+without inclusive or exclusive upper/lower bounds.  Specifically, when
+we speak of ranges, we refer to ranges as *objects* with a reasonable
+interface.
+
+## Motivation
+A *range*, or an *interval*, represents a contiguous sequence of
+values.  The use of ranges is widely common in programming due to its
+very general idea—whenever a (partial) order is available, or in
+Rhombus terms, a class implements `Comparable`, we can speak of
+ranges.  As an example, the sub-list/string/… operation takes an
+(optional) lower bound and an (optional) upper bound, which can as
+well be represented by a range of non-negative integers.  This is not
+only intentionally better than two ad hoc parameters `start` and
+`end`, but also practically better as one no longer has to explicitly
+verify that `start <= end`.
+
+We can also speak of *discrete* ranges, which can be enumerated,
+stepped, etc.  This is the notion of ranges that is more familiar to
+most people: discrete ranges can be used as sequences by stepping from
+the starting point to the ending point.  The above example, in fact,
+is better expressed with discrete ranges, because the bounds must be
+indexes, i.e., interpreted as natural numbers.
+
+## Current Status
+
+### Racket
+Racket has no ranges in our sense.  The sequence constructor
+`in-range` actually produces a sequence of (real!) numbers, with an
+optional step.  In other words, Racket
+
+```racket
+(in-range start end step)
+```
+
+is somewhat like Haskell
+
+```haskell
+unfoldr
+  (\x -> if (x < end) then Just (x, x + step) else Nothing)
+  start
+```
+
+or, somewhat like C (except the lack of generic numerics)
+
+```c
+for (int i = start; i < end; i += step) {
+    ....
+}
+```
+
+*when `step` is non-negative* (use `>` instead when `step` is
+negative).  The function `range` is just like `in-range`, but produces
+a list.
+
+There are also sequence constructors `in-inclusive-range`, which
+includes the `end` (by using `<=`/`>=`), and `in-naturals`, which is
+infinite, but curiously only applies to non-negative integers, i.e.,
+naturals.
+
+### Rhombus
+Rhombus does what Racket does, but `start .. end` (`in-range`), `start
+..= end` (`in-inclusive-range`), and `start ..` (`in-naturals`) only
+allow (any) integers, and do not support custom `step`s.  Moreover,
+`start .. end` and `start ..= end` are `Listable`.
+
+## Prior Art
+
+### Rust
+Rust provides ranges of any type that implements `PartialOrd` (like
+Rhombus `Comparable`).  Ranges are separated into six types:
+
+- `Range`, which is half-open (`start .. end`);
+- `RangeFrom`, which is bounded inclusively below (`start ..`);
+- `RangeFull`, which is unbounded (`..`);
+- `RangeInclusive`, which is closed (`start ..= end`);
+- `RangeTo`, which is bounded exclusively above (`.. end`);
+- `RangeToInclusive`, which is bounded inclusively above (`..= end`).
+
+The syntax itself seems reasonable to implement in Rhombus, but the
+semantics is more problematic.  Among these types, `Range`,
+`RangeFrom`, and `RangeInclusive` can serve as `Iterator`s (like
+Rhombus `Sequenceable`s), given that the item type implements `Step`
+(no Rhombus equivalent, so far; let’s say this is `Steppable`).  This
+is because an `Iterator` requires a starting point and a way to
+proceed through steps.
+
+Custom steps are not provided by ranges themselves, but are available
+for all `Iterator`s through the `Iterator::step_by` method.
+
+(Subtlety: The mentioned range types are `Iterator`s, as opposed to
+`IntoIterator`s, because `Iterator::next` can mutate the `start`
+field.  In Rhombus, ranges will more likely be `Sequenceable`s.)
+
+Range types also implement `SliceIndex`, which can in turn implement
+the sub-list/string/… operation.
+
+### Haskell
+Haskell has no ranges in our sense (indeed, Haskell favors a different
+organization principle).  However, two Haskell type classes are
+particularly relevant.
+
+The `Enum` type class identifies types that can be enumerated in the
+sense of mapping from and to natural numbers; in other words, `toEnum`
+and `fromEnum` comprise a minimal complete definition.  Therefore,
+`succ`essor and `pred`ecessor methods are provided, as well as methods
+backing range-like notations.  Specifically,
+
+- `[n ..]` is `enumFrom n`;
+- `[n, n' ..]` is `enumFromThen n n'`;
+- `[n .. m]` is `enumFromTo n m`; and
+- `[n, n' .. m]` is `enumFromThenTo n n' m`.
+
+The `Ix` type class identifies types that can serve as “indexes,”
+therefore closer to ranges in our sense.  Specifically, a range is
+represented as `(a, a)` where `Ix a`, and laws ensure that the methods
+preserve this fact.
+
+### Guava
+Guava provides `Range<C extends Comparable>` class, which has nine (!)
+constructors according to
+
+- + Whether there is a lower bound;
+  + If so, whether that is open;
+- + Whether there is an upper bound;
+  + If so, whether that is open.
+
+`BoundType`s are represented by an `Enum` with two variants.
+
+Additionally, when given a `DiscreteDomain<C>` (i.e., `Steppable`),
+the `Range<C>` can be viewed as `ContiguousSet<C>`, therefore
+`Iterable<C>`.
+
+### Elixir
+Elixir provides integer ranges.  The interesting part is the
+notations: `first .. last` and `first .. last // step`, the latter
+being a mixfix notation.
+
+### Ruby
+Ruby provides `Range`s of any object with a `<=>` operator (i.e.,
+`Comparable`).  Moreover, a `succ` method (i.e., `Steppable`) is
+required to treat the range as a sequence.
+
+### Python
+Python provides `range`s of any object that implements the
+`__index__()` special method, which converts to integers; in other
+words, only discrete ranges.
+
+Alternatively, Python provides `slice`s (with no obligation!), which
+back the slice notations `seq[:]`, `seq[start:]`, `seq[:end]`, and
+`seq[start:end:step]`.
+
+### Summary
+Generally, two interfaces seem to be relevant for generic ranges:
+
+- `Comparable`, with which the very basic inclusion operation can be
+  defined;
+- `Steppable`, with which the notion of discrete ranges can be
+  represented.
+
+In principle, a total of nine types of ranges can be defined, but the
+usual expression problem applies.
+
+Ranges can be used for many purposes.  Some use ranges for slicing;
+some use ranges as sequences; still some use ranges in data
+structures.
+
+## Proposed Design
+It’s not very clear how to make ranges generic while still efficient,
+so let’s confine ourselves to integer ranges, for now.
+
+Ranges will have nine types, with the following notations (*edited on
+14th May*):
+
+- ~~`Range.from_below(start, end)`~~
+  `Range.from_to(start, end)`, which is closed–open `start .. end`;
+- ~~`Range.from_to(start, end)`~~
+  `Range.from_to_inclusive(start, end)`, which is closed–closed
+  `start ..= end`;
+- `Range.from(start)`, which is closed–unbounded `start ..`;
+- ~~`Range.above_below(start, end)`~~
+  `Range.from_exclusive_to(start, end)`, which is open–open
+  `start <..< end`;
+- ~~`Range.above_to(start, end)`~~
+  `Range.from_exclusive_to_inclusive(start, end)`, which is
+  open–closed `start <..= end`;
+- ~~`Range.above(start)`~~
+  `Range.from_exclusive(start)`, which is open–unbounded `start <..<`;
+- ~~`Range.below(end)`~~
+  `Range.to(end)`, which is unbounded–open `.. end`;
+- ~~`Range.to(end)`~~
+  `Range.to_inclusive(end)`, which is unbounded–closed `..= end`;
+- `Range.full()`, which is unbounded–unbounded `..`.
+
+~~The terms `from`–`to` vs. `above`–`below` for inclusive
+vs. exclusive are inspired by Common Lisp `loop`~~
+The name `Range.from_to` is chosen for the common case `..`, and
+other names build on it; the operators `<..<` (cannot end in `.`) and
+`<..=` have no precedent, but resemble `..=` in a way.  For
+simplicity, prefer `..` over `..=` over `<..<`/`<..=` for unbounded
+sequences.
+
+The expression forms will have corresponding binding forms, as
+expected.  Three annotations will be available:
+
+- `Range`, satisfied by all range types;
+- `SequenceRange`, satisfied by `Range.from`, `Range.from_below`, and
+  `Range.from_to` (that implement `Sequenceable`);
+- `ListRange`, satisfied by `Range.from_below` and `Range.from_to`
+  (that implement `Listable`).
+
+Specifically, range types that have a “starting point” implement
+`Sequenceable`, and ones that have an “ending point” implement
+`Listable`.
+
+These methods seem reasonable for ranges, borrowed from Rebellion
+(*edited on 9th May*):
+
+- ~~`range.contains(v)`: checks whether `range` contains `v`;~~
+- `range.has_element(i)`: checks whether `range` has `i` in its range;
+- ~~`range.encloses(other)`: checks whether `range` encloses `other`;~~
+- `range.encloses(other, ...)`: checks whether `range` and `other`s
+  are in an enclosing order;
+- `range.is_connected(other)`: checks whether `range` is connected to
+  `other`;
+- `range.overlaps(other)`: checks whether `range` overlaps with
+  `other`;
+- ~~`range.span(other)`: returns the range that spans `range` and
+  `other`~~;
+- `range.span(other, ...)`: returns the range that spans `range` and
+  `other`s;
+- `range.gap(other)`: returns the gap between `range` and `other`, if
+  any;
+- ~~`range.intersection(other)`: returns the intersection of `range` and
+  `other`.~~
+- `range.intersect(other, ...)`: returns the intersection of `range`
+  and `other`s, if any.
+
+Four deconstructors are available on ranges (*added on 3rd May*):
+
+- `range.start()`: returns the starting point, which is an integer or
+  `#neginf`;
+- `range.end()`: returns the ending point, which is an integer or
+  `#inf`;
+- `range.includes_start()`: returns `#true` if `range` includes the
+  starting point, `#false` otherwise;
+- `range.includes_end()`: returns `#true` if `range` includes the
+  ending point, `#false` otherwise.
+
+These methods are available on `SequenceRange`, additionally:
+
+- `range.to_sequence()`: returns a sequence, like `in-range` with a
+  step of 1;
+- `range.step_by(step)`: returns a sequence, like `in-range` with a
+  custom `step`.
+
+The name `step_by` is borrowed from Rust, but restricted to ranges,
+for now.  This allows a naïve optimization strategy.
+
+These methods are available on `ListRange`, additionally:
+
+- `range.to_list()`: returns a list.
+
+## Future Possibilities
+Ranges can be made generic, but it’s not clear how to do that.  Does
+anyone have an idea that can work well in the context of Rhombus?
+
+The interface `Steppable` seems rather limited in functionality.
+Indeed, Rust puts the corresponding interface under `std::iter`
+module, which indicates that they also think such interface is
+intended for (generic) iterators.  Should we implement that?
+
+The method `Range.step_by` points to a more general version for all
+sequences, and there are more such methods that can be defined.  How
+should we do so?  As sequence combinators (however those will work)?
+As `Sequenceable` methods?

--- a/rhombus/private/bind-macro.rkt
+++ b/rhombus/private/bind-macro.rkt
@@ -71,7 +71,7 @@
   rhombus/bind
   #'make-binding-prefix-operator
   #'make-binding-infix-operator
-  #'prefix+infix)
+  #'binding-prefix+infix-operator)
 
 (begin-for-syntax
   (define-operator-syntax-classes
@@ -97,11 +97,6 @@
 
 (define-for-syntax space
   (space-syntax rhombus/bind))
-
-(begin-for-syntax
-  (struct prefix+infix (prefix infix)
-    #:property prop:binding-prefix-operator (lambda (self) (prefix+infix-prefix self))
-    #:property prop:binding-infix-operator (lambda (self) (prefix+infix-infix self))))
 
 (define-for-syntax (check-syntax who s)
   (unless (syntax? s)

--- a/rhombus/private/binding.rkt
+++ b/rhombus/private/binding.rkt
@@ -34,7 +34,9 @@
            in-binding-space
            bind-quote
 
-           binding-extension-combine))
+           binding-extension-combine
+
+           (struct-out binding-prefix+infix-operator)))
 
 (provide define-binding-syntax
          raise-binding-failure
@@ -120,6 +122,11 @@
   (define extension-syntax-property-key (gensym 'extension))
   (define (binding-extension-combine id prefix)
     (syntax-property id extension-syntax-property-key prefix)))
+
+(begin-for-syntax
+  (struct binding-prefix+infix-operator (prefix infix)
+    #:property prop:binding-prefix-operator (lambda (self) (binding-prefix+infix-operator-prefix self))
+    #:property prop:binding-infix-operator (lambda (self) (binding-prefix+infix-operator-infix self))))
 
 (define-syntax (identifier-infoer stx)
   (syntax-parse stx

--- a/rhombus/private/class-primitive.rkt
+++ b/rhombus/private/class-primitive.rkt
@@ -37,7 +37,7 @@
                    #:defaults ([instance-static-infos #'()]))
         (~and creation (~or* #:new #:existing))
         (~optional (~and actual-class (~or* #:class)))
-        (~and mode (~or* #:transparent #:opaque #:translucent))
+        (~and mode (~or* #:transparent #:translucent #:just-binding #:opaque))
         (~optional (~seq #:parent Parent parent)
                    #:defaults ([parent #'#f]
                                [Parent #'#f]))
@@ -91,7 +91,8 @@
          ...)
         )
      #:do [(define transparent? (eq? '#:transparent (syntax-e #'mode)))
-           (define translucent? (eq? '#:translucent (syntax-e #'mode)))]
+           (define translucent? (eq? '#:translucent (syntax-e #'mode)))
+           (define just-binding? (eq? '#:just-binding (syntax-e #'mode)))]
      #:with name? (datum->syntax #'name (string->symbol (format "~a?" (syntax-e #'name))))
      #:with struct_name (datum->syntax #'name (string->symbol (format "struct:~a" (syntax-e #'name))))
      #:with ([prop prop-proc (~optional prop-mutator) prop-static-infos] ...)
@@ -200,7 +201,10 @@
                 (list
                  #'(set-primitive-contract! 'name? Name-str)
                  #'(define-annotation-syntax Name
-                     (identifier-annotation #'name? name-static-infos))
+                     (identifier-annotation #'name? name-static-infos)))
+                '())
+         #,@(if (or transparent? translucent? just-binding?)
+                (list
                  #`(define-syntax Name
                      (expression-transformer
                       (lambda (stx)

--- a/rhombus/private/range.rkt
+++ b/rhombus/private/range.rkt
@@ -1,6 +1,14 @@
 #lang racket/base
 (require (for-syntax racket/base
-                     syntax/parse/pre)
+                     (only-in racket/fixnum
+                              fixnum-for-every-system?)
+                     syntax/parse/pre
+                     "tag.rkt")
+         racket/hash-code
+         (only-in racket/unsafe/ops
+                  unsafe-fx+
+                  unsafe-fx<
+                  unsafe-fx<=)
          "expression.rkt"
          "static-info.rkt"
          "parse.rkt"
@@ -10,107 +18,877 @@
          "treelist.rkt"
          (submod "list.rkt" for-listable)
          "realm.rkt"
-         "number.rkt")
+         "number.rkt"
+         "provide.rkt"
+         "printer-property.rkt"
+         "print-desc.rkt"
+         "class-primitive.rkt"
+         (submod "annotation.rkt" for-class)
+         "binding.rkt"
+         (submod "dot.rkt" for-dot-provider)
+         "define-arity.rkt"
+         "call-result-key.rkt"
+         "sequence-constructor-key.rkt")
 
-(provide ..
-         ..=)
+(provide (for-spaces (rhombus/namespace
+                      rhombus/annot)
+                     Range)
+         (for-spaces (rhombus/annot)
+                     SequenceRange
+                     ListRange)
+         (for-spaces (#f
+                      rhombus/bind)
+                     ..
+                     ..=
+                     <..<
+                     <..=))
+
+(define-primitive-class Range range
+  #:lift-declaration
+  #:no-constructor-static-info
+  #:instance-static-info ()
+  #:existing
+  #:opaque
+  #:fields ()
+  #:namespace-fields
+  ([from_to Range.from_to]
+   [from_to_inclusive Range.from_to_inclusive]
+   [from Range.from]
+   [from_exclusive_to Range.from_exclusive_to]
+   [from_exclusive_to_inclusive Range.from_exclusive_to_inclusive]
+   [from_exclusive Range.from_exclusive]
+   [to Range.to]
+   [to_inclusive Range.to_inclusive]
+   [full Range.full]
+   [to_sequence Range.to_sequence]
+   [step_by Range.step_by]
+   [to_list Range.to_list])
+  #:properties
+  ()
+  #:methods
+  (start
+   end
+   includes_start
+   includes_end
+   has_element
+   encloses
+   is_connected
+   overlaps
+   span
+   gap
+   intersect))
+
+(define-for-syntax sequence-range-static-infos/sequence
+  #`((#%sequence-constructor Range.to_sequence/optimize)
+     (#%sequence-element #,int-static-infos)))
+
+(define-primitive-class SequenceRange sequence-range
+  #:lift-declaration
+  #:no-constructor-static-info
+  #:instance-static-info #,sequence-range-static-infos/sequence
+  #:existing
+  #:opaque
+  #:parent #f range
+  #:fields ()
+  #:namespace-fields
+  (#:no-methods)
+  #:properties
+  ()
+  #:methods
+  ([to_sequence Range.to_sequence]
+   [step_by Range.step_by]))
+
+(define-primitive-class ListRange list-range
+  #:lift-declaration
+  #:no-constructor-static-info
+  #:instance-static-info #,sequence-range-static-infos/sequence
+  #:existing
+  #:opaque
+  #:parent #f sequence-range
+  #:fields ()
+  #:namespace-fields
+  (#:no-methods)
+  #:properties
+  ()
+  #:methods
+  ([to_list Range.to_list]))
+
+(define-annotation-syntax SequenceRange
+  (identifier-annotation #'sequence-range? sequence-range-static-infos))
+
+(define-annotation-syntax Range
+  (identifier-annotation #'range? range-static-infos))
+
+(define-annotation-syntax ListRange
+  (identifier-annotation #'list-range? list-range-static-infos))
+
+(define-for-syntax range-assoc-table
+  `((,(expr-quote rhombus-a:+) . weaker)
+    (,(expr-quote rhombus-a:-) . weaker)
+    (,(expr-quote rhombus-a:*) . weaker)
+    (,(expr-quote rhombus-a:/) . weaker)))
 
 (define-syntax ..
+  (expression-prefix+infix-operator
+   (expression-prefix-operator
+    (expr-quote ..)
+    range-assoc-table
+    'macro
+    (lambda (tail)
+      (syntax-parse tail
+        [(_)
+         (values (wrap-static-info*
+                  #`(range-full)
+                  range-static-infos)
+                 #'())]
+        [(_ . more)
+         #:with (~var rhs (:prefix-op+expression+tail #'..)) #'(group . more)
+         (values (wrap-static-info*
+                  #`(range-to/who '.. rhs.parsed)
+                  range-static-infos)
+                 #'rhs.tail)])))
+   (expression-infix-operator
+    (expr-quote ..)
+    range-assoc-table
+    'macro
+    (lambda (form1 tail)
+      (syntax-parse tail
+        [(_)
+         (values (wrap-static-info*
+                  #`(range-from/who '.. #,form1)
+                  sequence-range-static-infos)
+                 #'())]
+        [(_ . more)
+         #:with (~var rhs (:infix-op+expression+tail #'..)) #'(group . more)
+         (values (wrap-static-info*
+                  #`(range-from-to/who '.. #,form1 rhs.parsed)
+                  list-range-static-infos)
+                 #'rhs.tail)]))
+    'none)))
+
+(define-syntax ..=
+  (expression-prefix+infix-operator
+   (expression-prefix-operator
+    (expr-quote ..=)
+    range-assoc-table
+    'automatic
+    (lambda (form stx)
+      (wrap-static-info*
+       #`(range-to-inclusive/who '..= #,form)
+       range-static-infos)))
+   (expression-infix-operator
+    (expr-quote ..=)
+    range-assoc-table
+    'automatic
+    (lambda (form1 form2 stx)
+      (wrap-static-info*
+       #`(range-from-to-inclusive/who '..= #,form1 #,form2)
+       list-range-static-infos))
+    'none)))
+
+(define-syntax <..<
   (expression-infix-operator
-   (expr-quote ..)
-   `((,(expr-quote rhombus-a:+) . weaker)
-     (,(expr-quote rhombus-a:-) . weaker)
-     (,(expr-quote rhombus-a:*) . weaker)
-     (,(expr-quote rhombus-a:/) . weaker))
+   (expr-quote <..<)
+   range-assoc-table
    'macro
    (lambda (form1 tail)
      (syntax-parse tail
        [(_)
-        (values (wrap-as-static-sequence #`(in-infinite-range #,form1))
+        (values (wrap-static-info*
+                 #`(range-from-exclusive/who '<..< #,form1)
+                 range-static-infos)
                 #'())]
        [(_ . more)
-        #:with (~var rhs (:infix-op+expression+tail #'..)) #'(group . more)
-        (values (wrap-as-static-sequence #`(in-listable-range #,form1 rhs.parsed))
+        #:with (~var rhs (:infix-op+expression+tail #'<..<)) #'(group . more)
+        (values (wrap-static-info*
+                 #`(range-from-exclusive-to/who '<..< #,form1 rhs.parsed)
+                 range-static-infos)
                 #'rhs.tail)]))
    'none))
 
-(define-syntax ..=
+(define-syntax <..=
   (expression-infix-operator
-   (expr-quote ..=)
-   `((,(expr-quote rhombus-a:+) . weaker)
-     (,(expr-quote rhombus-a:-) . weaker)
-     (,(expr-quote rhombus-a:*) . weaker)
-     (,(expr-quote rhombus-a:/) . weaker))
+   (expr-quote <..=)
+   range-assoc-table
    'automatic
    (lambda (form1 form2 stx)
-     (wrap-as-static-sequence #`(in-listable-inclusive-range #,form1 #,form2)))
+     (wrap-static-info*
+      #`(range-from-exclusive-to-inclusive/who '<..= #,form1 #,form2)
+      range-static-infos))
    'none))
 
-(define-for-syntax (wrap-as-static-sequence stx)
-  (wrap-static-info (wrap-static-info stx #'#%sequence-constructor #'#t)
-                    #'#%sequence-element int-static-infos))
+(define-binding-syntax ..
+  (binding-prefix+infix-operator
+   (binding-prefix-operator
+    (bind-quote ..)
+    `()
+    'macro
+    (lambda (tail)
+      (syntax-parse tail
+        [(_)
+         (values (parse-range-binding #'Range.full)
+                 #'())]
+        [(_ . more)
+         #:with (~var rhs (:prefix-op+binding+tail #'..)) #'(group . more)
+         (values (parse-range-binding #'Range.to #'rhs.parsed)
+                 #'rhs.tail)])))
+   (binding-infix-operator
+    (bind-quote ..)
+    `()
+    'macro
+    (lambda (form1 tail)
+      (syntax-parse tail
+        [(_)
+         (values (parse-range-binding #'Range.from form1)
+                 #'())]
+        [(_ . more)
+         #:with (~var rhs (:infix-op+binding+tail #'..)) #'(group . more)
+         (values (parse-range-binding #'Range.from_to form1 #'rhs.parsed)
+                 #'rhs.tail)]))
+    'none)))
 
-(struct listable-range (range)
-  #:property prop:sequence (lambda (r) (listable-range-range r))
-  #:property prop:Listable (vector (lambda (r)
-                                     (for/treelist ([e (listable-range-range r)])
-                                       e))))
+(define-binding-syntax ..=
+  (binding-prefix+infix-operator
+   (binding-prefix-operator
+    (bind-quote ..=)
+    `()
+    'automatic
+    (lambda (form stx)
+      (parse-range-binding #'Range.to_inclusive form)))
+   (binding-infix-operator
+    (bind-quote ..=)
+    `()
+    'automatic
+    (lambda (form1 form2 stx)
+      (parse-range-binding #'Range.from_to_inclusive form1 form2))
+    'none)))
 
-(define-syntax (define-listable-range stx)
+(define-binding-syntax <..<
+  (binding-infix-operator
+   (bind-quote <..<)
+   `()
+   'macro
+   (lambda (form1 tail)
+     (syntax-parse tail
+       [(_)
+        (values (parse-range-binding #'Range.from_exclusive form1)
+                #'())]
+       [(_ . more)
+        #:with (~var rhs (:infix-op+binding+tail #'<..<)) #'(group . more)
+        (values (parse-range-binding #'Range.from_exclusive_to form1 #'rhs.parsed)
+                #'rhs.tail)]))
+   'none))
+
+(define-binding-syntax <..=
+  (binding-infix-operator
+   (bind-quote <..=)
+   `()
+   'automatic
+   (lambda (form1 form2 stx)
+     (parse-range-binding #'Range.from_exclusive_to_inclusive form1 form2))
+   'none))
+
+(define-for-syntax (parse-range-binding range . parseds)
+  (syntax-parse #`(#,group-tag
+                   #,range
+                   (parens #,@(for/list ([parsed parseds])
+                                #`(#,group-tag (parsed #:rhombus/bind #,parsed)))))
+    [b::binding #'b.parsed]))
+
+(define (check-int who i)
+  (unless (exact-integer? i)
+    (raise-argument-error* who rhombus-realm "Int" i)))
+
+(define (check-pos-int who i)
+  (unless (exact-positive-integer? i)
+    (raise-argument-error* who rhombus-realm "PosInt" i)))
+
+(define (check-start-end who start end)
+  (unless (start . <= . end)
+    (raise-arguments-error* who rhombus-realm
+                            "starting point must be less than or equal to ending point"
+                            "starting point" (unquoted-printing-string (number->string start))
+                            "ending point" (unquoted-printing-string (number->string end)))))
+
+(define (step->inc step)
+  (if step
+      (lambda (i) (+ i step))
+      add1))
+
+(define-syntax (define-range stx)
   (syntax-parse stx
-    [(_ name in-range)
-     #'(begin
-         (define-sequence-syntax name
-           (lambda () #'proc)
-           (lambda (stx)
-             (syntax-parse stx
-               [[(d) (_ a b)]
-                #'[(d) (in-range a b)]]
-               [_ #f])))
-         (define proc
-           (let ([name (lambda (a b)
-                         (listable-range (in-range a b)))])
-             name)))]))
+    [(_ range name Name op-str (~or* #f start) (~or* #f end)
+        (~or* #f ->sequence)
+        (~or* #f ->list))
+     #:with range-method-table (datum->syntax
+                                #'range
+                                (string->symbol
+                                 (format "~a-method-table" (syntax->datum #'range))))
+     #:with unsafe-name (datum->syntax
+                         #'name
+                         (string->symbol
+                          (format "unsafe-~a" (syntax->datum #'name))))
+     #:attr name/who (and (or (attribute start)
+                              (attribute end))
+                          (datum->syntax
+                           #'name
+                           (string->symbol
+                            (format "~a/who" (syntax->datum #'name)))))
+     #:attr name-start (and (attribute start)
+                            (datum->syntax
+                             #'name
+                             (string->symbol
+                              (format "~a-~a" (syntax->datum #'name) (syntax->datum #'start)))))
+     #:attr name-end (and (attribute end)
+                          (datum->syntax
+                           #'name
+                           (string->symbol
+                            (format "~a-~a" (syntax->datum #'name) (syntax->datum #'end)))))
+     (syntax-local-lift-module-end-declaration
+      #'(struct name range ((~? start) (~? end))
+          #:omit-define-syntaxes
+          #:constructor-name unsafe-name
+          #:property prop:field-name->accessor (list* '() range-method-table #hasheq())
+          #:property prop:equal+hash (list
+                                      (lambda (v v2 eql?)
+                                        (and (~? (eql? (name-start v)
+                                                       (name-start v2)))
+                                             (~? (eql? (name-end v)
+                                                       (name-end v2)))))
+                                      (lambda (v hc)
+                                        (hash-code-combine
+                                         (~? (hc (name-start v)))
+                                         (~? (hc (name-end v)))))
+                                      (lambda (v hc)
+                                        (hash-code-combine
+                                         (~? (hc (name-start v)))
+                                         (~? (hc (name-end v))))))
+          #:property prop:printer (lambda (v mode recur)
+                                    (pretty-concat
+                                     (~? (~@ (PrintDesc-doc (recur (name-start v)))
+                                             (pretty-text " ")))
+                                     (pretty-text 'op-str)
+                                     (~? (~@ (pretty-text " ")
+                                             (PrintDesc-doc (recur (name-end v)))))))
+          (~? (~@ #:property prop:sequence (lambda (r) (->sequence r))))
+          (~? (~@ #:property prop:Listable (vector (lambda (r) (->list r)))))))
+     (syntax-local-lift-module-end-declaration
+      #'(define-primitive-class Name name
+          #:existing
+          #:just-binding
+          #:parent #f range
+          #:fields
+          ((~? [(start) #,int-static-infos])
+           (~? [(end) #,int-static-infos]))
+          #:properties
+          ()
+          #:methods
+          ()))
+     (if (attribute name/who)
+         #'(begin
+             (define (name/who who (~? start) (~? end))
+               (~? (check-int who start))
+               (~? (check-int who end))
+               (~? (check-start-end who start end))
+               (unsafe-name (~? start) (~? end)))
+             (define name
+               (let ([Name (lambda ((~? start) (~? end))
+                             (name/who 'Name (~? start) (~? end)))])
+                 Name)))
+         #'(define name
+             (let ([Name (lambda ()
+                           (unsafe-name))])
+               Name)))]))
 
-(define-listable-range in-listable-range in-range)
+(struct range ())
+(struct sequence-range range ())
+(struct list-range sequence-range ())
 
-(define-listable-range in-listable-inclusive-range in-inclusive-range)
+(define-range list-range range-from-to Range.from_to ".." start end
+  range-from-to->sequence
+  range-from-to->list)
 
-(define (check-integer who int)
-  (unless (exact-integer? int)
-    (raise-argument-error* who rhombus-realm "Int" int)))
+(define (range-from-to->sequence r [step #f])
+  (define start (range-from-to-start r))
+  (define end (range-from-to-end r))
+  (define (cont? i)
+    (i . < . end))
+  (range-sequence start (step->inc step) cont?))
 
-(define-sequence-syntax in-infinite-range
-  (lambda () #'in-infinite-range/proc)
-  (lambda (stx)
-    (syntax-parse stx
-      [[(id) (_ start-expr)]
-       #'[(id)
-          (:do-in
-           ([(start) start-expr])
-           (unless (variable-reference-from-unsafe? (#%variable-reference))
-             (check-integer 'in-infinite-range start))
-           ([pos start])
-           #t
-           ([(id) pos])
-           #t
-           #t
-           ((+ pos 1)))]]
-      [_ #f])))
+(define (range-from-to->list r)
+  (define start (range-from-to-start r))
+  (define end (range-from-to-end r))
+  (for/treelist ([i (Range.to_sequence/optimize (range-from-to start end))])
+    i))
 
-(define (in-infinite-range/proc start)
-  (check-integer 'in-infinite-range start)
-  (infinite-range start))
+(define-range list-range range-from-to-inclusive Range.from_to_inclusive "..=" start end
+  range-from-to-inclusive->sequence
+  range-from-to-inclusive->list)
 
-(struct infinite-range (start)
+(define (range-from-to-inclusive->sequence r [step #f])
+  (define start (range-from-to-inclusive-start r))
+  (define end (range-from-to-inclusive-end r))
+  (define (cont? i)
+    (i . <= . end))
+  (range-sequence start (step->inc step) cont?))
+
+(define (range-from-to-inclusive->list r)
+  (define start (range-from-to-inclusive-start r))
+  (define end (range-from-to-inclusive-end r))
+  (for/treelist ([i (Range.to_sequence/optimize (range-from-to-inclusive start end))])
+    i))
+
+(define-range sequence-range range-from Range.from ".." start #f
+  range-from->sequence
+  #f)
+
+(define (range-from->sequence r [step #f])
+  (define start (range-from-start r))
+  (range-sequence start (step->inc step) #f))
+
+(define-range range range-from-exclusive-to Range.from_exclusive_to "<..<" start end
+  #f
+  #f)
+
+(define-range range range-from-exclusive-to-inclusive Range.from_exclusive_to_inclusive "<..=" start end
+  #f
+  #f)
+
+(define-range range range-from-exclusive Range.from_exclusive "<..<" start #f
+  #f
+  #f)
+
+(define-range range range-to Range.to ".." #f end
+  #f
+  #f)
+
+(define-range range range-to-inclusive Range.to_inclusive "..=" #f end
+  #f
+  #f)
+
+(define-range range range-full Range.full ".." #f #f
+  #f
+  #f)
+
+(struct range-sequence (start inc cont?)
   #:property prop:sequence (lambda (r)
                              (make-do-sequence
                               (lambda ()
                                 (values
                                  values
                                  #f
-                                 add1
-                                 (infinite-range-start r)
-                                 #f
+                                 (range-sequence-inc r)
+                                 (range-sequence-start r)
+                                 (range-sequence-cont? r)
                                  #f
                                  #f)))))
+
+(define (check-range who r)
+  (unless (range? r)
+    (raise-argument-error* who rhombus-realm "Range" r)))
+
+(define (check-sequence-range who r)
+  (unless (sequence-range? r)
+    (raise-argument-error* who rhombus-realm "SequenceRange" r)))
+
+(define (check-list-range who r)
+  (unless (list-range? r)
+    (raise-argument-error* who rhombus-realm "ListRange" r)))
+
+(define/method (Range.start r)
+  #:static-infos ((#%call-result #,int-static-infos))
+  (check-range who r)
+  (cond
+    [(range-from-to? r) (range-from-to-start r)]
+    [(range-from-to-inclusive? r) (range-from-to-inclusive-start r)]
+    [(range-from? r) (range-from-start r)]
+    [(range-from-exclusive-to? r) (range-from-exclusive-to-start r)]
+    [(range-from-exclusive-to-inclusive? r) (range-from-exclusive-to-inclusive-start r)]
+    [(range-from-exclusive? r) (range-from-exclusive-start r)]
+    [else -inf.0]))
+
+(define/method (Range.end r)
+  #:static-infos ((#%call-result #,int-static-infos))
+  (check-range who r)
+  (cond
+    [(range-from-to? r) (range-from-to-end r)]
+    [(range-from-to-inclusive? r) (range-from-to-inclusive-end r)]
+    [(range-from-exclusive-to? r) (range-from-exclusive-to-end r)]
+    [(range-from-exclusive-to-inclusive? r) (range-from-exclusive-to-inclusive-end r)]
+    [(range-to? r) (range-to-end r)]
+    [(range-to-inclusive? r) (range-to-inclusive-end r)]
+    [else +inf.0]))
+
+(define/method (Range.includes_start r)
+  (check-range who r)
+  (or (range-from-to? r)
+      (range-from-to-inclusive? r)
+      (range-from? r)))
+
+(define/method (Range.includes_end r)
+  (check-range who r)
+  (or (range-from-to-inclusive? r)
+      (range-from-exclusive-to-inclusive? r)
+      (range-to-inclusive? r)))
+
+;; NOTE The following implementation borrows from Rebellion, but does
+;; so in a way that doesn't use cuts and therefore doesn't allocate.
+(define (range-explode r)
+  (cond
+    [(range-from-to? r)
+     (values (range-from-to-start r) #t
+             (range-from-to-end r) #f)]
+    [(range-from-to-inclusive? r)
+     (values (range-from-to-inclusive-start r) #t
+             (range-from-to-inclusive-end r) #t)]
+    [(range-from? r)
+     (values (range-from-start r) #t
+             +inf.0 #f)]
+    [(range-from-exclusive-to? r)
+     (values (range-from-exclusive-to-start r) #f
+             (range-from-exclusive-to-end r) #f)]
+    [(range-from-exclusive-to-inclusive? r)
+     (values (range-from-exclusive-to-inclusive-start r) #f
+             (range-from-exclusive-to-inclusive-end r) #t)]
+    [(range-from-exclusive? r)
+     (values (range-from-exclusive-start r) #f
+             +inf.0 #f)]
+    [(range-to? r)
+     (values -inf.0 #f
+             (range-to-end r) #f)]
+    [(range-to-inclusive? r)
+     (values -inf.0 #f
+             (range-to-inclusive-end r) #t)]
+    [else
+     (values -inf.0 #f
+             +inf.0 #f)]))
+
+(define (range-implode start in-start? end in-end?)
+  (if (eqv? start -inf.0)
+      (if (eqv? end +inf.0)
+          (range-full)
+          (if in-end?
+              (range-to-inclusive end)
+              (range-to end)))
+      (if (eqv? end +inf.0)
+          (if in-start?
+              (range-from start)
+              (range-from-exclusive start))
+          (if in-start?
+              (if in-end?
+                  (range-from-to-inclusive start end)
+                  (range-from-to start end))
+              (if in-end?
+                  (range-from-exclusive-to-inclusive start end)
+                  (range-from-exclusive-to start end))))))
+
+;; `lower?`: `in-start?` or `(not in-end?)`
+(define (bound<? point lower?
+                 other-point other-lower?)
+  (or (point . < . other-point)
+      (and lower?
+           (not other-lower?)
+           (= point other-point))))
+
+;; `upper?`: `(not in-start?)` or `in-end?`
+(define (bound>? point upper?
+                 other-point other-upper?)
+  (or (point . > . other-point)
+      (and upper?
+           (not other-upper?)
+           (= point other-point))))
+
+(define/method (Range.has_element r i)
+  (check-range who r)
+  (check-int who i)
+  (define-values (start in-start? end in-end?)
+    (range-explode r))
+  (and (bound<? start in-start?
+                i #f)
+       (bound<? i #t
+                end (not in-end?))))
+
+(define (range-encloses? r other-r)
+  (define-values (start in-start? end in-end?)
+    (range-explode r))
+  (define-values (other-start other-in-start? other-end other-in-end?)
+    (range-explode other-r))
+  (and (not (bound>? start (not in-start?)
+                     other-start (not other-in-start?)))
+       (not (bound<? end (not in-end?)
+                     other-end (not other-in-end?)))))
+
+(define/method Range.encloses
+  (case-lambda
+    [() #t]
+    [(r)
+     (check-range who r)
+     #t]
+    [(r other-r)
+     (check-range who r)
+     (check-range who other-r)
+     (range-encloses? r other-r)]
+    [(r . other-rs)
+     (check-range who r)
+     (for ([other-r (in-list other-rs)])
+       (check-range who other-r))
+     (let loop ([r r] [other-rs other-rs])
+       (cond
+         [(null? other-rs) #t]
+         [else (and (range-encloses? r (car other-rs))
+                    (loop (car other-rs) (cdr other-rs)))]))]))
+
+(define (range-connected?/internal start in-start? end in-end?
+                                   other-start other-in-start? other-end other-in-end?)
+  (and (not (bound>? start (not in-start?)
+                     other-end other-in-end?))
+       (not (bound>? other-start (not other-in-start?)
+                     end in-end?))))
+
+(define/method (Range.is_connected r other-r)
+  (check-range who r)
+  (check-range who other-r)
+  (define-values (start in-start? end in-end?)
+    (range-explode r))
+  (define-values (other-start other-in-start? other-end other-in-end?)
+    (range-explode other-r))
+  (range-connected?/internal start in-start? end in-end?
+                             other-start other-in-start? other-end other-in-end?))
+
+(define/method (Range.overlaps r other-r)
+  (check-range who r)
+  (check-range who other-r)
+  (define-values (start in-start? end in-end?)
+    (range-explode r))
+  (define-values (other-start other-in-start? other-end other-in-end?)
+    (range-explode other-r))
+  (and (bound<? start in-start?
+                other-end (not other-in-end?))
+       (bound>? end in-end?
+                other-start (not other-in-start?))))
+
+(define (range-span r other-r)
+  (define-values (start in-start? end in-end?)
+    (range-explode r))
+  (define-values (other-start other-in-start? other-end other-in-end?)
+    (range-explode other-r))
+  (define-values (new-start new-in-start?)
+    (if (bound>? start (not in-start?)
+                 other-start (not other-in-start?))
+        (values other-start other-in-start?)
+        (values start in-start?)))
+  (define-values (new-end new-in-end?)
+    (if (bound<? end (not in-end?)
+                 other-end (not other-in-end?))
+        (values other-end other-in-end?)
+        (values end in-end?)))
+  (range-implode new-start new-in-start? new-end new-in-end?))
+
+(define/method Range.span
+  #:static-infos ((#%call-result #,range-static-infos))
+  (case-lambda
+    [(r)
+     (check-range who r)
+     r]
+    [(r other-r)
+     (check-range who r)
+     (check-range who other-r)
+     (range-span r other-r)]
+    [(r . other-rs)
+     (check-range who r)
+     (for ([other-r (in-list other-rs)])
+       (check-range who other-r))
+     (for/fold ([r r])
+               ([other-r (in-list other-rs)])
+       (range-span r other-r))]))
+
+(define/method (Range.gap r other-r)
+  (check-range who r)
+  (check-range who other-r)
+  (define-values (start in-start? end in-end?)
+    (range-explode r))
+  (define-values (other-start other-in-start? other-end other-in-end?)
+    (range-explode other-r))
+  (cond
+    [(not (bound<? start in-start?
+                   other-end (not other-in-end?)))
+     (range-implode other-end (not other-in-end?)
+                    start (not in-start?))]
+    [(not (bound>? end in-end?
+                   other-start (not other-in-start?)))
+     (range-implode end (not in-end?)
+                    other-start (not other-in-start?))]
+    [else #f]))
+
+(define (range-intersect r other-r)
+  (define-values (start in-start? end in-end?)
+    (range-explode r))
+  (define-values (other-start other-in-start? other-end other-in-end?)
+    (range-explode other-r))
+  (cond
+    [(range-connected?/internal start in-start? end in-end?
+                                other-start other-in-start? other-end other-in-end?)
+     (define-values (new-start new-in-start?)
+       (if (bound<? start in-start?
+                    other-start other-in-start?)
+           (values other-start other-in-start?)
+           (values start in-start?)))
+     (define-values (new-end new-in-end?)
+       (if (bound>? end in-end?
+                    other-end other-in-end?)
+           (values other-end other-in-end?)
+           (values end in-end?)))
+     (range-implode new-start new-in-start? new-end new-in-end?)]
+    [else #f]))
+
+(define/method Range.intersect
+  (case-lambda
+    [() (range-full)]
+    [(r)
+     (check-range who r)
+     r]
+    [(r other-r)
+     (check-range who r)
+     (check-range who other-r)
+     (range-intersect r other-r)]
+    [(r . other-rs)
+     (check-range who r)
+     (for ([other-r (in-list other-rs)])
+       (check-range who other-r))
+     (for/fold ([r r])
+               ([other-r (in-list other-rs)])
+       #:break (not r)
+       (range-intersect r other-r))]))
+
+(define-sequence-syntax Range.to_sequence/optimize
+  (lambda () #'Range.to_sequence)
+  (lambda (stx)
+    (syntax-parse stx
+      [[(id) (_ inner)]
+       (syntax-parse (unwrap-static-infos #'inner)
+         #:literals (range-from-to range-from-to-inclusive range-from)
+         [(range-from-to start-expr end-expr)
+          (range-sequence/optimize 'Range.from_to #'id #'start-expr #'end-expr 'exclusive)]
+         [(range-from-to-inclusive start-expr end-expr)
+          (range-sequence/optimize 'Range.from_to_inclusive #'id #'start-expr #'end-expr 'inclusive)]
+         [(range-from start-expr)
+          (range-sequence/optimize 'Range.from #'id #'start-expr #f 'infinite)]
+         [_ #f])]
+      [_ #f])))
+
+(define/method (Range.to_sequence r)
+  #:static-infos ((#%call-result ((#%sequence-constructor #t)
+                                  (#%sequence-element #,int-static-infos))))
+  (check-sequence-range who r)
+  (cond
+    [(range-from-to? r) (range-from-to->sequence r)]
+    [(range-from-to-inclusive? r) (range-from-to-inclusive->sequence r)]
+    [else (range-from->sequence r)]))
+
+(define-sequence-syntax Range.step_by/optimize
+  (lambda () #'Range.step_by)
+  (lambda (stx)
+    (syntax-parse stx
+      [[(id) (_ inner step-expr)]
+       (define step-who 'Range.step_by)
+       (syntax-parse (unwrap-static-infos #'inner)
+         #:literals (range-from-to range-from-to-inclusive range-from)
+         [(range-from-to start-expr end-expr)
+          (range-sequence/optimize 'Range.from_to #'id #'start-expr #'end-expr 'exclusive
+                                   #:step-who step-who
+                                   #:step-expr #'step-expr)]
+         [(range-from-to-inclusive start-expr end-expr)
+          (range-sequence/optimize 'Range.from_to_inclusive #'id #'start-expr #'end-expr 'inclusive
+                                   #:step-who step-who
+                                   #:step-expr #'step-expr)]
+         [(range-from start-expr)
+          (range-sequence/optimize 'Range.from #'id #'start-expr #f 'infinite
+                                   #:step-who step-who
+                                   #:step-expr #'step-expr)]
+         [_ #f])]
+      [_ #f])))
+
+(define-static-info-syntax Range.step_by/optimize
+  (#%call-result ((#%sequence-constructor #t)
+                  (#%sequence-element #,int-static-infos))))
+
+(define/method #:direct-id Range.step_by/optimize (Range.step_by r step)
+  #:static-infos ((#%call-result ((#%sequence-constructor #t)
+                                  (#%sequence-element #,int-static-infos))))
+  (check-sequence-range who r)
+  (check-pos-int who step)
+  (cond
+    [(range-from-to? r) (range-from-to->sequence r step)]
+    [(range-from-to-inclusive? r) (range-from-to-inclusive->sequence r step)]
+    [else (range-from->sequence r step)]))
+
+(define-for-syntax (range-sequence/optimize who id start-expr-in end-expr-in type
+                                            #:step-who [step-who #f]
+                                            #:step-expr [step-expr-in #f])
+  (define (maybe-unwrap-static-infos maybe-stx)
+    (and maybe-stx
+         (unwrap-static-infos maybe-stx)))
+  (define (maybe-unwrap-fixnum stx)
+    (syntax-parse stx
+      #:literals (quote)
+      [(quote num)
+       (define datum (syntax-e #'num))
+       (and (fixnum-for-every-system? datum)
+            datum)]
+      [_ #f]))
+  (define start-expr (maybe-unwrap-static-infos start-expr-in))
+  (define end-expr (maybe-unwrap-static-infos end-expr-in))
+  (define step-expr (maybe-unwrap-static-infos step-expr-in))
+  (define use-unsafe? (and (maybe-unwrap-fixnum start-expr)
+                           (let* ([end (and end-expr
+                                            (maybe-unwrap-fixnum end-expr))]
+                                  [step (and end
+                                             (if step-expr
+                                                 (maybe-unwrap-fixnum step-expr)
+                                                 1))])
+                             ;; conservatively check that the biggest
+                             ;; ending integer must be fixnum
+                             (and step
+                                  (fixnum-for-every-system?
+                                   (+ (case type
+                                        [(exclusive) (sub1 end)]
+                                        [(inclusive) end]
+                                        [else (error "cannot happen")])
+                                      step))))))
+  #`[(#,id) (:do-in
+             ([(start) #,start-expr]
+              #,@(if end-expr
+                     (list #`[(end) #,end-expr])
+                     '())
+              #,@(if step-expr
+                     (list #`[(step) #,step-expr])
+                     '()))
+             (unless (variable-reference-from-unsafe? (#%variable-reference))
+               (check-int '#,who start)
+               #,@(if end-expr
+                      (list #`(check-int '#,who end)
+                            #`(check-start-end '#,who start end))
+                      '())
+               #,@(if step-expr
+                      (list #`(check-pos-int '#,step-who step))
+                      '()))
+             ([pos start])
+             #,(let ([<-stx (case type
+                              [(exclusive) (if use-unsafe? #'unsafe-fx< #'<)]
+                              [(inclusive) (if use-unsafe? #'unsafe-fx<= #'<=)]
+                              [(infinite) #f]
+                              [else (error "cannot happen")])])
+                 (if <-stx #`(pos . #,<-stx . end) #'#t))
+             ([(#,id) pos])
+             #t
+             #t
+             ((#,(if use-unsafe? #'unsafe-fx+ #'+)
+               pos
+               #,(if step-expr #'step #'1))))])
+
+(define/method (Range.to_list r)
+  #:static-infos ((#%call-result #,treelist-static-infos))
+  (check-list-range who r)
+  (cond
+    [(range-from-to? r) (range-from-to->list r)]
+    [else (range-from-to-inclusive->list r)]))

--- a/rhombus/scribblings/ref-range.scrbl
+++ b/rhombus/scribblings/ref-range.scrbl
@@ -1,0 +1,460 @@
+#lang scribble/rhombus/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@title{Ranges}
+
+A @deftech{range}, or an @deftech{interval}, represents a contiguous
+set of integers between two points. When the starting point is
+included, the range can be used as a @tech{sequence}; in addition,
+when the ending point is not @rhombus(#inf), the range is
+@tech{listable}.
+
+@dispatch_table(
+  "range"
+  Range
+  rge.start()
+  rge.end()
+  rge.includes_start()
+  rge.includes_end()
+  rge.has_element(int)
+  rge.encloses(rge2, ...)
+  rge.is_connected(rge2)
+  rge.overlaps(rge2)
+  rge.span(rge2, ...)
+  rge.gap(rge2)
+  rge.intersect(rge2, ...)
+)
+
+@dispatch_table(
+  "range (sequenceable)"
+  Range
+  rge.to_sequence()
+  rge.step_by(step)
+)
+
+@dispatch_table(
+  "range (listable)"
+  Range
+  rge.to_list()
+)
+
+@doc(
+  annot.macro 'Range'
+  annot.macro 'SequenceRange'
+  annot.macro 'ListRange'
+){
+
+ The @rhombus(Range, ~annot) annotaiton matches any range.
+
+ The @rhombus(SequenceRange, ~annot) annotation matches a range that
+ can be used as a @tech{sequence}, for which
+ @rhombus(Range.includes_start) returns true.
+
+ The @rhombus(ListRange, ~annot) annotation matches a range that is
+ @tech{listable}, for which @rhombus(Range.includes_start) returns
+ true, and @rhombus(Range.end) returns non-@rhombus(#inf).
+
+ Static information associated by @rhombus(SequenceRange, ~annot) or
+ @rhombus(ListRange, ~annot) makes an expression acceptable as a
+ sequence to @rhombus(for) in static mode.
+
+}
+
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    end_expr: block expr
+    start_bind: def bind ~defn
+    end_bind: def bind ~defn
+  expr.macro '$start_expr .. $end_expr'
+  bind.macro '$start_bind .. $end_bind'
+  expr.macro '$start_expr ..'
+  bind.macro '$start_bind ..'
+  expr.macro '.. $end_expr'
+  bind.macro '.. $end_bind'
+  expr.macro '..'
+  bind.macro '..'
+){
+
+ The same as @rhombus(Range.from_to, ~expr),
+ @rhombus(Range.from, ~expr), @rhombus(Range.to, ~expr), and
+ @rhombus(Range.full, ~expr), respectively.
+
+}
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    end_expr: block expr
+    start_bind: def bind ~defn
+    end_bind: def bind ~defn
+  expr.macro '$start_expr ..= $end_expr'
+  bind.macro '$start_bind ..= $end_bind'
+  expr.macro '..= $end_expr'
+  bind.macro '..= $end_bind'
+){
+
+ The same as @rhombus(Range.from_to_inclusive, ~expr) and
+ @rhombus(Range.to_inclusive, ~expr), respectively.
+
+}
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    end_expr: block expr
+    start_bind: def bind ~defn
+    end_bind: def bind ~defn
+  expr.macro '$start_expr <..< $end_expr'
+  bind.macro '$start_bind <..< $end_bind'
+  expr.macro '$start_expr <..<'
+  bind.macro '$start_bind <..<'
+){
+
+ The same as @rhombus(Range.from_exclusive_to, ~expr) and
+ @rhombus(Range.from_exclusive, ~expr), respectively.
+
+}
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    end_expr: block expr
+    start_bind: def bind ~defn
+    end_bind: def bind ~defn
+  expr.macro '$start_expr <..= $end_expr'
+  bind.macro '$start_bind <..= $end_bind'
+){
+
+ The same as @rhombus(Range.from_exclusive_to_inclusive, ~expr).
+
+}
+
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    end_expr: block expr
+    start_bind: def bind ~defn
+    end_bind: def bind ~defn
+  fun Range.from_to(start :: Int, end :: Int) :: ListRange
+  bind.macro 'Range.from_to($start_bind, $end_bind)'
+){
+
+ Constructs a range that includes @rhombus(start), but does not
+ include @rhombus(end). The corresponding binding matches the
+ constructed range.
+
+}
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    end_expr: block expr
+    start_bind: def bind ~defn
+    end_bind: def bind ~defn
+  fun Range.from_to_inclusive(start :: Int, end :: Int)
+    :: ListRange
+  bind.macro 'Range.from_to_inclusive($start_bind, $end_bind)'
+){
+
+ Constructs a range that includes both @rhombus(start) and
+ @rhombus(end). The corresponding binding matches the constructed
+ range.
+
+}
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    start_bind: def bind ~defn
+  fun Range.from(start :: Int) :: SequenceRange
+  bind.macro 'Range.from($start_bind)'
+){
+
+ Constructs a range that includes @rhombus(start), and with
+ @rhombus(#inf) as the ending point. The corresponding binding matches
+ the constructed range.
+
+}
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    end_expr: block expr
+    start_bind: def bind ~defn
+    end_bind: def bind ~defn
+  fun Range.from_exclusive_to(start :: Int, end :: Int)
+    :: Range
+  bind.macro 'Range.from_exclusive_to($start_bind, $end_bind)'
+){
+
+ Constructs a range that does not include either @rhombus(start) or
+ @rhombus(end). The corresponding binding matches the constructed
+ range.
+
+}
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    end_expr: block expr
+    start_bind: def bind ~defn
+    end_bind: def bind ~defn
+  fun Range.from_exclusive_to_inclusive(start :: Int,
+                                        end :: Int)
+    :: Range
+  bind.macro 'Range.from_exclusive_to_inclusive($start_bind,
+                                                $end_bind)'
+){
+
+ Constructs a range that does not include @rhombus(start), but
+ includes @rhombus(end). The corresponding binding matches the
+ constructed range.
+
+}
+
+@doc(
+  ~nonterminal:
+    start_expr: block expr
+    start_bind: def bind ~defn
+  fun Range.from_exclusive(start :: Int) :: Range
+  bind.macro 'Range.from_exclusive($start_bind)'
+){
+
+ Constructs a range that does not include @rhombus(start), and with
+ @rhombus(#inf) as the ending point. The corresponding binding matches
+ the constructed range.
+
+}
+
+@doc(
+  ~nonterminal:
+    end_expr: block expr
+    end_bind: def bind ~defn
+  fun Range.to(end :: Int) :: Range
+  bind.macro 'Range.to($end_bind)'
+){
+
+ Constructs a range with @rhombus(#neginf) as the starting point, and
+ does not include @rhombus(end). The corresponding binding matches the
+ constructed range.
+
+}
+
+@doc(
+  ~nonterminal:
+    end_expr: block expr
+    end_bind: def bind ~defn
+  fun Range.to_inclusive(end :: Int) :: Range
+  bind.macro 'Range.to_inclusive($end_bind)'
+){
+
+ Constructs a range with @rhombus(#neginf) as the starting point, and
+ includes @rhombus(end). The corresponding binding matches the
+ constructed range.
+
+}
+
+@doc(
+  fun Range.full() :: Range
+  bind.macro 'Range.full()'
+){
+
+ Constructs a range with @rhombus(#neginf) as the starting point and
+ @rhombus(#inf) as the ending point. The corresponding binding matches
+ the constructed range.
+
+}
+
+
+@doc(
+  fun Range.start(rge :: Range) :: Int || matching(#neginf)
+  fun Range.end(rge :: Range) :: Int || matching(#inf)
+){
+
+ Returns the starting point and ending point of @rhombus(rge),
+ respectively. The starting point can be @rhombus(#neginf), and the
+ ending point can be @rhombus(#inf), indicating the lack of a starting
+ point or ending point.
+
+}
+
+@doc(
+  fun Range.includes_start(rge :: Range) :: Boolean
+  fun Range.includes_end(rge :: Range) :: Boolean
+){
+
+ Returns @rhombus(#true) if @rhombus(rge) includes the starting point
+ and the ending point, respectively, @rhombus(#false) otherwise. A
+ @rhombus(#neginf) starting point or @rhombus(#inf) ending point
+ cannot be included.
+
+}
+
+
+@doc(
+  fun Range.has_element(rge :: Range, int :: Int) :: Boolean
+){
+
+ Checks whether @rhombus(rge) has @rhombus(int) in the range that it
+ represents.
+
+@examples(
+  (3..=7).has_element(5)
+  (3..=7).has_element(7)
+  (3..=7).has_element(10)
+)
+
+}
+
+
+@doc(
+  fun Range.encloses(rge :: Range, ...) :: Boolean
+){
+
+ Checks whether @rhombus(rge)s are in enclosing order. A range
+ @rhombus(rge, ~var) encloses another range @rhombus(rge2, ~var) when
+ @rhombus(rge, ~var) has every integer in @rhombus(rge2, ~var). Every
+ range encloses itself, and empty ranges never enclose non-empty
+ ranges.
+
+@examples(
+  Range.encloses()
+  (2 <..< 8).encloses()
+  (2 <..< 8).encloses(4..=6)
+  (2 <..< 8).encloses(2..=6, 4..=6)
+  (2 <..< 8).encloses(5..)
+  (2 <..<).encloses(5..)
+)
+
+}
+
+@doc(
+  fun Range.is_connected(rge :: Range, rge2 :: Range) :: Boolean
+){
+
+ Checks whether @rhombus(rge) is connected with @rhombus(rge2), that
+ is, whether there exists a range (possibly empty) that is enclosed by
+ both @rhombus(rge) and @rhombus(rge2).
+
+@examples(
+  (2..=7).is_connected(3 <..< 8)
+  (2..=5).is_connected(5 <..< 8)
+  (2 <..< 5).is_connected(5 <..< 8)
+)
+
+}
+
+@doc(
+  fun Range.overlaps(rge :: Range, rge2 :: Range) :: Boolean
+){
+
+ Checks whether @rhombus(rge) overlaps with @rhombus(rge2), that is,
+ whether there exists a non-empty range that is enclosed by both
+ @rhombus(rge) and @rhombus(rge2).
+
+@examples(
+  (2..=7).overlaps(3 <..< 8)
+  (2..=5).overlaps(5..=8)
+  (2..=5).overlaps(5 <..< 8)
+)
+
+}
+
+
+@doc(
+  fun Range.span(rge0 :: Range, rge :: Range, ...) :: Range
+){
+
+ Returns the smallest range that encloses all @rhombus(rge)s
+ (including @rhombus(rge0)).
+
+@examples(
+  (2..=5).span()
+  (2..=5).span(8 <..< 9)
+  (..4).span(6..=6)
+  (2 <..< 8).span(..=5, 8 <..< 9)
+)
+
+}
+
+@doc(
+  fun Range.gap(rge :: Range, rge2 :: Range) :: maybe(Range)
+){
+
+ Returns the largest range that lies between @rhombus(rge) and
+ @rhombus(rge2), or @rhombus(#false) if no such range exists
+ (precisely when @rhombus(rge) overlaps with @rhombus(rge2)).
+
+@examples(
+  (2..=5).gap(8..=9)
+  (..4).gap(6..=6)
+  (2 <..< 8).gap(8..=10)
+  (2..=8).gap(8..=10)
+)
+
+}
+
+@doc(
+  fun Range.intersect(rge :: Range, ...) :: maybe(Range)
+){
+
+ Returns the intersection of all @rhombus(rge)s, or @rhombus(#false)
+ if no such range exists. The intersection of a range
+ @rhombus(rge, ~var) and another range @rhombus(rge2, ~var) is the
+ largest range that is enclosed by both @rhombus(rge, ~var) and
+ @rhombus(rge2, ~var), which only exists when @rhombus(rge, ~var) is
+ connected with @rhombus(rge2, ~var).
+
+@examples(
+  Range.intersect()
+  (2..=8).intersect()
+  (2..=8).intersect(4 <..< 16)
+  (4 <..<).intersect(..6, 2..=8)
+  (2 <..< 8).intersect(..=5)
+  (2 <..< 8).intersect(8 <..< 10)
+)
+
+}
+
+
+@doc(
+  fun Range.to_list(rge :: ListRange) :: List
+){
+
+ Implements @rhombus(Listable, ~class) by returning a @tech{list} of
+ integers in @rhombus(rge) in order.
+
+}
+
+
+@doc(
+  fun Range.to_sequence(rge :: SequenceRange) :: Sequence
+){
+
+ Implements @rhombus(Sequenceable, ~class) by returning a
+ @tech{sequence} of integers in @rhombus(rge) in order. The sequence
+ is infinite when the ending point is @rhombus(#inf).
+
+}
+
+@doc(
+  fun Range.step_by(rge :: SequenceRange, step :: PosInt)
+    :: Sequence
+){
+
+ Returns a @tech{sequence} of integers in @rhombus(rge) in order,
+ stepping by the given @rhombus(step) size.
+
+ When invoked as
+ @rhombus((#,(@rhombus(start, ~var)) .. #,(@rhombus(end, ~var))).step_by(step)),
+ @rhombus((#,(@rhombus(start, ~var)) ..= #,(@rhombus(end, ~var))).step_by(step)),
+ or @rhombus((#,(@rhombus(start, ~var)) ..).step_by(step))
+ in an @rhombus(each, ~for_clause) clause of @rhombus(for), the
+ sequence is optimized.
+
+}

--- a/rhombus/scribblings/ref-sequence.scrbl
+++ b/rhombus/scribblings/ref-sequence.scrbl
@@ -3,9 +3,6 @@
     "common.rhm" open
     "nonterminal.rhm" open)
 
-@(def dots = @rhombus(..., ~bind))
-@(def dots_expr = @rhombus(...))
-
 @title{Sequences}
 
 A @deftech{sequence} supplies elements to a @rhombus(for) iteration.
@@ -28,41 +25,6 @@ internal state, and the state can even be specific to a particular
  expression acceptable as a sequence to @rhombus(for) in static mode, and
  it is suitable when a more specialized annotation (such as
  @rhombus(List) or @rhombus(Array)) is not available.
-
-}
-
-
-@doc(
-  ~nonterminal:
-    n_expr: block expr
-    m_expr: block expr
-  expr.macro '$n_expr .. $m_expr'
-  expr.macro '$n_expr ..'
-){
-
- If @rhombus(n_expr) produces an integer @rhombus(n, ~var) and
- @rhombus(m_expr) (when supplied) produces an integer @rhombus(m, ~var),
- returns a @tech{listable} @tech{sequence} containing the integers from @rhombus(n, ~var)
- (inclusive) to @rhombus(m, ~var) (exclusive). If @rhombus(m_expr) is not
- specified, the result is an infinite sequence that contains all integers
- starting from @rhombus(n, ~var).
-
- The @rhombus(..) operator's precedence is lower than the arithmetic operators
- @rhombus(+), @rhombus(-), @rhombus(*), and @rhombus(/).
-
- A @rhombus(..) expression has static information that makes it
- acceptable as a sequence to @rhombus(for) in static mode.
-
-}
-
-@doc(
-  ~nonterminal:
-    n_expr: block expr
-    m_expr: block expr
-  expr.macro '$n_expr ..= $m_expr'
-){
-
- Like @rhombus(n_expr .. m_expr), but with an inclusive upper bound.
 
 }
 

--- a/rhombus/scribblings/reference.scrbl
+++ b/rhombus/scribblings/reference.scrbl
@@ -52,6 +52,7 @@
 @include_section("ref-map.scrbl")
 @include_section("ref-set.scrbl")
 @include_section("ref-box.scrbl")
+@include_section("ref-range.scrbl")
 @include_section("ref-indexable.scrbl")
 @include_section("ref-listable.scrbl")
 @include_section("ref-sequence.scrbl")

--- a/rhombus/tests/range.rhm
+++ b/rhombus/tests/range.rhm
@@ -1,0 +1,1488 @@
+#lang rhombus
+
+block:
+  import "static_arity.rhm"
+  static_arity.check:
+    Range.from_to(start, end)
+    Range.from_to_inclusive(start, end)
+    Range.from(start)
+    Range.from_exclusive_to(start, end)
+    Range.from_exclusive_to_inclusive(start, end)
+    Range.from_exclusive(start)
+    Range.to(end)
+    Range.to_inclusive(end)
+    Range.full()
+    Range.start(rge) ~method
+    Range.end(rge) ~method
+    Range.includes_start(rge) ~method
+    Range.includes_end(rge) ~method
+    Range.has_element(rge, v) ~method
+    Range.encloses(rge, ...) ~method
+    Range.is_connected(rge, other) ~method
+    Range.overlaps(rge, other) ~method
+    Range.span(rge, other, ...) ~method
+    Range.gap(rge, other) ~method
+    Range.intersect(rge, ...) ~method
+    Range.to_sequence(rge) ~method SequenceRange
+    Range.step_by(rge, step) ~method SequenceRange
+    Range.to_list(rge) ~method ListRange
+
+// basic sanity checks
+block:
+  def rge = 0..5
+  check rge ~is 0..5
+  check rge ~matches 0..5
+  check rge ~is Range.from_to(0, 5)
+  check rge ~matches Range.from_to(0, 5)
+  check rge ~matches !(0..4)
+  check rge ~matches !(1..5)
+  check rge ~matches !(0..=5)
+  check to_string(rge) ~is "0 .. 5"
+  block:
+    use_static
+    check:
+      rge.start() ~is 0
+      rge.end() ~is 5
+      rge.includes_start() ~is #true
+      rge.includes_end() ~is #false
+      rge.has_element(0) ~is #true
+      rge.has_element(5) ~is #false
+      rge.encloses(0..5) ~is #true
+      rge.is_connected(0..5) ~is #true
+      rge.overlaps(0..5) ~is #true
+      rge.span(0..5) ~is 0..5
+      rge.gap(0..5) ~is #false
+      rge.intersect(0..5) ~is 0..5
+  check:
+    dynamic(rge).start() ~is 0
+    dynamic(rge).end() ~is 5
+    dynamic(rge).includes_start() ~is #true
+    dynamic(rge).includes_end() ~is #false
+    dynamic(rge).has_element(0) ~is #true
+    dynamic(rge).has_element(5) ~is #false
+    dynamic(rge).encloses(0..5) ~is #true
+    dynamic(rge).is_connected(0..5) ~is #true
+    dynamic(rge).overlaps(0..5) ~is #true
+    dynamic(rge).span(0..5) ~is 0..5
+    dynamic(rge).gap(0..5) ~is #false
+    dynamic(rge).intersect(0..5) ~is 0..5
+
+block:
+  def rge = 0..=5
+  check rge ~is 0..=5
+  check rge ~matches 0..=5
+  check rge ~is Range.from_to_inclusive(0, 5)
+  check rge ~matches Range.from_to_inclusive(0, 5)
+  check rge ~matches !(0..=4)
+  check rge ~matches !(1..=5)
+  check rge ~matches !(0..5)
+  check to_string(rge) ~is "0 ..= 5"
+  block:
+    use_static
+    check:
+      rge.start() ~is 0
+      rge.end() ~is 5
+      rge.includes_start() ~is #true
+      rge.includes_end() ~is #true
+      rge.has_element(0) ~is #true
+      rge.has_element(5) ~is #true
+      rge.encloses(0..=5) ~is #true
+      rge.is_connected(0..=5) ~is #true
+      rge.overlaps(0..=5) ~is #true
+      rge.span(0..=5) ~is 0..=5
+      rge.gap(0..=5) ~is #false
+      rge.intersect(0..=5) ~is 0..=5
+  check:
+    dynamic(rge).start() ~is 0
+    dynamic(rge).end() ~is 5
+    dynamic(rge).includes_start() ~is #true
+    dynamic(rge).includes_end() ~is #true
+    dynamic(rge).has_element(0) ~is #true
+    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).encloses(0..=5) ~is #true
+    dynamic(rge).is_connected(0..=5) ~is #true
+    dynamic(rge).overlaps(0..=5) ~is #true
+    dynamic(rge).span(0..=5) ~is 0..=5
+    dynamic(rge).gap(0..=5) ~is #false
+    dynamic(rge).intersect(0..=5) ~is 0..=5
+
+block:
+  def rge = 0..
+  check rge ~is 0..
+  check rge ~matches 0..
+  check rge ~is Range.from(0)
+  check rge ~matches Range.from(0)
+  check rge ~matches !(1..)
+  check rge ~matches !(1 <..<)
+  check to_string(rge) ~is "0 .."
+  block:
+    use_static
+    check:
+      rge.start() ~is 0
+      rge.end() ~is #inf
+      rge.includes_start() ~is #true
+      rge.includes_end() ~is #false
+      rge.has_element(0) ~is #true
+      rge.has_element(5) ~is #true
+      rge.encloses(0..) ~is #true
+      rge.is_connected(0..) ~is #true
+      rge.overlaps(0..) ~is #true
+      rge.span(0..) ~is 0..
+      rge.gap(0..) ~is #false
+      rge.intersect(0..) ~is 0..
+  check:
+    dynamic(rge).start() ~is 0
+    dynamic(rge).end() ~is #inf
+    dynamic(rge).includes_start() ~is #true
+    dynamic(rge).includes_end() ~is #false
+    dynamic(rge).has_element(0) ~is #true
+    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).encloses(0..) ~is #true
+    dynamic(rge).is_connected(0..) ~is #true
+    dynamic(rge).overlaps(0..) ~is #true
+    dynamic(rge).span(0..) ~is 0..
+    dynamic(rge).gap(0..) ~is #false
+    dynamic(rge).intersect(0..) ~is 0..
+
+block:
+  def rge = 0 <..< 5
+  check rge ~is 0 <..< 5
+  check rge ~matches 0 <..< 5
+  check rge ~is Range.from_exclusive_to(0, 5)
+  check rge ~matches Range.from_exclusive_to(0, 5)
+  check rge ~matches !(0 <..< 4)
+  check rge ~matches !(1 <..< 5)
+  check rge ~matches !(0 <..= 5)
+  check to_string(rge) ~is "0 <..< 5"
+  block:
+    use_static
+    check:
+      rge.start() ~is 0
+      rge.end() ~is 5
+      rge.includes_start() ~is #false
+      rge.includes_end() ~is #false
+      rge.has_element(0) ~is #false
+      rge.has_element(5) ~is #false
+      rge.encloses(0 <..< 5) ~is #true
+      rge.is_connected(0 <..< 5) ~is #true
+      rge.overlaps(0 <..< 5) ~is #true
+      rge.span(0 <..< 5) ~is 0 <..< 5
+      rge.gap(0 <..< 5) ~is #false
+      rge.intersect(0 <..< 5) ~is 0 <..< 5
+  check:
+    dynamic(rge).start() ~is 0
+    dynamic(rge).end() ~is 5
+    dynamic(rge).includes_start() ~is #false
+    dynamic(rge).includes_end() ~is #false
+    dynamic(rge).has_element(0) ~is #false
+    dynamic(rge).has_element(5) ~is #false
+    dynamic(rge).encloses(0 <..< 5) ~is #true
+    dynamic(rge).is_connected(0 <..< 5) ~is #true
+    dynamic(rge).overlaps(0 <..< 5) ~is #true
+    dynamic(rge).span(0 <..< 5) ~is 0 <..< 5
+    dynamic(rge).gap(0 <..< 5) ~is #false
+    dynamic(rge).intersect(0 <..< 5) ~is 0 <..< 5
+
+block:
+  def rge = 0 <..= 5
+  check rge ~is 0 <..= 5
+  check rge ~matches 0 <..= 5
+  check rge ~is Range.from_exclusive_to_inclusive(0, 5)
+  check rge ~matches Range.from_exclusive_to_inclusive(0, 5)
+  check rge ~matches !(0 <..= 4)
+  check rge ~matches !(1 <..= 5)
+  check rge ~matches !(0 <..< 5)
+  check to_string(rge) ~is "0 <..= 5"
+  block:
+    use_static
+    check:
+      rge.start() ~is 0
+      rge.end() ~is 5
+      rge.includes_start() ~is #false
+      rge.includes_end() ~is #true
+      rge.has_element(0) ~is #false
+      rge.has_element(5) ~is #true
+      rge.encloses(0 <..= 5) ~is #true
+      rge.is_connected(0 <..= 5) ~is #true
+      rge.overlaps(0 <..= 5) ~is #true
+      rge.span(0 <..= 5) ~is 0 <..= 5
+      rge.gap(0 <..= 5) ~is #false
+      rge.intersect(0 <..= 5) ~is 0 <..= 5
+  check:
+    dynamic(rge).start() ~is 0
+    dynamic(rge).end() ~is 5
+    dynamic(rge).includes_start() ~is #false
+    dynamic(rge).includes_end() ~is #true
+    dynamic(rge).has_element(0) ~is #false
+    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).encloses(0 <..= 5) ~is #true
+    dynamic(rge).is_connected(0 <..= 5) ~is #true
+    dynamic(rge).overlaps(0 <..= 5) ~is #true
+    dynamic(rge).span(0 <..= 5) ~is 0 <..= 5
+    dynamic(rge).gap(0 <..= 5) ~is #false
+    dynamic(rge).intersect(0 <..= 5) ~is 0 <..= 5
+
+block:
+  def rge = 0 <..<
+  check rge ~is 0 <..<
+  check rge ~matches 0 <..<
+  check rge ~is Range.from_exclusive(0)
+  check rge ~matches Range.from_exclusive(0)
+  check rge ~matches !(1 <..<)
+  check rge ~matches !(0..)
+  check to_string(rge) ~is "0 <..<"
+  block:
+    use_static
+    check:
+      rge.start() ~is 0
+      rge.end() ~is #inf
+      rge.includes_start() ~is #false
+      rge.includes_end() ~is #false
+      rge.has_element(0) ~is #false
+      rge.has_element(5) ~is #true
+      rge.encloses(0 <..<) ~is #true
+      rge.is_connected(0 <..<) ~is #true
+      rge.overlaps(0 <..<) ~is #true
+      rge.span(0 <..<) ~is 0 <..<
+      rge.gap(0 <..<) ~is #false
+      rge.intersect(0 <..<) ~is 0 <..<
+  check:
+    dynamic(rge).start() ~is 0
+    dynamic(rge).end() ~is #inf
+    dynamic(rge).includes_start() ~is #false
+    dynamic(rge).includes_end() ~is #false
+    dynamic(rge).has_element(0) ~is #false
+    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).encloses(0 <..<) ~is #true
+    dynamic(rge).is_connected(0 <..<) ~is #true
+    dynamic(rge).overlaps(0 <..<) ~is #true
+    dynamic(rge).span(0 <..<) ~is 0 <..<
+    dynamic(rge).gap(0 <..<) ~is #false
+    dynamic(rge).intersect(0 <..<) ~is 0 <..<
+
+block:
+  def rge = ..5
+  check rge ~is ..5
+  check rge ~matches ..5
+  check rge ~is Range.to(5)
+  check rge ~matches Range.to(5)
+  check rge ~matches !(..4)
+  check rge ~matches !(..=5)
+  check to_string(rge) ~is ".. 5"
+  block:
+    use_static
+    check:
+      rge.start() ~is #neginf
+      rge.end() ~is 5
+      rge.includes_start() ~is #false
+      rge.includes_end() ~is #false
+      rge.has_element(0) ~is #true
+      rge.has_element(5) ~is #false
+      rge.encloses(..5) ~is #true
+      rge.is_connected(..5) ~is #true
+      rge.overlaps(..5) ~is #true
+      rge.span(..5) ~is ..5
+      rge.gap(..5) ~is #false
+      rge.intersect(..5) ~is ..5
+  check:
+    dynamic(rge).start() ~is #neginf
+    dynamic(rge).end() ~is 5
+    dynamic(rge).includes_start() ~is #false
+    dynamic(rge).includes_end() ~is #false
+    dynamic(rge).has_element(0) ~is #true
+    dynamic(rge).has_element(5) ~is #false
+    dynamic(rge).encloses(..5) ~is #true
+    dynamic(rge).is_connected(..5) ~is #true
+    dynamic(rge).overlaps(..5) ~is #true
+    dynamic(rge).span(..5) ~is ..5
+    dynamic(rge).gap(..5) ~is #false
+    dynamic(rge).intersect(..5) ~is ..5
+
+block:
+  def rge = ..=5
+  check rge ~is ..=5
+  check rge ~matches ..=5
+  check rge ~is Range.to_inclusive(5)
+  check rge ~matches Range.to_inclusive(5)
+  check rge ~matches !(..=4)
+  check rge ~matches !(..5)
+  check to_string(rge) ~is "..= 5"
+  block:
+    use_static
+    check:
+      rge.start() ~is #neginf
+      rge.end() ~is 5
+      rge.includes_start() ~is #false
+      rge.includes_end() ~is #true
+      rge.has_element(0) ~is #true
+      rge.has_element(5) ~is #true
+      rge.encloses(..=5) ~is #true
+      rge.is_connected(..=5) ~is #true
+      rge.overlaps(..=5) ~is #true
+      rge.span(..=5) ~is ..=5
+      rge.gap(..=5) ~is #false
+      rge.intersect(..=5) ~is ..=5
+  check:
+    dynamic(rge).start() ~is #neginf
+    dynamic(rge).end() ~is 5
+    dynamic(rge).includes_start() ~is #false
+    dynamic(rge).includes_end() ~is #true
+    dynamic(rge).has_element(0) ~is #true
+    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).encloses(..=5) ~is #true
+    dynamic(rge).is_connected(..=5) ~is #true
+    dynamic(rge).overlaps(..=5) ~is #true
+    dynamic(rge).span(..=5) ~is ..=5
+    dynamic(rge).gap(..=5) ~is #false
+    dynamic(rge).intersect(..=5) ~is ..=5
+
+block:
+  def rge = ..
+  check rge ~is ..
+  check rge ~matches ..
+  check rge ~is Range.full()
+  check rge ~matches Range.full()
+  check to_string(rge) ~is ".."
+  block:
+    use_static
+    check:
+      rge.start() ~is #neginf
+      rge.end() ~is #inf
+      rge.includes_start() ~is #false
+      rge.includes_end() ~is #false
+      rge.has_element(0) ~is #true
+      rge.has_element(5) ~is #true
+      rge.encloses(..) ~is #true
+      rge.is_connected(..) ~is #true
+      rge.overlaps(..) ~is #true
+      rge.span(..) ~is ..
+      rge.gap(..) ~is #false
+      rge.intersect(..) ~is ..
+  check:
+    dynamic(rge).start() ~is #neginf
+    dynamic(rge).end() ~is #inf
+    dynamic(rge).includes_start() ~is #false
+    dynamic(rge).includes_end() ~is #false
+    dynamic(rge).has_element(0) ~is #true
+    dynamic(rge).has_element(5) ~is #true
+    dynamic(rge).encloses(..) ~is #true
+    dynamic(rge).is_connected(..) ~is #true
+    dynamic(rge).overlaps(..) ~is #true
+    dynamic(rge).span(..) ~is ..
+    dynamic(rge).gap(..) ~is #false
+    dynamic(rge).intersect(..) ~is ..
+
+// error reporting
+block:
+  import rhombus/meta open
+  expr.macro 'generate_checks $variant $op $side':
+    ~op_stx self
+    let throws = '~throws'.relocate(self)
+    match side.unwrap()
+    | #'~left:
+        'check:
+           "oops" $op $throws values(
+             #%literal $(to_string(op) ++ ": contract violation"),
+             "expected: Int",
+             "given: \"oops\"",
+           )
+           Range . $variant("oops") $throws values(
+             #%literal $("Range." ++ to_string(variant) ++ ": contract violation"),
+             "expected: Int",
+             "given: \"oops\"",
+           )'
+    | #'~right:
+        'check:
+           $op "oops" $throws values(
+             #%literal $(to_string(op) ++ ": contract violation"),
+             "expected: Int",
+             "given: \"oops\"",
+           )
+           Range . $variant("oops") $throws values(
+             #%literal $("Range." ++ to_string(variant) ++ ": contract violation"),
+             "expected: Int",
+             "given: \"oops\"",
+           )'
+    | #'~both:
+        'check:
+           "oops" $op 5 $throws values(
+             #%literal $(to_string(op) ++ ": contract violation"),
+             "expected: Int",
+             "given: \"oops\"",
+           )
+           0 $op "oops" $throws values(
+             #%literal $(to_string(op) ++ ": contract violation"),
+             "expected: Int",
+             "given: \"oops\"",
+           )
+           5 $op 0 $throws values(
+             #%literal $(to_string(op) ++ ": starting point must be less than or equal to ending point"),
+             "starting point: 5",
+             "ending point: 0",
+           )
+           Range . $variant("oops", 5) $throws values(
+             #%literal $("Range." ++ to_string(variant) ++ ": contract violation"),
+             "expected: Int",
+             "given: \"oops\"",
+           )
+           Range . $variant(0, "oops") $throws values(
+             #%literal $("Range." ++ to_string(variant) ++ ": contract violation"),
+             "expected: Int",
+             "given: \"oops\"",
+           )
+           Range . $variant(5, 0) $throws values(
+             #%literal $("Range." ++ to_string(variant) ++ ": starting point must be less than or equal to ending point"),
+             "starting point: 5",
+             "ending point: 0",
+           )'
+  generate_checks from_to .. ~both
+  generate_checks from_to_inclusive ..= ~both
+  generate_checks from .. ~left
+  generate_checks from_exclusive_to <..< ~both
+  generate_checks from_exclusive_to_inclusive <..= ~both
+  generate_checks from_exclusive <..< ~left
+  generate_checks to .. ~right
+  generate_checks to_inclusive ..= ~right
+
+// `SequenceRange` and `ListRange`
+check:
+  0..5 ~is_a Sequence
+  0..5 ~is_a Listable
+  0..=5 ~is_a Sequence
+  0..=5 ~is_a Listable
+  0.. ~is_a Sequence
+  0.. ~is_a !Listable
+
+// sequences
+block:
+  use_static
+  check:
+    for List (x: 0..5):
+      x
+    ~is [0, 1, 2, 3, 4]
+  check:
+    for List (x: (0..5).step_by(2)):
+      x
+    ~is [0, 2, 4]
+  block:
+    def rge = 0..5
+    check:
+      for List (x: rge):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: dynamic(rge) :~ SequenceRange):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: dynamic(rge) :~ ListRange):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: rge.to_sequence()):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: Range.to_sequence(rge)):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: rge.step_by(2)):
+        x
+      ~is [0, 2, 4]
+    check:
+      for List (x: Range.step_by(rge, 2)):
+        x
+      ~is [0, 2, 4]
+
+block:
+  check:
+    for List (x: dynamic(0..5)):
+      x
+    ~is [0, 1, 2, 3, 4]
+  check:
+    for List (x: dynamic(0..5).step_by(2)):
+      x
+    ~is [0, 2, 4]
+  block:
+    def rge = dynamic(0..5)
+    check:
+      for List (x: rge):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: rge.to_sequence()):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: Range.to_sequence(rge)):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: rge.step_by(2)):
+        x
+      ~is [0, 2, 4]
+    check:
+      for List (x: Range.step_by(rge, 2)):
+        x
+      ~is [0, 2, 4]
+
+block:
+  use_static
+  check:
+    for List (x: 0..=5):
+      x
+    ~is [0, 1, 2, 3, 4, 5]
+  check:
+    for List (x: (0..=5).step_by(2)):
+      x
+    ~is [0, 2, 4]
+  block:
+    def rge = 0..=5
+    check:
+      for List (x: rge):
+        x
+      ~is [0, 1, 2, 3, 4, 5]
+    check:
+      for List (x: dynamic(rge) :~ SequenceRange):
+        x
+      ~is [0, 1, 2, 3, 4, 5]
+    check:
+      for List (x: dynamic(rge) :~ ListRange):
+        x
+      ~is [0, 1, 2, 3, 4, 5]
+    check:
+      for List (x: rge.to_sequence()):
+        x
+      ~is [0, 1, 2, 3, 4, 5]
+    check:
+      for List (x: Range.to_sequence(rge)):
+        x
+      ~is [0, 1, 2, 3, 4, 5]
+    check:
+      for List (x: rge.step_by(2)):
+        x
+      ~is [0, 2, 4]
+    check:
+      for List (x: Range.step_by(rge, 2)):
+        x
+      ~is [0, 2, 4]
+
+block:
+  check:
+    for List (x: dynamic(0..=5)):
+      x
+    ~is [0, 1, 2, 3, 4, 5]
+  check:
+    for List (x: dynamic(0..=5).step_by(2)):
+      x
+    ~is [0, 2, 4]
+  block:
+    def rge = dynamic(0..=5)
+    check:
+      for List (x: rge):
+        x
+      ~is [0, 1, 2, 3, 4, 5]
+    check:
+      for List (x: rge.to_sequence()):
+        x
+      ~is [0, 1, 2, 3, 4, 5]
+    check:
+      for List (x: Range.to_sequence(rge)):
+        x
+      ~is [0, 1, 2, 3, 4, 5]
+    check:
+      for List (x: rge.step_by(2)):
+        x
+      ~is [0, 2, 4]
+    check:
+      for List (x: Range.step_by(rge, 2)):
+        x
+      ~is [0, 2, 4]
+
+block:
+  use_static
+  check:
+    for List (x: 0..,
+              _: 0..5):
+      x
+    ~is [0, 1, 2, 3, 4]
+  check:
+    for List (x: (0..).step_by(2),
+              _: 0..5):
+      x
+    ~is [0, 2, 4, 6, 8]
+  block:
+    def rge = 0..
+    check:
+      for List (x: dynamic(rge) :~ SequenceRange,
+                _: 0..5):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: rge,
+                _: 0..5):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: rge.to_sequence(),
+                _: 0..5):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: Range.to_sequence(rge),
+                _: 0..5):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: rge.step_by(2),
+                _: 0..5):
+        x
+      ~is [0, 2, 4, 6, 8]
+    check:
+      for List (x: Range.step_by(rge, 2),
+                _: 0..5):
+        x
+      ~is [0, 2, 4, 6, 8]
+
+block:
+  check:
+    for List (x: dynamic(0..),
+              _: 0..5):
+      x
+    ~is [0, 1, 2, 3, 4]
+  check:
+    for List (x: dynamic(0..).step_by(2),
+              _: 0..5):
+      x
+    ~is [0, 2, 4, 6, 8]
+  block:
+    def rge = dynamic(0..)
+    check:
+      for List (x: rge,
+                _: 0..5):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: rge.to_sequence(),
+                _: 0..5):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: Range.to_sequence(rge),
+                _: 0..5):
+        x
+      ~is [0, 1, 2, 3, 4]
+    check:
+      for List (x: rge.step_by(2),
+                _: 0..5):
+        x
+      ~is [0, 2, 4, 6, 8]
+    check:
+      for List (x: Range.step_by(rge, 2),
+                _: 0..5):
+        x
+      ~is [0, 2, 4, 6, 8]
+
+// listables
+check:
+  [& 0..5] ~is [0, 1, 2, 3, 4]
+  [& 0..=5] ~is [0, 1, 2, 3, 4, 5]
+
+block:
+  use_static
+  check:
+    (0..5).to_list().length() ~is 5
+    (0..=5).to_list().length() ~is 6
+
+// errors
+block:
+  check:
+    Range.to_sequence("oops")
+    ~throws values(
+      "contract violation",
+      "expected: SequenceRange",
+      "given: \"oops\"",
+    )
+  check:
+    ("oops" :~ SequenceRange).to_sequence()
+    ~throws values(
+      "contract violation",
+      "expected: SequenceRange",
+      "given: \"oops\"",
+    )
+  check:
+    Range.step_by("oops", 2)
+    ~throws values(
+      "contract violation",
+      "expected: SequenceRange",
+      "given: \"oops\"",
+    )
+  check:
+    ("oops" :~ SequenceRange).step_by(2)
+    ~throws values(
+      "contract violation",
+      "expected: SequenceRange",
+      "given: \"oops\"",
+    )
+  check:
+    for List (x: ("oops" :~ SequenceRange)):
+      x
+    ~throws values(
+      "contract violation",
+      "expected: SequenceRange",
+      "given: \"oops\"",
+    )
+  check:
+    for List (x: Range.to_sequence("oops")):
+      x
+    ~throws values(
+      "contract violation",
+      "expected: SequenceRange",
+      "given: \"oops\"",
+    )
+  check:
+    for List (x: ("oops" :~ SequenceRange).to_sequence()):
+      x
+    ~throws values(
+      "contract violation",
+      "expected: SequenceRange",
+      "given: \"oops\"",
+    )
+  check:
+    for List (x: Range.step_by("oops", 2)):
+      x
+    ~throws values(
+      "contract violation",
+      "expected: SequenceRange",
+      "given: \"oops\"",
+    )
+  check:
+    for List (x: ("oops" :~ SequenceRange).step_by(2)):
+      x
+    ~throws values(
+      "contract violation",
+      "expected: SequenceRange",
+      "given: \"oops\"",
+    )
+
+block:
+  check:
+    Range.to_list("oops")
+    ~throws values(
+      "contract violation",
+      "expected: ListRange",
+      "given: \"oops\"",
+    )
+  check:
+    ("oops" :~ ListRange).to_list()
+    ~throws values(
+      "contract violation",
+      "expected: ListRange",
+      "given: \"oops\"",
+    )
+
+// errors in optimized cases
+block:
+  check:
+    for List (i: "oops"..5):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+  check:
+    for List (i: 0.."oops"):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+  check:
+    for List (i: 5..0):
+      i
+    ~throws values(
+      "starting point must be less than or equal to ending point",
+      "starting point: 5",
+      "ending point: 0",
+    )
+  check:
+    for List (i: "oops"..=5):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+  check:
+    for List (i: 0..="oops"):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+  check:
+    for List (i: 5..=0):
+      i
+    ~throws values(
+      "starting point must be less than or equal to ending point",
+      "starting point: 5",
+      "ending point: 0",
+    )
+  check:
+    for List (i: "oops"..):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+
+block:
+  check:
+    for List (i: ("oops"..5).step_by(2)):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+  check:
+    for List (i: (0.."oops").step_by(2)):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+  check:
+    for List (i: (5..0).step_by(2)):
+      i
+    ~throws values(
+      "starting point must be less than or equal to ending point",
+      "starting point: 5",
+      "ending point: 0",
+    )
+  check:
+    for List (i: (0..5).step_by("oops")):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: PosInt",
+      "given: \"oops\""
+    )
+  check:
+    for List (i: ("oops"..=5).step_by(2)):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+  check:
+    for List (i: (0..="oops").step_by(2)):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+  check:
+    for List (i: (5..=0).step_by(2)):
+      i
+    ~throws values(
+      "starting point must be less than or equal to ending point",
+      "starting point: 5",
+      "ending point: 0",
+    )
+  check:
+    for List (i: (0..=5).step_by("oops")):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: PosInt",
+      "given: \"oops\""
+    )
+  check:
+    for List (i: ("oops"..).step_by(2)):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: Int",
+      "given: \"oops\"",
+    )
+  check:
+    for List (i: (0..).step_by("oops")):
+      i
+    ~throws values(
+      "contract violation",
+      "expected: PosInt",
+      "given: \"oops\""
+    )
+
+// non-unsafe for non-fixnums
+block:
+  import rhombus/meta open
+  expr.macro 'generate_checks $(power :: Int)':
+    ~op_stx self
+    let check = 'check'.relocate(self)
+    let power = power.unwrap() - 1
+    let most_positive = 2**power - 1
+    let most_positive_to = most_positive + 5
+    let most_negative = -(2**power)
+    let most_negative_from = most_negative - 5
+    'block:
+       $check:
+         for List (i: (#%literal $most_positive) .. (#%literal $most_positive_to)):
+           i
+         ~is $(block:
+                 let [num, ...]:
+                   for List (i: most_positive .. most_positive_to):
+                     i
+                 '[#%literal $num, ...]')
+       $check:
+         for List (i: (#%literal $most_negative_from) .. (#%literal $most_negative)):
+           i
+         ~is $(block:
+                 let [num, ...]:
+                   for List (i: most_negative_from .. most_negative):
+                     i
+                 '[#%literal $num, ...]')
+       $check:
+         for List (i: ((#%literal $most_positive) .. (#%literal $most_positive_to)).step_by(2)):
+           i
+         ~is $(block:
+                 let [num, ...]:
+                   for List (i: (most_positive .. most_positive_to).step_by(2)):
+                     i
+                 '[#%literal $num, ...]')
+       $check:
+         for List (i: ((#%literal $most_negative_from) .. (#%literal $most_negative)).step_by(2)):
+           i
+         ~is $(block:
+                 let [num, ...]:
+                   for List (i: (most_negative_from .. most_negative).step_by(2)):
+                     i
+                 '[#%literal $num, ...]')
+       $check:
+         for List (i: (0..5).step_by(#%literal $(most_positive + 1))):
+           i
+         ~is [0]
+       $check:
+         for List (i: (#%literal $most_positive) ..= (#%literal $most_positive_to)):
+           i
+         ~is $(block:
+                 let [num, ...]:
+                   for List (i: most_positive ..= most_positive_to):
+                     i
+                 '[#%literal $num, ...]')
+       $check:
+         for List (i: (#%literal $most_negative_from) ..= (#%literal $most_negative)):
+           i
+         ~is $(block:
+                 let [num, ...]:
+                   for List (i: most_negative_from ..= most_negative):
+                     i
+                 '[#%literal $num, ...]')
+       $check:
+         for List (i: ((#%literal $most_positive) ..= (#%literal $most_positive_to)).step_by(2)):
+           i
+         ~is $(block:
+                 let [num, ...]:
+                   for List (i: (most_positive ..= most_positive_to).step_by(2)):
+                     i
+                 '[#%literal $num, ...]')
+       $check:
+         for List (i: ((#%literal $most_negative_from) ..= (#%literal $most_negative)).step_by(2)):
+           i
+         ~is $(block:
+                 let [num, ...]:
+                   for List (i: (most_negative_from ..= most_negative).step_by(2)):
+                     i
+                 '[#%literal $num, ...]')
+       $check:
+         for List (i: (0..=5).step_by(#%literal $(most_positive + 1))):
+           i
+         ~is [0]'
+  generate_checks 29
+  generate_checks 30
+  generate_checks 31
+  generate_checks 60
+  generate_checks 61
+  generate_checks 62
+  generate_checks 63
+
+// The following checks are borrowed from Rebellion
+// `Range.has_element`
+block:
+  def rng = 2..4
+  check:
+    rng.has_element(1) ~is #false
+    rng.has_element(2) ~is #true
+    rng.has_element(3) ~is #true
+    rng.has_element(4) ~is #false
+    rng.has_element(5) ~is #false
+
+check:
+  (3..3).has_element(3) ~is #false
+
+block:
+  def rng = 2..=4
+  check:
+    rng.has_element(1) ~is #false
+    rng.has_element(2) ~is #true
+    rng.has_element(3) ~is #true
+    rng.has_element(4) ~is #true
+    rng.has_element(5) ~is #false
+
+check:
+  (3..=3).has_element(3) ~is #true
+
+block:
+  def rng = 2..
+  check:
+    rng.has_element(1) ~is #false
+    rng.has_element(2) ~is #true
+    rng.has_element(3) ~is #true
+
+block:
+  def rng = 2 <..< 4
+  check:
+    rng.has_element(1) ~is #false
+    rng.has_element(2) ~is #false
+    rng.has_element(3) ~is #true
+    rng.has_element(4) ~is #false
+    rng.has_element(5) ~is #false
+
+block:
+  def rng = 2 <..= 4
+  check:
+    rng.has_element(1) ~is #false
+    rng.has_element(2) ~is #false
+    rng.has_element(3) ~is #true
+    rng.has_element(4) ~is #true
+    rng.has_element(5) ~is #false
+
+block:
+  def rng = 2 <..<
+  check:
+    rng.has_element(1) ~is #false
+    rng.has_element(2) ~is #false
+    rng.has_element(3) ~is #true
+
+block:
+  def rng = ..4
+  check:
+    rng.has_element(3) ~is #true
+    rng.has_element(4) ~is #false
+    rng.has_element(5) ~is #false
+
+block:
+  def rng = ..=4
+  check:
+    rng.has_element(3) ~is #true
+    rng.has_element(4) ~is #true
+    rng.has_element(5) ~is #false
+
+block:
+  def rng = ..
+  check:
+    rng.has_element(1) ~is #true
+    rng.has_element(2) ~is #true
+    rng.has_element(3) ~is #true
+    rng.has_element(4) ~is #true
+    rng.has_element(5) ~is #true
+
+// `Range.encloses`
+check:
+  Range.encloses() ~is #true
+
+block:
+  def rng = 2..9
+  check:
+    rng.encloses() ~is #true
+    rng.encloses(rng) ~is #true
+    rng.encloses(4..=6) ~is #true
+    rng.encloses(2..=6) ~is #true
+    rng.encloses(4..=9) ~is #false
+    rng.encloses(2..6) ~is #true
+    rng.encloses(4..9) ~is #true
+    rng.encloses(1..=10) ~is #false
+    rng.encloses(1..=5) ~is #false
+    rng.encloses(5..=10) ~is #false
+    rng.encloses(1..5) ~is #false
+    rng.encloses(5..10) ~is #false
+    rng.encloses(5 <..<) ~is #false
+    rng.encloses(..5) ~is #false
+    rng.encloses(5..) ~is #false
+    rng.encloses(..=5) ~is #false
+    rng.encloses(2..=2) ~is #true
+    rng.encloses(5..=5) ~is #true
+    rng.encloses(9..=9) ~is #false
+
+block:
+  def rng = 2..=9
+  check:
+    rng.encloses() ~is #true
+    rng.encloses(rng) ~is #true
+    rng.encloses(4..=6) ~is #true
+    rng.encloses(2..=6) ~is #true
+    rng.encloses(4..=9) ~is #true
+    rng.encloses(2..6) ~is #true
+    rng.encloses(4..9) ~is #true
+    rng.encloses(1..=10) ~is #false
+    rng.encloses(1..=5) ~is #false
+    rng.encloses(5..=10) ~is #false
+    rng.encloses(1..5) ~is #false
+    rng.encloses(5..10) ~is #false
+    rng.encloses(5 <..<) ~is #false
+    rng.encloses(..5) ~is #false
+    rng.encloses(5..) ~is #false
+    rng.encloses(..=5) ~is #false
+    rng.encloses(2..=2) ~is #true
+    rng.encloses(5..=5) ~is #true
+    rng.encloses(9..=9) ~is #true
+
+block:
+  def rng = 2..
+  check:
+    rng.encloses() ~is #true
+    rng.encloses(rng) ~is #true
+    rng.encloses(4..=6) ~is #true
+    rng.encloses(2..=6) ~is #true
+    rng.encloses(4..=9) ~is #true
+    rng.encloses(2..6) ~is #true
+    rng.encloses(4..9) ~is #true
+    rng.encloses(1..=10) ~is #false
+    rng.encloses(1..=5) ~is #false
+    rng.encloses(5..=10) ~is #true
+    rng.encloses(1..5) ~is #false
+    rng.encloses(5..10) ~is #true
+    rng.encloses(5 <..<) ~is #true
+    rng.encloses(..5) ~is #false
+    rng.encloses(5..) ~is #true
+    rng.encloses(..=5) ~is #false
+    rng.encloses(2..=2) ~is #true
+    rng.encloses(5..=5) ~is #true
+    rng.encloses(9..=9) ~is #true
+
+block:
+  def rng = 2 <..< 9
+  check:
+    rng.encloses() ~is #true
+    rng.encloses(rng) ~is #true
+    rng.encloses(4..=6) ~is #true
+    rng.encloses(2..=6) ~is #false
+    rng.encloses(4..=9) ~is #false
+    rng.encloses(2..6) ~is #false
+    rng.encloses(4..9) ~is #true
+    rng.encloses(1..=10) ~is #false
+    rng.encloses(1..=5) ~is #false
+    rng.encloses(5..=10) ~is #false
+    rng.encloses(1..5) ~is #false
+    rng.encloses(5..10) ~is #false
+    rng.encloses(5 <..<) ~is #false
+    rng.encloses(..5) ~is #false
+    rng.encloses(5..) ~is #false
+    rng.encloses(..=5) ~is #false
+    rng.encloses(2..=2) ~is #false
+    rng.encloses(5..=5) ~is #true
+    rng.encloses(9..=9) ~is #false
+
+block:
+  def rng = 2 <..= 9
+  check:
+    rng.encloses() ~is #true
+    rng.encloses(rng) ~is #true
+    rng.encloses(4..=6) ~is #true
+    rng.encloses(2..=6) ~is #false
+    rng.encloses(4..=9) ~is #true
+    rng.encloses(2..6) ~is #false
+    rng.encloses(4..9) ~is #true
+    rng.encloses(1..=10) ~is #false
+    rng.encloses(1..=5) ~is #false
+    rng.encloses(5..=10) ~is #false
+    rng.encloses(1..5) ~is #false
+    rng.encloses(5..10) ~is #false
+    rng.encloses(5 <..<) ~is #false
+    rng.encloses(..5) ~is #false
+    rng.encloses(5..) ~is #false
+    rng.encloses(..=5) ~is #false
+    rng.encloses(2..=2) ~is #false
+    rng.encloses(5..=5) ~is #true
+    rng.encloses(9..=9) ~is #true
+
+block:
+  def rng = 2 <..<
+  check:
+    rng.encloses() ~is #true
+    rng.encloses(rng) ~is #true
+    rng.encloses(4..=6) ~is #true
+    rng.encloses(2..=6) ~is #false
+    rng.encloses(4..=9) ~is #true
+    rng.encloses(2..6) ~is #false
+    rng.encloses(4..9) ~is #true
+    rng.encloses(1..=10) ~is #false
+    rng.encloses(1..=5) ~is #false
+    rng.encloses(5..=10) ~is #true
+    rng.encloses(1..5) ~is #false
+    rng.encloses(5..10) ~is #true
+    rng.encloses(5 <..<) ~is #true
+    rng.encloses(..5) ~is #false
+    rng.encloses(5..) ~is #true
+    rng.encloses(..=5) ~is #false
+    rng.encloses(2..=2) ~is #false
+    rng.encloses(5..=5) ~is #true
+    rng.encloses(9..=9) ~is #true
+
+block:
+  def rng = ..9
+  check:
+    rng.encloses() ~is #true
+    rng.encloses(rng) ~is #true
+    rng.encloses(4..=6) ~is #true
+    rng.encloses(2..=6) ~is #true
+    rng.encloses(4..=9) ~is #false
+    rng.encloses(2..6) ~is #true
+    rng.encloses(4..9) ~is #true
+    rng.encloses(1..=10) ~is #false
+    rng.encloses(1..=5) ~is #true
+    rng.encloses(5..=10) ~is #false
+    rng.encloses(1..5) ~is #true
+    rng.encloses(5..10) ~is #false
+    rng.encloses(5 <..<) ~is #false
+    rng.encloses(..5) ~is #true
+    rng.encloses(5..) ~is #false
+    rng.encloses(..=5) ~is #true
+    rng.encloses(2..=2) ~is #true
+    rng.encloses(5..=5) ~is #true
+    rng.encloses(9..=9) ~is #false
+
+block:
+  def rng = ..=9
+  check:
+    rng.encloses() ~is #true
+    rng.encloses(rng) ~is #true
+    rng.encloses(4..=6) ~is #true
+    rng.encloses(2..=6) ~is #true
+    rng.encloses(4..=9) ~is #true
+    rng.encloses(2..6) ~is #true
+    rng.encloses(4..9) ~is #true
+    rng.encloses(1..=10) ~is #false
+    rng.encloses(1..=5) ~is #true
+    rng.encloses(5..=10) ~is #false
+    rng.encloses(1..5) ~is #true
+    rng.encloses(5..10) ~is #false
+    rng.encloses(5 <..<) ~is #false
+    rng.encloses(..5) ~is #true
+    rng.encloses(5..) ~is #false
+    rng.encloses(..=5) ~is #true
+    rng.encloses(2..=2) ~is #true
+    rng.encloses(5..=5) ~is #true
+    rng.encloses(9..=9) ~is #true
+
+block:
+  def rng = ..
+  check:
+    rng.encloses() ~is #true
+    rng.encloses(rng) ~is #true
+    rng.encloses(4..=6) ~is #true
+    rng.encloses(2..=6) ~is #true
+    rng.encloses(4..=9) ~is #true
+    rng.encloses(2..6) ~is #true
+    rng.encloses(4..9) ~is #true
+    rng.encloses(1..=10) ~is #true
+    rng.encloses(1..=5) ~is #true
+    rng.encloses(5..=10) ~is #true
+    rng.encloses(1..5) ~is #true
+    rng.encloses(5..10) ~is #true
+    rng.encloses(5 <..<) ~is #true
+    rng.encloses(..5) ~is #true
+    rng.encloses(5..) ~is #true
+    rng.encloses(..=5) ~is #true
+    rng.encloses(2..=2) ~is #true
+    rng.encloses(5..=5) ~is #true
+    rng.encloses(9..=9) ~is #true
+
+check:
+  (..).encloses(2.., 2..=9, 2..9, 2 <..< 9) ~is #true
+
+// `Range.is_connected`
+block:
+  import rhombus/meta open
+  expr.macro '$lhs is_connected $rhs':
+    ~op_stx self
+    let is = '~is'.relocate(self)
+    'block:
+       def lhs = $lhs
+       def rhs = $rhs
+       check:
+         Range.is_connected(lhs, lhs) $is #true
+         Range.is_connected(rhs, rhs) $is #true
+         Range.is_connected(lhs, rhs) $is #true
+         Range.is_connected(rhs, lhs) $is #true'
+  expr.macro '$lhs is_not_connected $rhs':
+    ~op_stx self
+    let is = '~is'.relocate(self)
+    'block:
+       def lhs = $lhs
+       def rhs = $rhs
+       check:
+         Range.is_connected(lhs, lhs) $is #true
+         Range.is_connected(rhs, rhs) $is #true
+         Range.is_connected(lhs, rhs) $is #false
+         Range.is_connected(rhs, lhs) $is #false'
+  (3..=6) is_connected (4..=8)
+  (1..=9) is_connected (4..=6)
+  (1 <..< 9) is_connected (1..=4)
+  (1 <..< 9) is_connected (4..=9)
+  (1..=5) is_connected (5..=9)
+  (1 <..< 5) is_connected (5..=9)
+  (1..=5) is_connected (5 <..< 9)
+  (1 <..< 5) is_not_connected (5 <..< 9)
+  (1..=2) is_not_connected (7..=8)
+  (..=2) is_not_connected (5..)
+  (..4) is_not_connected (4 <..<)
+  (..4) is_connected (4..)
+  (..=4) is_connected (4 <..<)
+  (..5) is_connected (3..)
+
+// `Range.overlaps`
+block:
+  import rhombus/meta open
+  expr.macro '$lhs does_overlap $rhs':
+    ~op_stx self
+    let is = '~is'.relocate(self)
+    'block:
+       def lhs = $lhs
+       def rhs = $rhs
+       check:
+         Range.overlaps(lhs, rhs) $is #true
+         Range.overlaps(rhs, lhs) $is #true'
+  expr.macro '$lhs does_not_overlap $rhs':
+    ~op_stx self
+    let is = '~is'.relocate(self)
+    'block:
+       def lhs = $lhs
+       def rhs = $rhs
+       check:
+         Range.overlaps(lhs, rhs) $is #false
+         Range.overlaps(rhs, lhs) $is #false'
+  (1..=5) does_overlap (2..=10)
+  (1..=5) does_overlap (2..=3)
+  (1..=5) does_overlap (5..=10)
+  (1..=5) does_overlap (1..=3)
+  (1..=5) does_overlap (3..=5)
+  (1..=5) does_overlap (1 <..< 3)
+  (1..=5) does_overlap (3 <..< 5)
+  (1..=5) does_not_overlap (10..=20)
+  (1..=5) does_not_overlap (5 <..< 10)
+  (1..=10) does_overlap (1..=10)
+  (1 <..< 10) does_overlap (1 <..< 10)
+  (1..10) does_overlap (1..10)
+  (1 <..= 10) does_overlap (1 <..= 10)
+  (5..5) does_not_overlap (5..5)
+  (5..=5) does_overlap (5..=5)
+  (5 <..< 5) does_not_overlap (5 <..< 5)
+  (5 <..= 5) does_not_overlap (5 <..= 5)
+  (5..=5) does_overlap (5..=10)
+  (5..=5) does_overlap (1..=5)
+  (5..=5) does_not_overlap (5 <..< 10)
+  (5..=5) does_not_overlap (1 <..< 5)
+
+// `Range.span`
+block:
+  import rhombus/meta open
+  expr.macro '$lhs span $rhs is $res':
+    ~op_stx self
+    let is = '~is'.relocate(self)
+    'block:
+       def lhs = $lhs
+       def rhs = $rhs
+       def res = $res
+       check:
+         Range.span(lhs) $is lhs
+         Range.span(rhs) $is rhs
+         Range.span(res) $is res
+         Range.span(lhs, lhs) $is lhs
+         Range.span(rhs, rhs) $is rhs
+         Range.span(lhs, rhs) $is res
+         Range.span(rhs, lhs) $is res
+         Range.span(lhs, res) $is res
+         Range.span(rhs, res) $is res'
+  (2..=4) span (8 <..< 16) is (2..16)
+  (3 <..< 8) span (3..=5) is (3..8)
+  (2 <..< 9) span (4..=6) is (2 <..< 9)
+  (2..5) span (7 <..= 9) is (2..=9)
+  (2..) span (5..=6) is (2..)
+  (4..) span (3..=8) is (3..)
+  (4..) span (3 <..< 8) is (3 <..<)
+  (..4) span (2 <..<) is (..)
+  (4 <..<) span (..2) is (..)
+  (..7) span (2..=5) is (..7)
+  (..7) span (2 <..< 7) is (..7)
+  (..7) span (2..=7) is (..=7)
+
+check:
+  (..).span(2.., ..=4, 8 <..< 16) ~is ..
+
+// `Range.gap`
+block:
+  import rhombus/meta open
+  expr.macro '$lhs gap $rhs is $res':
+    ~op_stx self
+    let is = '~is'.relocate(self)
+    'block:
+       def lhs = $lhs
+       def rhs = $rhs
+       def res = $res
+       check:
+         Range.gap(lhs, rhs) $is res
+         Range.gap(rhs, lhs) $is res'
+  (2..=7) gap (10..=15) is (7 <..< 10)
+  (..7) gap (10 <..<) is (7..=10)
+  (2..=10) gap (5..=7) is #false
+  (..7) gap (5 <..<) is #false
+  (2..=7) gap (7 <..< 10) is (7 <..= 7)
+  (2 <..< 7) gap (7..=10) is (7..7)
+  (2..=7) gap (7..=10) is #false
+
+// `Range.intersect`
+check:
+  Range.intersect() ~is ..
+
+block:
+  import rhombus/meta open
+  expr.macro '$lhs intersect $rhs is $res':
+    ~op_stx self
+    let is = '~is'.relocate(self)
+    'block:
+       def lhs = $lhs
+       def rhs = $rhs
+       def res = $res
+       check:
+         Range.intersect(lhs) $is lhs
+         Range.intersect(rhs) $is rhs
+         $(if res.unwrap()
+           | 'Range.intersect(res) $is res'
+           | '')
+         Range.intersect(lhs, lhs) $is lhs
+         Range.intersect(rhs, rhs) $is rhs
+         Range.intersect(lhs, rhs) $is res
+         Range.intersect(rhs, lhs) $is res
+         $(if res.unwrap()
+           | 'Range.intersect(lhs, res) $is res
+              Range.intersect(rhs, res) $is res'
+           | '')'
+  (2..=8) intersect (5..=10) is (5..=8)
+  (0..=10) intersect (4..=6) is (4..=6)
+  (0..=5) intersect (5..=10) is (5..=5)
+  (0 <..< 5) intersect (5..=10) is (5..5)
+  (0..=5) intersect (5 <..< 10) is (5 <..= 5)
+  (0 <..< 5) intersect (5 <..< 10) is #false
+
+check:
+  (..).intersect(2.., ..=4, 8 <..< 16) ~is #false

--- a/rhombus/tests/static_arity.rhm
+++ b/rhombus/tests/static_arity.rhm
@@ -17,8 +17,15 @@ expr.macro 'static_arity_check $(pattern:
                                  | '': field import = #false):
               $(pattern:
                   kind ~group
-                | '$pre ... $args ~method': field is_method = #true
-                | '$pre ... $(args :: Term)': field is_method = #false)
+                | '$pre ... $args ~method':
+                    field method_annot = #false
+                    field is_method = #true
+                | '$pre ... $args ~method $method_annot':
+                    field is_method = #true
+                | '$pre ... $(args :: Term)':
+                    field method_annot = #false
+                    field is_method = #false
+                )
               ...':
   fun make_error(_):
     'error("static_arity.check", "should not get here")'
@@ -44,7 +51,7 @@ expr.macro 'static_arity_check $(pattern:
                '($(make_error(arg)), ...,
                  $(make_error(more)), ...,
                  $(make_error(#false)))')
-  fun make_check(pres && '$self $_ ...', args, is_method):
+  fun make_check(pres && '$self $_ ...', args, is_method, method_annot):
     let check = 'check'.relocate(self)
     fun finish(kind, '$pre ...', args):
       let (just, less, more) = extract_args(args)
@@ -80,7 +87,8 @@ expr.macro 'static_arity_check $(pattern:
                ''
            | '($(_ :: Identifier), $arg, ...)':
                let '$annot ... . $(method :: Term)' = pres
-               let pres = '($(make_error(#false)) :~ $annot ...) . $method'
+               let annot = method_annot || '$annot ...'
+               let pres = '($(make_error(#false)) :~ $annot) . $method'
                let args = '($arg, ...)'
                finish("method", pres, args)
            | ~else:
@@ -94,7 +102,7 @@ expr.macro 'static_arity_check $(pattern:
              Evaluator.import(ModulePath '$import')
            »'
        | '')
-     $(make_check('$pre ...', args, is_method))
+     $(make_check('$pre ...', args, is_method, method_annot))
      ...'
 
 // expose meta bindings at phase 0 for `~meta` option


### PR DESCRIPTION
(*See also [the proposal](<https://github.com/usaoc/rhombus-prototype/blob/2ad95b1d5457045ef095edd1acb4a4ce17339359/design/range/range.md>).*)

Range objects can be constructed and matched by nine constructors (but no separate annotation is given for each constructor, to avoid the combinatorial explosion).  ~~The constructors are named with `from`–`to` vs. `above`–`below`, which is taken from Common Lisp `loop` for inclusive vs. exclusive bounds.~~  The name `Range.from_to` is chosen for the common case `..`, and other names build on it.  Four operators `..`, `..=`, `<..<` (this is unfortunate, because operators cannot end in `.`), and `<..=` are available as shorthand notations for the nine constructors.

Range objects are currently restricted to integers, because it’s not apparent how to make them generic while still efficient in the context of Rhombus.

~~`Range.from_below`, `Range.from_to`~~ `Range.from_to`, `Range_from_to_inclusive`, and `Range.from` can be used as sequences, and a naïve optimization strategy is applied to ensure that they work as efficiently as before.  The strategy simply looks for a direct application of the three constructors and dispatch to special cases that work like `in-range`, `in-inclusive-range`, and `in-naturals`.  The same strategy is also found in `Range.step_by`, but only when it’s invoked as a dot method (over a direct application).

~~`Range.from_below` and `Range.from_to`~~ `Range.from_to` and `Range.from_to_inclusive` are `Listable`, which is the same as before.

Accordingly, ranges are separated into three subtypes: `Range` (all ranges), `SequenceRange` (ranges that can be used as sequences), and `ListRange` (ranges that are `Listable`).

A list of methods is implemented, which is essentially borrowed from Rebellion.  In addition, ranges can be deconstructed through `Range.start`, `Range.end`, `Range.includes_start`, and `Range.includes_end`, if one wants to.