### PR TITLE
allow `...` or `&` for `List` in the middle of other bindings

### DIFF
--- a/rhombus/private/amalgam/list.rkt
+++ b/rhombus/private/amalgam/list.rkt
@@ -443,27 +443,31 @@
       [(_ . tail)
        (values proc-stx #'tail)])))
 
-(define-for-syntax (make-treelist-rest-selector args-n for-rep?)
+(define-for-syntax (make-treelist-rest-selector args-n post-args-n)
   (if (= 0 args-n)
-      #'values
-      #`(lambda (v) (treelist-drop v '#,args-n))))
+      (if (= 0 post-args-n)
+          #'values
+          #`(lambda (v) (treelist-drop-right v '#,post-args-n)))
+      (if (= 0 post-args-n)
+          #`(lambda (v) (treelist-drop v '#,args-n))
+          #`(lambda (v) (treelist-drop-right (treelist-drop v '#,args-n) '#,post-args-n)))))
 
-(define-for-syntax (make-list-rest-selector args-n for-rep?)
+(define-for-syntax (make-list-rest-selector args-n zero-post-args-n)
   (if (= 0 args-n)
       #'values
       #'cdr))
 
-(define-for-syntax (make-binding generate-binding make-rest-selector get-static-infos)
+(define-for-syntax (make-binding generate-binding make-rest-selector get-static-infos mid-splice-allowed?)
   (binding-transformer
    (lambda (stx)
      (syntax-parse stx
        [(form-id (_::parens arg ...) . tail)
-        (parse-*list-binding stx generate-binding make-rest-selector (get-static-infos))]
+        (parse-*list-binding stx generate-binding make-rest-selector (get-static-infos) mid-splice-allowed?)]
        [(form-id (_::brackets arg ...) . tail)
-        (parse-*list-binding stx generate-binding make-rest-selector (get-static-infos))]))))
+        (parse-*list-binding stx generate-binding make-rest-selector (get-static-infos) mid-splice-allowed?)]))))
 
 (define-for-syntax (parse-list-binding stx)
-  (parse-*list-binding stx generate-treelist-binding make-treelist-rest-selector (get-treelist-static-infos)))
+  (parse-*list-binding stx generate-treelist-binding make-treelist-rest-selector (get-treelist-static-infos) #t))
 
 (define-annotation-constructor (List List.of)
   ()
@@ -1133,49 +1137,79 @@
 
 ;; parses a list pattern that has already been checked for use with a
 ;; suitable `parens` or `brackets` form
-(define-for-syntax (parse-*list-binding stx generate-binding make-rest-selector static-infos)
+(define-for-syntax (parse-*list-binding stx generate-binding make-rest-selector static-infos mid-splice-allowed?)
+  (define (check-allowed-args args after-args op-stx)
+    (define (no op-stx)
+      (raise-syntax-error #f
+                          "second splice or repetition not allowed in a list pattern"
+                          stx
+                          op-stx))
+    (for ([arg (in-list args)])
+      (syntax-parse arg
+        [(group _::&-bind . _) (no op-stx)]
+        [(group _::...-bind . _) (no op-stx)]
+        [_ (void)]))
+    (for ([arg (in-list after-args)])
+      (syntax-parse arg
+        [(group op::&-bind . _) (no #'op)]
+        [(group op::...-bind . _) (no #'op)]
+        [_ (void)]))
+    (unless mid-splice-allowed?
+      (when (pair? after-args)
+        (raise-syntax-error #f
+                            "splice or repetition not allowed before the end of the pattern"
+                            stx
+                            op-stx))))
   (syntax-parse stx
     #:datum-literals (group)
-    [(form-id (_ arg ... (group _::&-bind rest-arg ...)) . tail)
+    [(form-id (_ arg ... (group op::&-bind rest-arg ...) after-arg ...) . tail)
      (define args (syntax->list #'(arg ...)))
-     (define len (length args))
-     (generate-binding #'form-id len #t args #'tail
+     (define after-args (syntax->list #'(after-arg ...)))
+     (check-allowed-args args after-args #'op)
+     (generate-binding #'form-id #t args after-args #'tail
                        #`(#,group-tag rest-bind #,static-infos
                           (#,group-tag rest-arg ...))
-                       (make-rest-selector len #f)
+                       make-rest-selector
                        #f)]
-    [(form-id (_ arg ... rest-arg (group _::...-bind)) . tail)
+    [(form-id (_ arg ... rest-arg (group op::...-bind) after-arg ...) . tail)
      (define args (syntax->list #'(arg ...)))
+     (define after-args (syntax->list #'(after-arg ...)))
+     (check-allowed-args args after-args #'op)
      (define len (length args))
-     (generate-binding #'form-id len #t args #'tail #'rest-arg
-                       (make-rest-selector len #t)
+     (generate-binding #'form-id #t args after-args #'tail #'rest-arg
+                       make-rest-selector
                        #t)]
     [(form-id (_ arg ...) . tail)
      (define args (syntax->list #'(arg ...)))
-     (define len (length args))
-     (generate-binding #'form-id len #f args #'tail)]))
+     (generate-binding #'form-id #f args null #'tail)]))
 
-(define-for-syntax (generate-treelist-binding form-id len or-more? args tail [rest-arg #f] [rest-selector #f]
+(define-for-syntax (generate-treelist-binding form-id or-more? args after-args tail [rest-arg #f] [make-rest-selector #f]
                                               [rest-repetition? #t])
+  (define pre-len (length args))
+  (define post-len (length after-args))
+  (define len (+ pre-len post-len))
   (define pred #`(lambda (v)
                    (and (treelist? v)
                         (#,(if or-more? #'>= #'=) (treelist-length v) #,len))))
-  (composite-binding-transformer #`(#,form-id (parens . #,args) . #,tail)
+  (composite-binding-transformer #`(#,form-id (parens . #,(append args after-args)) . #,tail)
                                  #:rest-arg rest-arg
                                  "List"
                                  pred
-                                 (for/list ([i (in-range (length args))])
-                                   #`(lambda (tl) (treelist-ref tl #,i)))
-                                 (for/list ([arg (in-list args)])
+                                 (for/list ([i (in-range len)])
+                                   (if (i . < . pre-len)
+                                       #`(lambda (tl) (treelist-ref tl #,i))
+                                       #`(lambda (tl) (treelist-ref tl (+ (treelist-length tl) #,(- i len))))))
+                                 (for/list ([i (in-range len)])
                                    #'())
                                  #:index-result-info? #t
-                                 #:rest-accessor rest-selector
+                                 #:rest-accessor (and make-rest-selector (make-rest-selector pre-len post-len))
                                  #:rest-repetition? rest-repetition?
                                  #:rest-to-repetition #'treelist->list
                                  #:static-infos (get-treelist-static-infos)))
 
-(define-for-syntax (generate-list-binding form-id len or-more? args tail [rest-arg #f] [rest-selector #f]
+(define-for-syntax (generate-list-binding form-id or-more? args after-args tail [rest-arg #f] [make-rest-selector #f]
                                           [rest-repetition? #t])
+  (define len (length args))
   (define pred #`(lambda (v)
                    (and (list? v)
                         #,(let ([check #`(maybe-list-tail v #,len)])
@@ -1196,12 +1230,12 @@
                                   (for/list ([arg (in-list args)])
                                     #'())
                                   #:index-result-info? #t
-                                  #:rest-accessor rest-selector
+                                  #:rest-accessor (and make-rest-selector (make-rest-selector len 0))
                                   #:rest-repetition? rest-repetition?
                                   #:static-infos (get-list-static-infos)))
 
-(define-binding-syntax List (make-binding generate-treelist-binding make-treelist-rest-selector get-treelist-static-infos))
-(define-binding-syntax PairList (make-binding generate-list-binding make-list-rest-selector get-list-static-infos))
+(define-binding-syntax List (make-binding generate-treelist-binding make-treelist-rest-selector get-treelist-static-infos #t))
+(define-binding-syntax PairList (make-binding generate-list-binding make-list-rest-selector get-list-static-infos #f))
 
 (begin-for-syntax
   (struct list-rest (syntax))

--- a/rhombus/scribblings/ref-list.scrbl
+++ b/rhombus/scribblings/ref-list.scrbl
@@ -113,11 +113,11 @@ it supplies its elements in order.
     list_bind: def bind ~defn
     repet_bind: def bind ~defn
   bind.macro 'List($bind, ...)'
-  bind.macro 'List($bind, ..., $rest)'
+  bind.macro 'List($bind, ..., $rest, $bind, ...)'
   bind.macro '#%brackets [$bind, ...]'
-  bind.macro '#%brackets [$bind, ..., $rest]'
+  bind.macro '#%brackets [$bind, ..., $rest, $bind, ...]'
   bind.macro 'List[$bind, ...]'
-  bind.macro 'List[$bind, ..., $rest]'
+  bind.macro 'List[$bind, ..., $rest, $bind, ...]'
   grammar rest:
     $repet_bind #,(@litchar{,}) $ellipsis
     & $list_bind
@@ -128,9 +128,11 @@ it supplies its elements in order.
  Matches a list with as many elements as @rhombus(bind)s, or if
  @rhombus(rest) is included, at least as many elements as
  @rhombus(bind)s, where the @rhombus(rest) (if present) matches the
- rest of the list.
+ remainder of the list. Unlike most binding forms, a list pattern
+ can include a @rhombus(rest) in the middle of a @rhombus(bind)
+ sequence, and not just after @rhombus(bind)s.
 
- When @rhombus(& list_bind) is used, the rest of the list must match
+ When @rhombus(& list_bind) is used, the remainder of the list must match
  the @rhombus(list_bind). Static information associated by
  @rhombus(List) is propagated to @rhombus(list_bind).
 
@@ -151,6 +153,8 @@ it supplies its elements in order.
   def List(1, & xs) = [1, 2, 3]
   xs
   def List(1, x, ...) = [1, 2, 3]
+  [x, ...]
+  def List(1, x, ..., 3) = [1, 2, 3]
   [x, ...]
 )
 

--- a/rhombus/tests/list.rhm
+++ b/rhombus/tests/list.rhm
@@ -345,3 +345,57 @@ version_guard.at_least "8.13.0.1":
 check:
   to_string([]) ~is "[]"
   to_string([1, 2, 3]) ~is "[1, 2, 3]"
+
+check:
+  let [a, b, ...] = [1, 2, 3]
+  [a, [b, ...]]
+  ~is [1, [2, 3]]
+
+check:
+  let [a, ..., b] = [1, 2, 3]
+  [[a, ...], b]
+  ~is [[1, 2], 3]
+
+check:
+  let [a, b, ...] = [1]
+  let [c, ..., d] = [2]
+  [a, [b, ...], [c, ...], d]
+  ~is [1, [], [], 2]
+
+check:
+  let [a, b, ..., c, d] = [1, 2, 3, 4, 5, 6]
+  [a, [b, ...], c, d]
+  ~is [1, [2, 3, 4], 5, 6]
+
+check:
+  let [a, & b, c, d] = [1, 2, 3, 4, 5, 6]
+  [a, b, c, d]
+  ~is [1, [2, 3, 4], 5, 6]
+
+block:
+  fun f(x, ...):
+    match [x, ...]
+    | [1, a, ...]: {a, ...}
+    | [2, a, ...]: [a, ...]
+    | [3, a, ..., 4]: [a, ...]
+    | [x, & y, z]: [x, y, z]
+  check f(1, 2, 3) ~is {2, 3}
+  check f(2, 3, 4, 5) ~is [3, 4, 5]
+  check f(3, 4, 5, 6, 4) ~is [4, 5, 6]
+  check f(3, 4) ~is []
+  check f(3, 4, 5, 6) ~is [3, [4, 5], 6]
+
+check:
+  ~eval
+  def [x, ..., y, ...] = [1, 2]
+  ~throws "second splice or repetition not allowed"
+
+check:
+  ~eval
+  def [& x, y, ...] = [1, 2]
+  ~throws "second splice or repetition not allowed"
+
+check:
+  ~eval
+  def [x, ..., & y, z] = [1, 2]
+  ~throws "second splice or repetition not allowed"

--- a/rhombus/tests/pairlist.rhm
+++ b/rhombus/tests/pairlist.rhm
@@ -327,3 +327,18 @@ version_guard.at_least "8.13.0.1":
 check:
   to_string(PairList[]) ~is "PairList[]"
   to_string(PairList[1, 2, 3]) ~is "PairList[1, 2, 3]"
+
+check:
+  ~eval
+  def PairList[x, ..., y, ...] = [1, 2]
+  ~throws "second splice or repetition not allowed"
+
+check:
+  ~eval
+  def PairList[& x, y, ...] = [1, 2]
+  ~throws "second splice or repetition not allowed"
+
+check:
+  ~eval
+  def PairList[x, ..., & y, z] = [1, 2]
+  ~throws "second splice or repetition not allowed"


### PR DESCRIPTION
Since list items (unlike pair-list items) at the end of a list can be accessed just as efficiently as items at the start, allow a repetition in places other than the end of a `List` pattern.

```
fun
| sum_left_to_right([]): 0
| sum_left_to_right([a, ..., b]):
    sum_left_to_right([a, ...]) + b
```