### PR TITLE
use generic `is_less` argument in `{,Mutable,Pair}List.sort` methods

### DIFF
--- a/rhombus/private/amalgam/comparable.rkt
+++ b/rhombus/private/amalgam/comparable.rkt
@@ -10,11 +10,9 @@
          "repetition.rkt"
          (submod "annotation.rkt" for-class)
          "parse.rkt"
-         (only-in "arithmetic.rkt" .< .<= .= .>= .>)
          (submod "arithmetic.rkt" precedence)
          "compare-key.rkt"
          "static-info.rkt"
-         "repetition.rkt"
          "compound-repetition.rkt"
          "realm.rkt"
          (only-in "class-desc.rkt" define-class-desc-syntax)
@@ -33,6 +31,14 @@
                       [rhombus> >])
                      compares_equal
                      compares_unequal))
+
+(module+ for-builtin
+  (provide general<
+           general<=
+           general=
+           general!=
+           general>=
+           general>))
 
 (define-values (prop:Comparable Comparable? Comparable-ref)
   (make-struct-type-property 'Comparable))
@@ -295,10 +301,7 @@
                          "other value"))
   (raise-arguments-error*
    op rhombus-realm
-   (string-append "cannot compare "
-                  (case (string-ref what 0)
-                    [(#\a #\i) "an "]
-                    [else "a "])
+   (string-append "cannot compare a "
                   what " and " other-what
                   (if both-compare?
                       (string-append ";\n two "

--- a/rhombus/private/amalgam/list.rkt
+++ b/rhombus/private/amalgam/list.rkt
@@ -32,7 +32,8 @@
          "class-primitive.rkt"
          "rhombus-primitive.rkt"
          "rest-bind.rkt"
-         "number.rkt")
+         "number.rkt"
+         (submod "comparable.rkt" for-builtin))
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -824,18 +825,18 @@
   #:primitive (mutable-treelist-for-each)
   (mutable-treelist-for-each lst proc))
 
-(define/method (List.sort lst [less-than? <])
+(define/method (List.sort lst [less-than? general<])
   #:primitive (treelist-sort)
   #:static-infos ((#%call-result #,(get-treelist-static-infos)))
   (treelist-sort lst less-than?))
 
-(define/method (PairList.sort lst [less-than? <])
+(define/method (PairList.sort lst [less-than? general<])
   #:static-infos ((#%call-result #,(get-list-static-infos)))
   (check-list who lst)
   (check-function-of-arity 2 who less-than?)
   (sort lst less-than?))
 
-(define/method (MutableList.sort lst [less-than? <])
+(define/method (MutableList.sort lst [less-than? general<])
   #:primitive (mutable-treelist-sort!)
   (mutable-treelist-sort! lst less-than?))
 

--- a/rhombus/scribblings/ref-list.scrbl
+++ b/rhombus/scribblings/ref-list.scrbl
@@ -561,7 +561,7 @@ it supplies its elements in order.
 
 @doc(
   fun List.sort(lst :: List,
-                is_less :: Function.of_arity(2) = (_ .< _))
+                is_less :: Function.of_arity(2) = (_ < _))
     :: List,
 ){
 
@@ -570,7 +570,7 @@ it supplies its elements in order.
 
 @examples(
   List.sort([1, 3, 2])
-  List.sort([1, 3, 2], (_ .> _))
+  List.sort([1, 3, 2], (_ > _))
 )
 
 }

--- a/rhombus/scribblings/ref-mutable-list.scrbl
+++ b/rhombus/scribblings/ref-mutable-list.scrbl
@@ -467,7 +467,7 @@ and it is not managed by a lock.
 
 @doc(
   fun MutableList.sort(mlst :: MutableList,
-                       is_less :: Function.of_arity(2) = (_ .< _))
+                       is_less :: Function.of_arity(2) = (_ < _))
     :: Void,
 ){
 
@@ -479,7 +479,7 @@ and it is not managed by a lock.
   def mlst = MutableList[1, 3, 2]
   MutableList.sort(mlst)
   mlst
-  MutableList.sort(mlst, (_ .> _))
+  MutableList.sort(mlst, (_ > _))
   mlst
 )
 

--- a/rhombus/scribblings/ref-pair.scrbl
+++ b/rhombus/scribblings/ref-pair.scrbl
@@ -541,7 +541,7 @@ list is a pair, a pair is a pair list only if its ``rest'' is a list.
 
 @doc(
   fun PairList.sort(lst :: PairList,
-                    is_less :: Function.of_arity(2) = (_ .< _))
+                    is_less :: Function.of_arity(2) = (_ < _))
     :: PairList,
 ){
 
@@ -550,7 +550,7 @@ list is a pair, a pair is a pair list only if its ``rest'' is a list.
 
 @examples(
   PairList.sort(PairList[1, 3, 2])
-  PairList.sort(PairList[1, 3, 2], (_ .> _))
+  PairList.sort(PairList[1, 3, 2], (_ > _))
 )
 
 }

--- a/rhombus/tests/list.rhm
+++ b/rhombus/tests/list.rhm
@@ -277,6 +277,16 @@ check:
   List.sublist([1, 2, 3, 4, 5, 6], 2, 5) ~is [3, 4, 5]
 
 check:
+  [1, 2, 3].sort() ~is [1, 2, 3]
+  List.sort([1, 2, 3]) ~is [1, 2, 3]
+  [1, 2, 3].sort(fun (x, y): x > y) ~is [3, 2, 1]
+  List.sort([1, 2, 3], fun (x, y): x > y) ~is [3, 2, 1]
+  ["", "a", "ab"].sort() ~is ["", "a", "ab"]
+  List.sort(["", "a", "ab"]) ~is ["", "a", "ab"]
+  ["", "a", "ab"].sort(fun (x, y): x > y) ~is ["ab", "a", ""]
+  List.sort(["", "a", "ab"], fun (x, y): x > y) ~is ["ab", "a", ""]
+
+check:
   use_static
   List.rest([1, 2, 3]).map(math.abs)
   ~is [2, 3]

--- a/rhombus/tests/mutable-list.rhm
+++ b/rhombus/tests/mutable-list.rhm
@@ -110,7 +110,7 @@ check:
   MutableList[1, 2, 3] is_a MutableIndexable ~is #true
   MutableList[1, 2, 3] is_a Appendable ~is #false
   MutableList[1, 2, 3] is_a Listable ~is #true
-  
+
 block:
   check:
     1 :: MutableList
@@ -178,22 +178,22 @@ check:
   MutableList[1, 2, 3].find(fun (x): x > 10) ~is #false
   dynamic(MutableList[1, 2, 3]).find(fun (x): x > 1) ~is 2
 
-check: 
+check:
   (block: let l = MutableList[1, 2, 3]; l.remove(2); l) ~is_now MutableList[1, 3]
   (block: let l = MutableList[1, 2, 3]; l.remove(4); l) ~is_now MutableList[1, 2, 3]
   (block: let l = MutableList[1, 2, 2, 3]; l.remove(4); l) ~is_now MutableList[1, 2, 2, 3]
   (block: let l = dynamic(MutableList[1, 2, 3]); l.remove(1); l) ~is_now MutableList[2, 3]
 
 check:
-  [1, 2, 3].insert(2, "x") ~is [1, 2, "x", 3]
-  [1, 2, 3].insert(3, "x") ~is [1, 2, 3, "x"]
-  [1, 2, 3].insert(0, "x") ~is ["x", 1, 2, 3]
-  dynamic([1, 2, 3]).insert(1, "x") ~is [1, "x", 2, 3]
+  (block: let l = MutableList[1, 2, 3]; l.insert(2, "x"); l) ~is_now MutableList[1, 2, "x", 3]
+  (block: let l = MutableList[1, 2, 3]; l.insert(3, "x"); l) ~is_now MutableList[1, 2, 3, "x"]
+  (block: let l = MutableList[1, 2, 3]; l.insert(0, "x"); l) ~is_now MutableList["x", 1, 2, 3]
+  (block: let l = MutableList[1, 2, 3]; dynamic(l).insert(1, "x"); l) ~is_now MutableList[1, "x", 2, 3]
 
 check:
-  [1, 2, 3].delete(2) ~is [1, 2]
-  [1, 2, 3].delete(0) ~is [2, 3]
-  dynamic([1, 2, 3]).delete(1) ~is [1, 3]
+  (block: let l = MutableList[1, 2, 3]; l.delete(2); l) ~is_now MutableList[1, 2]
+  (block: let l = MutableList[1, 2, 3]; l.delete(0); l) ~is_now MutableList[2, 3]
+  (block: let l = MutableList[1, 2, 3]; dynamic(l).delete(1); l) ~is_now MutableList[1, 3]
 
 check:
   (block: let l = MutableList[1, 2, 3]; l.drop(2); l) ~is_now MutableList[3]
@@ -201,6 +201,12 @@ check:
   (block: let l = MutableList[1, 2, 3]; l.take(2); l) ~is_now MutableList[1, 2]
   (block: let l = MutableList[1, 2, 3]; l.take_last(2); l) ~is_now MutableList[2, 3]
   (block: let l = MutableList[1, 2, 3, 4, 5, 6]; l.sublist(2, 5); l) ~is_now MutableList[3, 4, 5]
+
+check:
+  (block: let l = MutableList[1, 2, 3]; l.sort(); l) ~is_now MutableList[1, 2, 3]
+  (block: let l = MutableList[1, 2, 3]; l.sort(fun (x, y): x > y); l) ~is_now MutableList[3, 2, 1]
+  (block: let l = MutableList["", "a", "ab"]; l.sort(); l) ~is_now MutableList["", "a", "ab"]
+  (block: let l = MutableList["", "a", "ab"]; l.sort(fun (x, y): x > y); l) ~is_now MutableList["ab", "a", ""]
 
 check:
   use_static

--- a/rhombus/tests/pairlist.rhm
+++ b/rhombus/tests/pairlist.rhm
@@ -257,6 +257,16 @@ check:
   )
 
 check:
+  PairList[1, 2, 3].sort() ~is PairList[1, 2, 3]
+  PairList.sort(PairList[1, 2, 3]) ~is PairList[1, 2, 3]
+  PairList[1, 2, 3].sort(fun (x, y): x > y) ~is PairList[3, 2, 1]
+  PairList.sort(PairList[1, 2, 3], fun (x, y): x > y) ~is PairList[3, 2, 1]
+  PairList["", "a", "ab"].sort() ~is PairList["", "a", "ab"]
+  PairList.sort(PairList["", "a", "ab"]) ~is PairList["", "a", "ab"]
+  PairList["", "a", "ab"].sort(fun (x, y): x > y) ~is PairList["ab", "a", ""]
+  PairList.sort(PairList["", "a", "ab"], fun (x, y): x > y) ~is PairList["ab", "a", ""]
+
+check:
   use_static
   PairList.rest(PairList[1, 2, 3]).map(math.abs)
   ~is PairList[2, 3]


### PR DESCRIPTION
Change the default `is_less` argument to the generic `Comparable` version.  This makes a plain `.sort` slower, but probably a performance-aware `.sort` should use a specialized `is_less` anyway.