### PR TITLE
disallow use of veneer names in dynamic-mode contexts

### DIFF
--- a/rhombus/private/char.rkt
+++ b/rhombus/private/char.rkt
@@ -36,7 +36,8 @@
                                             (= char-ci=?)
                                             (!= char-ci!=?)
                                             (>= char-ci>=?)
-                                            (> char-ci>?))))))
+                                            (> char-ci>?))))
+                         #:static-only))
 
 (define-name-root Char
   #:fields

--- a/rhombus/private/string.rkt
+++ b/rhombus/private/string.rkt
@@ -154,8 +154,8 @@
     (values (convert get-string-static-infos)
             (convert get-readable-string-static-infos))))
 
-(define-annotation-syntax StringCI (identifier-annotation immutable-string? #,(get-string-ci-static-infos)))
-(define-annotation-syntax ReadableStringCI (identifier-annotation string? #,(get-readable-string-ci-static-infos)))
+(define-annotation-syntax StringCI (identifier-annotation immutable-string? #,(get-string-ci-static-infos) #:static-only))
+(define-annotation-syntax ReadableStringCI (identifier-annotation string? #,(get-readable-string-ci-static-infos) #:static-only))
 
 (define-infix +& append-as-strings
   #:stronger-than (== ===)

--- a/rhombus/private/veneer.rkt
+++ b/rhombus/private/veneer.rkt
@@ -237,7 +237,7 @@
 
        (with-syntax ([(export ...) exs])
          (with-syntax ([constructor-name (and (not expression-macro-rhs)
-                                              #'name)]
+                                              (car (generate-temporaries (list #'name))))]
                        [(super-name* ...) (if super #'(super-name) '())]
                        [(interface-name ...) interface-names]
                        [(dot-id ...) (map car dots)]
@@ -344,7 +344,8 @@
           #`(define-annotation-syntax name
               (identifier-annotation name?
                                      ((#%dot-provider dot-providers)
-                                      . indirect-static-infos))))]
+                                      . indirect-static-infos)
+                                     #:static-only)))]
         [else
          (list
           #`(define-annotation-syntax name
@@ -352,7 +353,8 @@
                                                              #'(name name-convert val))
                                              val
                                              ((#%dot-provider dot-providers)
-                                              . indirect-static-infos))))]))))
+                                              . indirect-static-infos)
+                                             #:static-only)))]))))
 
 (define-syntax (converter-binding-infoer stx)
   (syntax-parse stx

--- a/rhombus/scribblings/ref-char.scrbl
+++ b/rhombus/scribblings/ref-char.scrbl
@@ -167,12 +167,16 @@ like @rhombus(<) and @rhombus(>) work on characters.
  comparisons, equivalent to using @rhombus(Char.foldcase) on each
  character before comparing.
 
- As always for a veneer, @rhombus(CharCI, ~annot) normally should be used in
- static mode to help ensure that it has the intended effect.
+ As always for a veneer, @rhombus(CharCI, ~annot) works only in static
+ mode (see @rhombus(use_static)) to help ensure that it has the intended
+ effect.
 
 @examples(
-  "a"[0] < "B"[0]
-  ("a"[0] :: CharCI) < ("B"[0] :: CharCI)
+  ~hidden:
+    use_static
+  ~repl:
+    "a"[0] < "B"[0]
+    ("a"[0] :: CharCI) < ("B"[0] :: CharCI)
 )
 
 }

--- a/rhombus/scribblings/ref-dynamic-static.scrbl
+++ b/rhombus/scribblings/ref-dynamic-static.scrbl
@@ -9,7 +9,7 @@
 ){
 
  Initially indicates dynamic mode, but intended to be redefined by
- or @rhombus(use_dynamic).
+ @rhombus(use_static) or @rhombus(use_dynamic).
 
  This binding is not exported by @rhombuslangname(rhombus/static), and
  a binding to indicate static mode is exported, instead.

--- a/rhombus/scribblings/ref-string.scrbl
+++ b/rhombus/scribblings/ref-string.scrbl
@@ -331,12 +331,15 @@ Strings are @tech{comparable}, which means that generic operations like
  string before comparing.
 
  As always for a veneer, @rhombus(StringCI, ~annot) and
- @rhombus(ReadableStringCI, ~annot) normally should be used in static
- mode to help ensure that they have the intended effect.
+ @rhombus(ReadableStringCI, ~annot) work only in static mode (see
+ @rhombus(use_static)) to help ensure that they have the intended effect.
 
 @examples(
-  "apple" < "BANANA"
-  ("apple" :: StringCI) < ("BANANA" :: StringCI)
+  ~hidden:
+    use_static
+  ~repl:
+    "apple" < "BANANA"
+    ("apple" :: StringCI) < ("BANANA" :: StringCI)
 )
 
 }

--- a/rhombus/scribblings/ref-veneer.scrbl
+++ b/rhombus/scribblings/ref-veneer.scrbl
@@ -43,7 +43,7 @@
 
  Similar to @rhombus(class), but binds @rhombus(id_name) as a static
  class @deftech{veneer} over an existing representation, instead of creating a new
- representation like @rhombus(class) does. The existing reprsentation is
+ representation like @rhombus(class) does. The existing representation is
  indicated by the @rhombus(annot) written after the @rhombus(this)
  pseudo-field (in parentheses after @rhombus(id_name)); this
  representation is checked only when using @rhombus(::, ~bind), and not
@@ -54,6 +54,12 @@
  methods, indexing operations, etc., use the veneer instead of the
  underlying representation. Within the @rhombus(veneer) body, however,
  @rhombus(this) has the static information of @rhombus(annot).
+
+ A veneer affects only static resolution of operations. To help avoid
+ confusing behavior when dynamic resolution is chosen in a dynamic-mode
+ context, a veneer can be used as an expression or annotation only in a
+ static-mode context (see @rhombus(use_static)). Using a veneer
+ annotation in a dynamic-mode context is a syntax error.
 
  The veneer's @rhombus(id_name) is bound in several @tech{spaces}:
 

--- a/rhombus/tests/char.rhm
+++ b/rhombus/tests/char.rhm
@@ -49,6 +49,16 @@ check:
   Char.titlecase("a"[0]) ~is "A"[0]
   Char.grapheme_step("a"[0], 0) ~is values(#false, 1)
 
+check:
+  ~eval
+  "a"[0] :: CharCI
+  ~throws "not allowed in a dynamic context"
+
+check:
+  ~eval
+  def c :: CharCI = "a"[0]
+  ~throws "not allowed in a dynamic context"
+
 block:
   use_static
   let a :: CharCI = "a"[0]

--- a/rhombus/tests/string.rhm
+++ b/rhombus/tests/string.rhm
@@ -140,6 +140,16 @@ block:
     to_string("hello", ~mode: #'expr) ~is "\"hello\""
     to_string(copy("hello"), ~mode: #'expr) ~is "racket.#{string-copy}(\"hello\")"
 
+check:
+  ~eval
+  "a" :: StringCI
+  ~throws "not allowed in a dynamic context"
+
+check:
+  ~eval
+  def s :: StringCI = "a"
+  ~throws "not allowed in a dynamic context"
+
 block:
   use_static
   let a :: StringCI = "a"

--- a/rhombus/tests/veneer.rhm
+++ b/rhombus/tests/veneer.rhm
@@ -194,6 +194,7 @@ check:
 
 check:
   ~eval
+  use_static
   import rhombus/meta open
   expr.macro 'meta_error($msg)':
     syntax_meta.error(msg)
@@ -233,3 +234,17 @@ check:
   ("smaller" :: WeirdString) >= ("greater" :: WeirdString) ~is #false
   ("same" :: WeirdString) compares_equal ("same" :: WeirdString) ~is #false
   ("same" :: WeirdString) compares_unequal ("same" :: WeirdString) ~is #true
+
+check:
+  ~eval
+  use_dynamic
+  veneer RevList(this :: List)
+  [] :: RevList
+  ~throws "not allowed in a dynamic context"
+
+check:
+  ~eval
+  use_dynamic
+  veneer RevList(this :: List)
+  RevList([])
+  ~throws "not allowed in a dynamic context"


### PR DESCRIPTION
Since veneers can behave confusingly in dynamic-mode contexts, disallow their use as an expression or annotation in a dynamic-mode context. The intent is to avoid especially confusing behavior like a true result from

```("a" :: StringCI) > "A"```

where static mode would error due to inconsistent comparable implementations for the arguments to `>`, but dynamic mode would just dispatch to a dynamic (not case-sensitive) string comparison.

This change does not avoid all possible confusions with veneers. For example, a function declared in a static context can declare a veneer result annotation, and then the function can still be called in a dynamic context. The change hopefully avoids most potential confusion, though.