### PR TITLE
adjust meaning and implementation of repetitions

### DIFF
--- a/rhombus/private/amalgam/apostrophe.rkt
+++ b/rhombus/private/amalgam/apostrophe.rkt
@@ -38,12 +38,10 @@
        [(form-name q . tail)
         (define si (check-quotable #'form-name #'q))
         (values (make-repetition-info #'datum
-                                      #'value
+                                      #'()
                                       (syntax/loc stx (quote q))
-                                      0
-                                      0
                                       si
-                                      #t)
+                                      0)
                 #'tail)]))))
 
 (define-binding-syntax |#'|

--- a/rhombus/private/amalgam/binding.rkt
+++ b/rhombus/private/amalgam/binding.rkt
@@ -134,7 +134,7 @@
      (binding-info annotation-any-string
                    #'id
                    #'static-infos
-                   #'((id (0) . static-infos))
+                   #'((id ([#:repet ()]) . static-infos))
                    #'always-succeed
                    #'identifier-commit
                    #'identifier-bind

--- a/rhombus/private/amalgam/compound-repetition.rkt
+++ b/rhombus/private/amalgam/compound-repetition.rkt
@@ -64,6 +64,7 @@
 
 (define-for-syntax (build-compound-repetition at-stx forms build-one
                                               #:is-sequence? [is-sequence? (lambda (form) #f)]
+                                              #:maybe-immediate? [maybe-immediate? #f]
                                               #:extract [extract (lambda (form) form)])
   (define depths
     (for/list ([form (in-list forms)]
@@ -73,24 +74,33 @@
           (max 0 (sub1 depth))
           depth)))
   (define depth (apply max depths))
-  (define-values (names lists use-depths immed?s)
-    (for/lists (names lists depths immed?s) ([form (in-list forms)]
-                                             [form-depth (in-list depths)])
+  (define-values (names lists use-depths list-depths immed?s)
+    (for/lists (names lists use-depths list-depths immed?s)
+               ([form (in-list forms)]
+                [form-depth (in-list depths)])
       (define seq? (is-sequence? form))
       (syntax-parse (extract form)
         [rep::repetition-info
+         (define list-depth (+ (min depth form-depth)
+                               (if seq? 1 0)))
+         (define e (repetition-as-list/non-immediate (extract form) list-depth))
          (values #'rep.name
-                 (repetition-as-list (extract form)
-                                     (+ (min depth form-depth)
-                                        (if seq? 1 0)))
+                 e
                  form-depth
-                 (if seq?
-                     #f
-                     (syntax-e #'rep.immediate?)))])))
+                 list-depth
+                 (syntax-e #'rep.immediate?))])))
+  (define immed? (and maybe-immediate?
+                      (for/and ([immed? (in-list immed?s)]) immed?)))
   (define-values (list-e element-static-infos)
     (build-repetition-map depth
-                          names lists use-depths immed?s
-                          build-one))
+                          names lists use-depths list-depths immed?s
+                          (if immed?
+                              build-one
+                              (lambda args
+                                (define-values (body static-infos)
+                                  (apply build-one args))
+                                (values #`(lambda () #,body)
+                                        static-infos)))))
   (make-repetition-info at-stx
                         (syntax/loc (syntax-parse at-stx
                                       [(x . _) #'x]
@@ -100,50 +110,51 @@
                         depth
                         0
                         element-static-infos
-                        #f))
+                        immed?))
 
-(define-for-syntax (build-repetition-map depth names lists depths immed?s build)
-  (define (wrap-body body)
-    #`(let #,(for/list ([name (in-list names)]
-                        [lst (in-list lists)]
-                        [immed? (in-list immed?s)]
-                        #:unless immed?)
-               #`[#,name #,lst])
-          #,body))
+(define-for-syntax (build-repetition-map depth names lists depths list-depths immed?s build)
+  (define top-depth depth)
   (define-values (body static-infos)
     (let loop ([depth depth]
                [depths depths]
-               [immed?s immed?s])
+               [named?s (for/list ([n (in-list names)])
+                          #f)])
       (cond
         [(= 0 depth)
          ;; returns expression + static infos
-         (apply build (for/list ([name (in-list names)]
+         (apply build (for/list ([l-depth (in-list list-depths)]
+                                 [name (in-list names)]
                                  [lst (in-list lists)]
+                                 [named? (in-list named?s)]
                                  [immed? (in-list immed?s)])
-                        (if immed?
-                            lst
-                            name)))]
+                        (define e (if named? name lst))
+                        (cond
+                          [immed? e]
+                          [else
+                           (let loop ([e e] [depth (max 0 (- l-depth top-depth))])
+                             (cond
+                               [(= depth 0) #`(#,e)]
+                               [else #`(for/list ([e (in-list #,e)])
+                                         #,(loop #'e (sub1 depth)))]))])))]
         [else
          (define (wrap-body body)
            #`(for/list #,(for/list ([a-depth (in-list depths)]
                                     [name (in-list names)]
                                     [lst (in-list lists)]
-                                    [immed? (in-list immed?s)]
+                                    [named? (in-list named?s)]
                                     #:when (= a-depth depth))
-                           #`[#,name (in-list #,(if immed?
-                                                    lst
-                                                    name))])
+                           #`[#,name (in-list #,(if named? name lst))])
                #,body))
          (define-values (body static-infos)
            (loop (sub1 depth)
                  (for/list ([a-depth (in-list depths)])
                    (min a-depth (sub1 depth)))
-                 (for/list ([immed? (in-list immed?s)]
+                 (for/list ([named? (in-list named?s)]
                             [a-depth (in-list depths)])
                    (if (= a-depth depth)
-                       #f
-                       immed?))))
+                       #t
+                       named?))))
          (values (wrap-body body)
                  static-infos)])))
-  (values (wrap-body body)
+  (values body
           static-infos))

--- a/rhombus/private/amalgam/compound-repetition.rkt
+++ b/rhombus/private/amalgam/compound-repetition.rkt
@@ -59,102 +59,51 @@
   (define (repetition-depth form)
     (syntax-parse form
       [rep::repetition-info
-       (- (syntax-e #'rep.bind-depth)
-          (syntax-e #'rep.use-depth))])))
+       (length (syntax->list #'rep.for-clausess))])))
 
 (define-for-syntax (build-compound-repetition at-stx forms build-one
+                                              #:sequence-for-form [sequence-for-form #'for/list]
                                               #:is-sequence? [is-sequence? (lambda (form) #f)]
-                                              #:maybe-immediate? [maybe-immediate? #f]
                                               #:extract [extract (lambda (form) form)])
-  (define depths
-    (for/list ([form (in-list forms)]
-               [i (in-naturals)])
-      (define depth (repetition-depth (extract form)))
-      (if (is-sequence? form)
-          (max 0 (sub1 depth))
-          depth)))
-  (define depth (apply max depths))
-  (define-values (names lists use-depths list-depths immed?s)
-    (for/lists (names lists use-depths list-depths immed?s)
-               ([form (in-list forms)]
-                [form-depth (in-list depths)])
-      (define seq? (is-sequence? form))
+  (define depth
+    (for/fold ([depth 0]) ([form (in-list forms)])
+      (max depth (- (repetition-depth (extract form))
+                    (if (is-sequence? form) 1 0)))))
+  (define-values (for-clausesss bodys)
+    (for/lists (bodys for-clausesss)
+               ([form (in-list forms)])
       (syntax-parse (extract form)
         [rep::repetition-info
-         (define list-depth (+ (min depth form-depth)
-                               (if seq? 1 0)))
-         (define e (repetition-as-list/non-immediate (extract form) list-depth))
-         (values #'rep.name
-                 e
-                 form-depth
-                 list-depth
-                 (syntax-e #'rep.immediate?))])))
-  (define immed? (and maybe-immediate?
-                      (for/and ([immed? (in-list immed?s)]) immed?)))
-  (define-values (list-e element-static-infos)
-    (build-repetition-map depth
-                          names lists use-depths list-depths immed?s
-                          (if immed?
-                              build-one
-                              (lambda args
-                                (define-values (body static-infos)
-                                  (apply build-one args))
-                                (values #`(lambda () #,body)
-                                        static-infos)))))
-  (make-repetition-info at-stx
-                        (syntax/loc (syntax-parse at-stx
-                                      [(x . _) #'x]
-                                      [_ at-stx])
-                          value)
-                        list-e
-                        depth
-                        0
-                        element-static-infos
-                        immed?))
-
-(define-for-syntax (build-repetition-map depth names lists depths list-depths immed?s build)
-  (define top-depth depth)
+         (define for-clausess (syntax->list #'rep.for-clausess))
+         (cond
+           [(is-sequence? form)
+            (define rev-for-clausess (reverse for-clausess))
+            (values (reverse (cdr rev-for-clausess))
+                    #`(#,sequence-for-form #,(car rev-for-clausess)
+                        rep.body))]
+           [else
+            (values for-clausess
+                    #'rep.body)])])))
   (define-values (body static-infos)
-    (let loop ([depth depth]
-               [depths depths]
-               [named?s (for/list ([n (in-list names)])
-                          #f)])
-      (cond
-        [(= 0 depth)
-         ;; returns expression + static infos
-         (apply build (for/list ([l-depth (in-list list-depths)]
-                                 [name (in-list names)]
-                                 [lst (in-list lists)]
-                                 [named? (in-list named?s)]
-                                 [immed? (in-list immed?s)])
-                        (define e (if named? name lst))
-                        (cond
-                          [immed? e]
-                          [else
-                           (let loop ([e e] [depth (max 0 (- l-depth top-depth))])
-                             (cond
-                               [(= depth 0) #`(#,e)]
-                               [else #`(for/list ([e (in-list #,e)])
-                                         #,(loop #'e (sub1 depth)))]))])))]
-        [else
-         (define (wrap-body body)
-           #`(for/list #,(for/list ([a-depth (in-list depths)]
-                                    [name (in-list names)]
-                                    [lst (in-list lists)]
-                                    [named? (in-list named?s)]
-                                    #:when (= a-depth depth))
-                           #`[#,name (in-list #,(if named? name lst))])
-               #,body))
-         (define-values (body static-infos)
-           (loop (sub1 depth)
-                 (for/list ([a-depth (in-list depths)])
-                   (min a-depth (sub1 depth)))
-                 (for/list ([named? (in-list named?s)]
-                            [a-depth (in-list depths)])
-                   (if (= a-depth depth)
-                       #t
-                       named?))))
-         (values (wrap-body body)
-                 static-infos)])))
-  (values body
-          static-infos))
+    (apply build-one bodys))
+  (make-repetition-info at-stx
+                        (let loop ([depth depth]
+                                   [for-clausesss for-clausesss])
+                          (cond
+                            [(zero? depth)
+                             null]
+                            [else
+                             (cons
+                              (apply
+                               append
+                               (for/list ([for-clausess (in-list for-clausesss)]
+                                          #:when (= (length for-clausess) depth))
+                                 (syntax->list (car for-clausess))))
+                              (loop (sub1 depth)
+                                    (for/list ([for-clausess (in-list for-clausesss)])
+                                      (if (= (length for-clausess) depth)
+                                          (cdr for-clausess)
+                                          for-clausess))))]))
+                        body
+                        static-infos
+                        0))

--- a/rhombus/private/amalgam/implicit.rkt
+++ b/rhombus/private/amalgam/implicit.rkt
@@ -114,13 +114,11 @@
        [(form-id datum . tail)
         (check-literal-term #'form-id #'datum)
         (values (make-repetition-info #'datum
-                                      #'value
-                                      (syntax/loc #'datum (quote datum))
-                                      0
-                                      0
+                                      '()
+                                      #'(quote datum)
                                       (or (literal-static-infos #'datum)
                                           #'())
-                                      #t)
+                                      0)
                 #'tail)]))))
 
 (define-for-syntax (check-literal-term form-id d-stx)

--- a/rhombus/private/amalgam/key-comp-primitive.rkt
+++ b/rhombus/private/amalgam/key-comp-primitive.rkt
@@ -14,12 +14,12 @@
   (key-comp-maker
    (lambda ()
      (key-comp '== #'equal-always-hash?
-               #'Map-build #'Map-pair-build #'list->map
+               #'Map-build #'Map-pair-build #'for/hashalw
                #'mutable-equal-always-hash? #'MutableMap-build
                #'weak-mutable-equal-always-hash? #'WeakMutableMap-build
                #'#hashalw()
                #'immutable-equal-always-set?
-               #'Set-build #'Set-build* #'list->set
+               #'Set-build #'Set-build* #'for/setalw
                #'mutable-equal-always-set? #'MutableSet-build
                #'weak-mutable-equal-always-set? #'WeakMutableSet-build))))
 
@@ -27,12 +27,12 @@
   (key-comp-maker
    (lambda ()
      (key-comp '=== #'object-hash?
-               #'ObjectMap-build #'ObjectMap-pair-build #'list->object-map
+               #'ObjectMap-build #'ObjectMap-pair-build #'for/hasheq
                #'mutable-object-hash? #'MutableObjectMap-build
                #'weak-mutable-object-hash? #'WeakMutableObjectMap-build
                #'#hasheq()
                #'immutable-object-set?
-               #'ObjectSet-build #'ObjectSet-build* #'list->object-set
+               #'ObjectSet-build #'ObjectSet-build* #'for/seteq
                #'mutable-object-set? #'MutableObjectSet-build
                #'weak-mutable-object-set? #'WeakMutableObjectSet-build))))
 
@@ -40,12 +40,12 @@
   (key-comp-maker
    (lambda ()
      (key-comp 'is_now #'now-hash?
-               #'NowMap-build #'NowMap-pair-build #'list->now-map
+               #'NowMap-build #'NowMap-pair-build #'for/hash
                #'mutable-now-hash? #'MutableNowMap-build 
                #'weak-mutable-now-hash? #'WeakMutableNowMap-build 
                #'#hash()
                #'immutable-now-set?
-               #'NowSet-build #'NowSet-build* #'list->now-set
+               #'NowSet-build #'NowSet-build* #'for/set
                #'mutable-now-set? #'MutableNowSet-build
                #'weak-mutable-now-set? #'WeakMutableNowSet-build))))
 
@@ -53,11 +53,11 @@
   (key-comp-maker
    (lambda ()
      (key-comp 'is_same_number_or_object #'number-or-object-hash?
-               #'NumberOrObjectMap-build #'NumberOrObjectMap-pair-build #'list->number-or-object-map
+               #'NumberOrObjectMap-build #'NumberOrObjectMap-pair-build #'for/hasheqv
                #'mutable-number-or-object-hash? #'MutableNumberOrObjectMap-build 
                #'weak-mutable-number-or-object-hash? #'WeakMutableNumberOrObjectMap-build 
                #'#hasheqv()
                #'immutable-number-or-object-set?
-               #'NumberOrObjectSet-build #'NumberOrObjectSet-build* #'list->number-or-object-set
+               #'NumberOrObjectSet-build #'NumberOrObjectSet-build* #'for/seteqv
                #'mutable-number-or-object-set? #'MutableNumberOrObjectSet-build
                #'weak-mutable-number-or-object-set? #'WeakMutableNumberOrObjectSet-build))))

--- a/rhombus/private/amalgam/key-comp.rkt
+++ b/rhombus/private/amalgam/key-comp.rkt
@@ -14,12 +14,12 @@
   (define in-key-comp-space (make-interned-syntax-introducer/add 'rhombus/key_comp))
 
   (struct key-comp (name-sym map?-id
-                             map-build-id map-pair-build-id list->map-id
+                             map-build-id map-pair-build-id map-for-form-id
                              mutable-map?-id mutable-map-build-id
                              weak-mutable-map?-id weak-mutable-map-build-id
                              empty-stx
                              set?-id
-                             set-build-id set-build*-id list->set-id
+                             set-build-id set-build*-id set-for-form-id
                              mutable-set?-id mutable-set-build-id
                              weak-mutable-set?-id weak-mutable-set-build-id))
 

--- a/rhombus/private/amalgam/list.rkt
+++ b/rhombus/private/amalgam/list.rkt
@@ -762,7 +762,7 @@
                                       1
                                       0
                                       #'()
-                                      #f)
+                                      #t)
                 #'tail)]))))
 
 (define-repetition-syntax List.repet
@@ -1280,6 +1280,7 @@
            stx
            content
            #:is-sequence? list-rest-rep?
+           #:maybe-immediate? #t
            #:extract (lambda (e) (if (list-rest? e) (list-rest-syntax e) e))
            (lambda new-content
              (let ([content (for/list ([e (in-list content)]

--- a/rhombus/private/amalgam/listable.rkt
+++ b/rhombus/private/amalgam/listable.rkt
@@ -78,7 +78,7 @@
      (binding-info "to_list"
                    #'val
                    #'()
-                   #'((val (0)))
+                   #'((val (#:repet ())))
                    #'to_list-matcher
                    #'to_list-committer
                    #'to_list-binder

--- a/rhombus/private/amalgam/map.rkt
+++ b/rhombus/private/amalgam/map.rkt
@@ -729,7 +729,8 @@
                  (lambda args
                    (values (quasisyntax/loc stx
                              (#,map-copy-id (#,map-build-id #,@args)))
-                           (get-mutable-map-static-infos))))]
+                           (get-mutable-map-static-infos)))
+                 #:maybe-immediate? #t)]
                [else
                 (wrap-static-info*
                  (quasisyntax/loc stx

--- a/rhombus/private/amalgam/pattern-variable.rkt
+++ b/rhombus/private/amalgam/pattern-variable.rkt
@@ -97,10 +97,11 @@
                           (lambda ()
                             (id-handler stx))))))]
     [else (make-expression+repetition
-           name-id
-           #`(#,unpack* #'$ #,temp-id #,depth)
+           #`(([(elem) (in-list (#,unpack* #'$ #,temp-id #,depth))])
+              #,@(for/list ([i (in-range (sub1 depth))])
+                   #`([(elem) (in-list elem)])))
+           #'elem
            (get-syntax-static-infos)
-           #:depth depth
            #:repet-handler (lambda (stx next)
                              (syntax-parse stx
                                #:datum-literals (op |.|)
@@ -109,16 +110,16 @@
                                 #:when attr
                                 (define var-depth (+ (pattern-variable-depth attr) depth))
                                 (values (make-repetition-info #'(var-id dot-op attr-id)
-                                                              (string->symbol
-                                                               (format "~a.~a" (syntax-e #'var-id) (syntax-e #'attr-id)))
-                                                              #`(#,(pattern-variable-unpack* attr)
-                                                                 #'$
-                                                                 #,(pattern-variable-val-id attr)
-                                                                 #,var-depth)
-                                                              var-depth
-                                                              #'0
+                                                              #`(([(elem) (in-list
+                                                                           (#,(pattern-variable-unpack* attr)
+                                                                            #'$
+                                                                            #,(pattern-variable-val-id attr)
+                                                                            #,var-depth))])
+                                                                 #,@(for/list ([i (in-range (sub1 var-depth))])
+                                                                      #`([(elem) (in-list elem)])))
+                                                              #'elem
                                                               (get-syntax-static-infos)
-                                                              #t)
+                                                              0)
                                         #'tail)]
                                [_ (next)]))
            #:expr-handler expr-handler)]))

--- a/rhombus/private/amalgam/pattern-variable.rkt
+++ b/rhombus/private/amalgam/pattern-variable.rkt
@@ -118,7 +118,7 @@
                                                               var-depth
                                                               #'0
                                                               (get-syntax-static-infos)
-                                                              #f)
+                                                              #t)
                                         #'tail)]
                                [_ (next)]))
            #:expr-handler expr-handler)]))

--- a/rhombus/private/amalgam/quasiquote.rkt
+++ b/rhombus/private/amalgam/quasiquote.rkt
@@ -667,7 +667,7 @@
                                           depth
                                           0
                                           (get-syntax-static-infos)
-                                          #f)]
+                                          #t)]
        [else (wrap-static-info* template-e
                                 (get-syntax-static-infos))])]))
 

--- a/rhombus/private/amalgam/set.rkt
+++ b/rhombus/private/amalgam/set.rkt
@@ -729,7 +729,8 @@
                  (lambda args
                    (values (quasisyntax/loc stx
                              (#,mutable-set-build-id #,@args))
-                           (get-mutable-set-static-infos))))]
+                           (get-mutable-set-static-infos)))
+                 #:maybe-immediate? #t)]
                [else (wrap-static-info*
                       (quasisyntax/loc stx
                         (#,mutable-set-build-id #,@(if (null? argss) null (car argss))))

--- a/rhombus/private/amalgam/setmap-parse.rkt
+++ b/rhombus/private/amalgam/setmap-parse.rkt
@@ -61,14 +61,15 @@
       [else
        (define key-parsed (syntax-parse key-e [key::repetition #'key.parsed]))
        (define val-parsed (syntax-parse val-e [val::repetition #'val.parsed]))
-       ;; This could be faster than building list of pair
+       ;; This could be faster than building a list of pairs
        ;; to convert to a hash table...
        (define pair-rep (flatten-repetition
                          (build-compound-repetition
                           stx (list key-parsed val-parsed)
                           (lambda (key val)
                             (values #`(cons #,key #,val)
-                                    #'())))
+                                    #'()))
+                          #:maybe-immediate? #t)
                          extra-ellipses))
        (list (rest-rep (if repetition?
                            pair-rep
@@ -205,6 +206,7 @@
                   (lambda args
                     (values (build (regroup-setmap-arguments args argss))
                             static-info))
+                  #:maybe-immediate? #t
                   #:is-sequence? rest-rep?
                   #:extract (lambda (v) (if (rest-rep? v) (rest-rep-stx v) v)))]
     [else (wrap-static-info* (build argss) static-info)]))

--- a/rhombus/private/amalgam/setmap.rkt
+++ b/rhombus/private/amalgam/setmap.rkt
@@ -20,6 +20,7 @@
                                              #:repetition? [repetition? #f])
   (define-values (shape argss)
     (parse-setmap-content stx
+                          #:set-for-form #'for/setalw
                           #:shape init-shape
                           #:who who
                           #:repetition? repetition?))
@@ -33,7 +34,7 @@
                  (if (eq? shape 'set) #'set-assert #'hash-assert)
                  (if (eq? shape 'set) (get-set-static-infos) (get-map-static-infos))
                  #:repetition? repetition?
-                 #:list->setmap (if (eq? shape 'set) #'list->set #'list->map))))
+                 #:rep-for-form (if (eq? shape 'set) #'for/setalw #'for/hashalw))))
 
 (define-for-syntax (parse-setmap-binding who stx)
   ;; we use `parse-setmap-content` just to pick between maps and sets;

--- a/rhombus/private/amalgam/veneer.rkt
+++ b/rhombus/private/amalgam/veneer.rkt
@@ -362,7 +362,7 @@
      (binding-info (shrubbery-syntax->string #'name)
                    #'val
                    #'()
-                   #'((val (0)))
+                   #'((val (~repeat ())))
                    #'converter-matcher
                    #'converter-committer
                    #'converter-binder

--- a/rhombus/scribblings/bind-macro-protocol.scrbl
+++ b/rhombus/scribblings/bind-macro-protocol.scrbl
@@ -193,8 +193,10 @@ which matches only things that are fruits according to @rhombus(is_fruit):
         $id,
         // no overall static info:
         (),
-        // `id` is bound, `0` means usable as expression, no static info:
-        (($id, [0], ())),
+        // `id` is bound,
+        //  `~repet ()` means usable as repetition, and
+        //  `()` means no static info:
+        (($id, [~repet ()], ())),
         fruit_matcher,
         fruit_committer,
         fruit_binder,

--- a/rhombus/scribblings/ref-bind-macro.scrbl
+++ b/rhombus/scribblings/ref-bind-macro.scrbl
@@ -172,14 +172,15 @@
  @rhombus(var_static_key, ~var)--@rhombus(var_static_value, ~var) pairs.
  Like @rhombus(var_static_key, ~var)s, the meaning of
  @rhombus(var_use, ~var)s is up to cooperating parts in general, but
- two values are recognized by built-in forms:
+ two shapes are recognized by built-in forms:
 
 @itemlist(
 
-  @item{an exact non-negative integer indicates that the variable can be
-  used as an expression (in the case of @rhombus(0)) or repetition at a
-  certain depth (in the case of @rhombus(k, ~var) greater than
-  @rhombus(0)); and}
+  @item{@rhombus(~repeat (#,(@rhombus(sequencer, ~var)), ...))
+  indicates that the variable can be used as repetition at a depth
+  corresponding to the number of @rhombus(sequencer, ~var)s, and also
+  as an expression if the number @rhombus(sequencer, ~var)s is zero;
+  and}
 
   @item{@rhombus(~no_stx) indicates that the variable's is not
   compatible with @rhombus(let), because it needs to be bound early (such

--- a/rhombus/scribblings/ref-repet-macro.scrbl
+++ b/rhombus/scribblings/ref-repet-macro.scrbl
@@ -46,7 +46,7 @@
   ~defn:
     repet.macro 'nat3':
       ~op_stx self
-      repet_meta.pack_list('($self, n, PairList[0, 1, 2], 1, 0, (), #true)')
+      repet_meta.pack_list('($self, [0, 1, 2], 1, 0, ())')
   ~repl:
     [nat3, ...]
 )
@@ -68,13 +68,12 @@
 
  @rhombusblock(
   '(#,(@rhombus(source_form, ~var)),
-    #,(@rhombus(name_id, ~var)),
-    #,(@rhombus(pair_list_expr, ~var)),
-    #,(@rhombus(total_depth, ~var)),
+    #,(@rhombus(list_expr, ~var)),
+    #,(@rhombus(depth, ~var)),
     #,(@rhombus(use_depth, ~var)),
-    ((#,(@rhombus(static_key, ~var)), #,(@rhombus(static_value, ~var))), ...),
-    #,(@rhombus(is_immediate, ~var)))'
-   )
+    ((#,(@rhombus(static_key, ~var)), #,(@rhombus(static_value, ~var))), ...)
+   )'
+ )
 
  The @rhombus(source_form, ~var) group is used for error repoting to
  show the repetition, such as when the repeition is used at the wrong
@@ -84,30 +83,21 @@
  in the sense that it is used as the inferred name for an element of the
  repetition, in case such a name is relevant.
 
- The @rhombus(pair_list_expr, ~var) expression produces a @rhombus(PairList, ~annot) that contains
+ The @rhombus(list_expr, ~var) expression produces a @rhombus(List, ~annot) that contains
  the elements of the repetition. Lists must be nested according to the
  repeition's depth: a list of elements for depth 1, a list of element
  lists for depth 2, and so on.
 
- The @rhombus(total_depth, ~var) integer specifies the depth of the
- original repetition, while @rhombus(use_depth, ~var) specifies how much
- of the original depth has already been extracted; that is, the
- difference @rhombus(total_depth, ~var) minus @rhombus(use_depth, ~var)
- indicates the depth of the list nesting that is produced by
- @rhombus(list_expr, ~var). A non-zero @rhombus(use_depth, ~var) might be
- relevant to reporting the use of a repetition at the wrong depth in
- terms of the original form's depth.
+ The @rhombus(depth, ~var) integer specifies the depth of the
+ repetition. The @rhombus(use_depth, ~var) specifies how much additional
+ depth has already been extracted from an original repetition; a non-zero
+ @rhombus(use_depth, ~var) might be relevant to reporting the use of a
+ repetition at the wrong depth in terms of the original form's depth.
 
  The @rhombus(static_key, ~var)--@rhombus(static_value, ~var) pairs
  describe ``upward'' static information for inidvidual elements of the
  repeition. This information is automatically packed via
  @rhombus(statinfo_meta.pack).
-
- The @rhombus(is_immediate, ~var) component must be a literal boolean. A
- @rhombus(#true) indicates that @rhombus(list_expr, ~var) provides
- immediate values for the repetition, while @rhombus(#false) indicates
- that @rhombus(list_expr, ~var) contains a thunk that produces the
- values.
 
 }
 
@@ -125,19 +115,17 @@
   ~defn:
     repet.macro 'enum($from, $(sub :: repet_meta.Parsed))':
       ~op_stx self
-      let '($_, $name, $expr, $depth, $use_depth, $_, $_)':
+      let '($_, $expr, $depth, $use_depth, $_)':
         repet_meta.unpack_list(sub)
       let (_, si):
         let '$(p :: annot_meta.Parsed)' = 'List'
         annot_meta.unpack_predicate(p)
       repet_meta.pack_list(
         '($self(),
-          $name,
-          for PairList (elem: $expr, i: $from ..): [i, elem],
+          for List (elem: $expr, i: $from ..): [i, elem],
           $depth,
           $use_depth,
-          $si,
-          #true)'
+          $si)'
       )
   ~repl:
     def [x, ...] = ["a", "b", "c"]

--- a/rhombus/scribblings/ref-repet-macro.scrbl
+++ b/rhombus/scribblings/ref-repet-macro.scrbl
@@ -104,10 +104,10 @@
  @rhombus(statinfo_meta.pack).
 
  The @rhombus(is_immediate, ~var) component must be a literal boolean. A
- @rhombus(#true) indicates that @rhombus(list_expr, ~var) can be efficiently
- evaluated multiple times, while @rhombus(#false) indicates that
- @rhombus(list_expr, ~var) should be lifted out of enclosing repetitions
- to avoid evaluating it multiple times.
+ @rhombus(#true) indicates that @rhombus(list_expr, ~var) provides
+ immediate values for the repetition, while @rhombus(#false) indicates
+ that @rhombus(list_expr, ~var) contains a thunk that produces the
+ values.
 
 }
 
@@ -137,7 +137,7 @@
           $depth,
           $use_depth,
           $si,
-          #false)'
+          #true)'
       )
   ~repl:
     def [x, ...] = ["a", "b", "c"]

--- a/rhombus/scribblings/ref-repetition.scrbl
+++ b/rhombus/scribblings/ref-repetition.scrbl
@@ -88,6 +88,19 @@ In other words, unless otherwise documented, the depth of a repetition
 formed by combining repetitions is the maximum of the depths of the
 combined repetitions, so @rhombus(z+y) is a repetition of depth 2.
 
+Expressions with side effects or short-circuiting operators can appear
+within a repetition. Each effect and control-flow choice is applied on
+demand per element of the repetition, which can be different than
+constructing an intermediate repetition.
+
+@examples(
+  def [x, ...] = [1, 2, 3]
+  [x > 1 && println(x), ...]
+  block:
+    let [void, ...] = [println(x), ...]
+    [x > 1 && void, ...]
+)
+
 When an identifier is bound as a repetition, it is bound in the
 @rhombus(repet, ~space) space, but also in the @rhombus(expr, ~space).
 The @rhombus(expr, ~space) binding reports an error, but the intent of

--- a/rhombus/tests/quasiquote.rhm
+++ b/rhombus/tests/quasiquote.rhm
@@ -212,3 +212,13 @@ check:
       match y
       | '': "ok"
   ~is "ok"
+
+// Make sure multi-element syntax can be replicated for a repetition
+check:
+  def [x, ...] = [1, 2, 3]
+  def body = '1 2'
+  '$x: $body
+   ...'
+  ~prints_like '1: 1 2
+                2: 1 2
+                3: 1 2'

--- a/rhombus/tests/repet-macro.rhm
+++ b/rhombus/tests/repet-macro.rhm
@@ -9,12 +9,10 @@ block:
 repet.macro 'nat3':
   ~op_stx self
   repet_meta.pack_list('($self,
-                         n,
-                         PairList[0, 1, 2],
+                         List[0, 1, 2],
                          1,
                          0,
-                         (),
-                         #true)')
+                         ())')
 
 check:
   [nat3, ...] ~is [0, 1, 2]
@@ -23,21 +21,19 @@ check:
 
 repet.macro 'enum($from, $(sub :: repet_meta.Parsed))':
   ~op_stx self
-  def '($orig, $name, $expr, $depth, $use_depth, $statinfos, $is_immed)':
+  def '($orig, $expr, $depth, $use_depth, $statinfos)':
     repet_meta.unpack_list(sub)
   def (pred, si):
     annot_meta.unpack_predicate(match 'List' | '$(p :: annot_meta.Parsed)': p)
   repet_meta.pack_list('($self(),
-                         $name,
-                         for PairList:
+                         for List:
                            each:
                              elem: $expr
                              i: $from..
                            [i, elem],
                          $depth,
                          $use_depth,
-                         $si,
-                         #true)')
+                         $si)')
 
 check:
   [enum(10, nat3), ...] ~is [[10, 0], [11, 1], [12, 2]]

--- a/rhombus/tests/repet-macro.rhm
+++ b/rhombus/tests/repet-macro.rhm
@@ -37,7 +37,7 @@ repet.macro 'enum($from, $(sub :: repet_meta.Parsed))':
                          $depth,
                          $use_depth,
                          $si,
-                         #false)')
+                         #true)')
 
 check:
   [enum(10, nat3), ...] ~is [[10, 0], [11, 1], [12, 2]]


### PR DESCRIPTION
The change to the meaning of repetitions makes examples like these work better:
    
```
> let [x, ...] = [1, 2, 3]
> [(x == 1) && println(x), ...]
1
[#void, #false, #false]
> [(x != 1) && println(x), ...]
2
3
[#false, #void, #void]
```
    
In particular, an expression derived from a use of a repetition is evaluated once for each instance of the repetition. In contrast, the old implementation would create a list of `x == 1` results and separate list of `println(x)` results, and then build up a larger list from those.
    
Internally, instead of an expression that produces nested pair lists, change the representation of a repetition to be a sequence of `for` clauses plus a `for` body. This revised representation is a better fit for the revised semantics of repetitions, it makes repetition combinations much simpler to implement, and it produces faster code by deforesting common cases.
    
The representation change requires some small adjustments to the binding macro protocol and the repetition macro protocol. The current repetition macro protocol is still tied to lists (but regular Rhombus lists instead of pair lists), and we'll eventually want to add a packing variant to `repet_macro` to support for more general forms. Related to that, the binding macro protocol involves "sequencer" forms that are currently opaque. Adding a way to go from an annotation to a sequencer will fill in the binding protocol and probably be the right ingredient for a generalized repetition packer, but that's not done here.
