### PR TITLE
enable repetition-sensitive dot providers

### DIFF
--- a/rhombus/private/amalgam/class-clause-primitive-meta-macro.rkt
+++ b/rhombus/private/amalgam/class-clause-primitive-meta-macro.rkt
@@ -61,8 +61,8 @@
   (define (class-dot-transformer pat)
     (parse-identifier-syntax-transformer pat
                                          #'dot-transformer-compiletime
-                                         '(#:head_stx #:is_static #:tail)
-                                         '(value value pattern)
+                                         '(#:head_stx #:is_static #:is_repet #:tail)
+                                         '(value value value pattern)
                                          (lambda (p ct)
                                            ct)
                                          (lambda (ps ct)
@@ -75,11 +75,12 @@
                                          (syntax->list #'self-ids)
                                          (syntax->list #'all-ids)
                                          (syntax->list #'extra-argument-binds)
-                                         #'values
-                                         #'(get-syntax-static-infos get-empty-static-infos get-syntax-static-infos)
-                                         '(value value pattern)
+                                         #'wrap-dot-transformer
+                                         #'(get-syntax-static-infos get-empty-static-infos get-empty-static-infos get-syntax-static-infos)
+                                         '(value value value pattern)
                                          #:else #'#f
-                                         #:cut? #t)])))
+                                         #:cut? #t
+                                         #:report-keywords '(#:head_stx #:is_static #:is_repet #:tail))])))
 
 
 (define-for-syntax (parse-static_info stx data)
@@ -96,3 +97,11 @@
 
 (define-veneer-clause-syntax static_info
   (veneer-clause-transformer parse-static_info))
+
+(define-for-syntax (wrap-dot-transformer proc provided-kws)
+  (if (memq '#:is_repet provided-kws)
+      proc
+      (lambda (left dot right static? repetition? tail)
+        (if repetition?
+            #false
+            (proc left dot right static? repetition? tail)))))

--- a/rhombus/private/amalgam/class-primitive.rkt
+++ b/rhombus/private/amalgam/class-primitive.rkt
@@ -295,16 +295,22 @@
                 null)
 
          (define-for-syntax name-dot-dispatch
-           (lambda (field-sym field-proc ary nary fail-k)
+           (lambda (field-sym field-proc ary nary repetition? fail-k)
              (case field-sym
-               [(prop) (field-proc (lambda (e reloc)
-                                     (build-accessor-call (quote-syntax prop-proc) e reloc prop-static-infos))
-                                   (~? (lambda (e rhs reloc)
-                                         (build-mutator-call (quote-syntax prop-mutator) e rhs reloc))))]
+               [(prop)
+                (cond
+                  [repetition?
+                   ;; let dot-provider dispatcher handle repetition construction:
+                   (fail-k)]
+                  [else
+                   (field-proc (lambda (e reloc)
+                                 (build-accessor-call (quote-syntax prop-proc) e reloc prop-static-infos))
+                               (~? (lambda (e rhs reloc)
+                                     (build-mutator-call (quote-syntax prop-mutator) e rhs reloc))))])]
                ...
                [(method) method-dispatch]
                ...
-               [else (~? (parent-dot-dispatch field-sym field-proc ary nary fail-k)
+               [else (~? (parent-dot-dispatch field-sym field-proc ary nary repetition? fail-k)
                          (fail-k))])))
 
          (define-syntax name-instance

--- a/rhombus/private/amalgam/dot-macro.rkt
+++ b/rhombus/private/amalgam/dot-macro.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 (require (for-syntax racket/base
+                     syntax/parse/pre
                      "pack.rkt"
                      (submod "syntax-object.rkt" for-quasiquote)
                      (only-in "static-info.rkt"
@@ -7,7 +8,8 @@
          "space-provide.rkt"
          (submod "dot.rkt" for-dot-provider)
          "macro-macro.rkt"
-         "wrap-expression.rkt")
+         "wrap-expression.rkt"
+         "repetition.rkt")
 
 (define+provide-space dot rhombus/dot
   #:fields
@@ -21,23 +23,42 @@
 (define-identifier-syntax-definition-transformer macro
   rhombus/dot
   #:extra ([#:is_static get-empty-static-infos value]
+           [#:is_repet get-empty-static-infos value]
            [#:tail get-syntax-static-infos pattern])
+  #:report-keywords
   #'make-dot-provider-transformer)
 
-(define-for-syntax (make-dot-provider-transformer proc)
-  (dot-provider (wrap-dot-provider-transformer proc)))
+(define-for-syntax (make-dot-provider-transformer proc provided-kws)
+  (dot-provider (wrap-dot-provider-transformer proc
+                                               (and (memq '#:is_repet provided-kws) #t))))
 
-(define-for-syntax (wrap-dot-provider-transformer proc)
-  (lambda (left dot right tail static? success-k fail-k)
-    (call-with-values
-     (lambda () (proc (pack-tail #`((parsed #:rhombus/expr #,left) #,dot #,right)) dot static? (pack-tail tail)))
-     (case-lambda
-       [(e)
-        (cond
-          [e (success-k (wrap-expression e) tail)]
-          [else
-           (fail-k)])]
-       [(e tail)
-        (if e
-            (success-k (wrap-expression e) (unpack-tail tail proc #f))
-            (fail-k))]))))
+(define-for-syntax (wrap-dot-provider-transformer proc handled-repet?)
+  (lambda (left dot right tail static? repetition? success-k fail-k)
+    (cond
+      [(and repetition? (not handled-repet?)) (fail-k)]
+      [else
+       (define (wrap e) (if repetition?
+                            (syntax-parse #`(group #,e)
+                              [rep::repetition #'rep.parsed]
+                              [_
+                               (log-error "oops ~s" e)
+                               e]) ; leave it to the macro driver to complain
+                            (wrap-expression e)))
+       (call-with-values
+        (lambda () (proc (pack-tail #`((parsed #,(if repetition? '#:rhombus/repet '#:rhombus/expr) #,left)
+                                       #,dot
+                                       #,right))
+                         dot
+                         static?
+                         repetition?
+                         (pack-tail tail)))
+        (case-lambda
+          [(e)
+           (cond
+             [e (success-k (wrap e) tail)]
+             [else
+              (fail-k)])]
+          [(e tail)
+           (if e
+               (success-k (wrap e) (unpack-tail tail proc #f))
+               (fail-k))]))])))

--- a/rhombus/private/amalgam/listable.rkt
+++ b/rhombus/private/amalgam/listable.rkt
@@ -52,7 +52,7 @@
 (define-dot-provider-syntax listable-instance
   (dot-provider
    (dot-parse-dispatch
-    (lambda (field-sym field-proc ary nary fail-k)
+    (lambda (field-sym field-proc ary nary repetition? fail-k)
       (case field-sym
         [(to_list) (nary 1 #'Listable.to_list #'Listable.to_list/method)]
         [else (fail-k)])))))

--- a/rhombus/private/amalgam/macro-rhs.rkt
+++ b/rhombus/private/amalgam/macro-rhs.rkt
@@ -394,7 +394,8 @@
                                                      #:tail-ids [tail-ids '()]
                                                      #:wrap-for-tail [wrap-for-tail values]
                                                      #:else [else-case #f]
-                                                     #:cut? [cut? #f])
+                                                     #:cut? [cut? #f]
+                                                     #:report-keywords [report-keywords #f])
   (define case-shape (select-transformer-case-shape pre-parseds extra-bindss))
   (define in-extra-ids (generate-temporaries (car extra-bindss)))
   (with-syntax ([((_ id . _) . _) pre-parseds])
@@ -464,7 +465,17 @@
                             #,@(if else-case
                                    #`([_ #,else-case])
                                    null))]))])
-         id))))
+         id)
+       #,@(if report-keywords
+              #`((quote #,(hash-keys
+                           (for/hasheq ([extra-binds-stx (in-list extra-bindss)]
+                                        #:when #t
+                                        [extra-bind (in-list (syntax->list extra-binds-stx))]
+                                        [kw (in-list report-keywords)]
+                                        #:when (syntax-e extra-bind))
+                             (values kw #t))
+                           #t)))
+              null))))
 
 (define-for-syntax (parse-transformer-definition-sequence-rhs pre-parsed self-id all-id
                                                               make-transformer-id

--- a/rhombus/private/amalgam/repet-macro.rkt
+++ b/rhombus/private/amalgam/repet-macro.rkt
@@ -152,7 +152,7 @@
        (define depth (length (syntax->list #'r.for-clausess)))
        (pack-term
         #`(parens (group . r.rep-expr)
-                  (group (parsed #:rhombus/expr #,(repetition-as-nested-lists #'r depth #'for/list)))
+                  (group (parsed #:rhombus/expr #,(repetition-as-nested-lists #'r depth #'for/treelist)))
                   (group #,depth)
                   (group r.used-depth)
                   (group #,(unpack-static-infos who #'r.element-static-infos))))]))

--- a/rhombus/scribblings/ref-dot-provider.scrbl
+++ b/rhombus/scribblings/ref-dot-provider.scrbl
@@ -27,33 +27,46 @@
     ~is_static $id
     ~tail: '$pattern'
     ~tail '$pattern'
+    ~is_repet: $id
+    ~is_repet $id
 ){
 
  Similar to @rhombus(defn.macro), but binds a @tech{dot provider} that
  is normally referenced indirectly via @tech{static information},
  instead of directly. The @rhombus(pattern) sequence after the leading
  @rhombus(defined_name) should match a sequence of three
- terms: a parsed left-hand expression, a @rhombus(.) term, and a
+ terms: a parsed left-hand expression or repetition, a @rhombus(.) term, and a
  right-hand identifier. The @rhombus(defined_name) is bound in the
  @rhombus(dot, ~space) @tech{space}.
 
- Two extra @rhombus(option)s are supported: @rhombus(~is_static) and
- @rhombus(~tail). The identifier for @rhombus(~is_static) is bound to
+ If the @rhombus(~is_repet) option is specified, then the dot provider
+ can be called in either expression or repetition mode, where the
+ left-hand term and the result correspond to the mode. The dot provider
+ is only called in expression mode if the @rhombus(~is_repet) option is
+ not specified for any pattern case.
+
+ Compared to @rhombus(defn.macro), three extra @rhombus(option)s are supported:
+ @rhombus(~is_static), @rhombus(~tail), and
+ @rhombus(~is_repet). The identifier for @rhombus(~is_static) is bound to
  @rhombus(#true) or @rhombus(#false), depending on whether the use of
  @rhombus(.) to reach the provider was a static or dynamic dot; see
  @rhombus(use_static). The pattern for @rhombus(~tail) is matched to the
  tail of the enclosing group after the @rhombus(.) and subsequent
  identifier. If the @rhombus(~tail) pattern doesn't match, then the case
  containing the @rhombus(~tail) pattern does not match, which is useful
- in a multi-case @rhombus(dot.macro) form.
+ in a multi-case @rhombus(dot.macro) form. The @rhombus(~is_repet) identifier
+ is bound to @rhombus(#true) or @rhombus(#false), depending on whether the
+ dot provider is called in repetition or expression mode.
 
  The result must be either @rhombus(#false), a syntax object, or two
  syntax-object values. A @rhombus(#false) result means that static
  resolution failed, in which case the @rhombus(.) operator will generate
- a fallback lookup that is dynamic and generic---unless the @rhombus(.)
- operator is in static mode, in which case it will report a syntax error.
- A (first) syntax-object result provides an expression form (that normally
- includes the left-hand expression) to replace the @rhombus(.)
+ a fallback lookup. In repetition mode, the fallback is to try expression
+ mode. In expression mode, the fallback implements a lookup
+ that is dynamic and generic---unless the @rhombus(.)
+ operator is in static mode, in which case the fallback will report a syntax error.
+ A (first) syntax-object result provides an expression or repetition form (that normally
+ includes the left-hand expression or repetition) to replace the @rhombus(.)
  expression. When a second syntax-object result is provided, it is used
  as the remainder of the enclosing group for further processing, and the
  default result is the same tail that would be provided for an identifier
@@ -89,6 +102,8 @@
     ~is_static $id
     ~tail: '$pattern'
     ~tail '$pattern'
+    ~is_repet: $id
+    ~is_repet $id
 ){
 
  A form for @rhombus(class), @rhombus(interface), or @rhombus(veneer) to bind a macro that

--- a/rhombus/tests/class.rhm
+++ b/rhombus/tests/class.rhm
@@ -743,13 +743,26 @@ check:
       '77'
   ~throws "dot: unbound"
 
-check:
+block:
   import rhombus/meta open
   class Posn(x, y):
     dot '$left . sevens':
       '77'
-  Posn(1, 2).sevens
-  ~is 77
+  check Posn(1, 2).sevens ~is 77
+  def [p :: Posn, ...] = [Posn(1, 2), Posn(3, 4)]
+  check [p.sevens, ...] ~is [77, 77]
+
+block:
+  import rhombus/meta open
+  class Posn(x, y):
+    dot '$left . sevens':
+      ~is_repet is_repet
+      if is_repet
+      | repet_meta.pack_list('(???, [77, 77, 77], 1, 0, ())')
+      | '77'
+  check Posn(1, 2).sevens ~is 77
+  def [p :: Posn, ...] = [Posn(1, 2), Posn(3, 4)]
+  check [p.sevens, ...] ~is [77, 77, 77]
 
 block:
   import rhombus/meta open

--- a/rhombus/tests/dot-macro.rhm
+++ b/rhombus/tests/dot-macro.rhm
@@ -22,6 +22,10 @@ check:
 check:
   vec.magnitude
   ~is 5
+check:
+  let [vec :: Vector, ...] = [Posn(3, 4), Posn(5, 6)]
+  [vec.angle, ...]
+  ~is [math.atan(4, 3), math.atan(6, 5)]
 
 expr.macro 'or_zero ($p)':
   statinfo_meta.wrap('($p) || Posn(0,0)',
@@ -93,6 +97,13 @@ check:
   (-2 my_plus 2).is_zero
   ~is #true
 
+check:
+  let [x :: MyInt, ...] = [1, 2, 3]
+  [x.add(10), ...]
+  ~is [11, 12, 13]
+
+// check is_static option
+  
 block:
   annot.macro 'MyStr':
     annot_meta.pack_predicate('fun (x): x is_a String',
@@ -121,3 +132,48 @@ check:
     | 'static': '#%literal $is_static'
   values(check_options.op, check_options.static)
   ~matches values('.', #true)
+
+// checking repetition handling
+
+dot.macro 'myint2_dot_provider $left $dot $right':
+  ~is_repet: is_repet
+  ~all_stx: self_stx
+  ~tail: '$tail ...'
+  if is_repet
+  | // assumes a depth-1 `left`
+    let '($_, $expr, $depth, $use_depth, $_)' = repet_meta.unpack_list(left)
+    fun make(list_expr):
+      repet_meta.pack_list('($self_stx,
+                             $list_expr,
+                             $depth,
+                             $use_depth,
+                             ())')
+    match '$right $tail ...'
+    | 'is_zero $tail ...': values(make('for List (v: ($expr :~ List)): v .= 0'),
+                                  '$tail ...')
+    | 'add($(right :: repet_meta.Parsed)) $tail ...':
+        // assumes a depth-1 `right`, too
+        let '($_, $r_expr, $r_depth, $r_use_depth, $_)' = repet_meta.unpack_list(right)
+        values(make('for List (v: ($expr :~ List),
+                               r_v: ($r_expr :~ List)):
+                       v + r_v'),
+               '$tail ...')
+  | values(match right
+           | 'is_zero': '$left .= 0'
+           | 'add': 'fun (v :~ MyInt) :~ MyInt: $left + v',
+           '$tail ...')
+
+annot.macro 'MyInt2':
+  annot_meta.pack_predicate('fun (x): x is_a Int',
+                            '(($(statinfo_meta.dot_provider_key), myint2_dot_provider))')
+
+def (four :~ MyInt2) = 4
+def [more :~ MyInt2, ...] = [5, 6, 7]
+
+check:
+  four.add(5)
+  ~is 9
+
+check:
+  [more.add(more), ...]
+  ~is [10, 12, 14]


### PR DESCRIPTION
When a dot form needs extra arguments, then it's not enough to handle the left-hand side as a repetition automatically if the arguments can also be repetitions. Keep automatic handling for the simple case, and allow a dot provider to be called in repetition mode to handle repetition arguments. A dot handler opts into repetition support by including the `~is_repet: var` option.

Closes #389