### PR TITLE
remove compatibility aliases

### DIFF
--- a/rhombus/private/amalgam/array.rkt
+++ b/rhombus/private/amalgam/array.rkt
@@ -54,7 +54,6 @@
   #:fields ()
   #:namespace-fields
   ([make Array.make]
-   [of now_of] ;; TEMPORARY
    now_of
    later_of
    of_length)

--- a/rhombus/private/amalgam/map.rkt
+++ b/rhombus/private/amalgam/map.rkt
@@ -63,9 +63,7 @@
          (for-spaces (rhombus/namespace
                       rhombus/bind
                       rhombus/annot)
-                     ReadableMap
-                     ;; temporary:
-                     (rename-out [ReadableMap MapView])))
+                     ReadableMap))
 
 (module+ for-binding
   (provide (for-syntax parse-map-binding)))
@@ -177,7 +175,6 @@
    [values Map.values]
    [keys Map.keys]
    [get Map.get]
-   [ref Map.get] ; temporary
    [has_key Map.has_key]
    [copy Map.copy]
    [snapshot Map.snapshot]

--- a/rhombus/private/amalgam/set.rkt
+++ b/rhombus/private/amalgam/set.rkt
@@ -56,9 +56,7 @@
          (for-spaces (rhombus/namespace
                       rhombus/bind
                       rhombus/annot)
-                     ReadableSet
-                     ;; temporary:
-                     (rename-out [ReadableSet SetView])))
+                     ReadableSet))
 
 (module+ for-binding
   (provide (for-syntax parse-set-binding)))

--- a/rhombus/private/amalgam/static-info-macro.rkt
+++ b/rhombus/private/amalgam/static-info-macro.rkt
@@ -75,8 +75,6 @@
      index_result_key
      index_get_key
      index_set_key
-     [map_ref_key index_get_key] ; temporary
-     [map_set_key index_set_key] ; temporary
      append_key
      dot_provider_key
      sequence_constructor_key

--- a/rhombus/private/amalgam/string.rkt
+++ b/rhombus/private/amalgam/string.rkt
@@ -41,9 +41,7 @@
          (for-space rhombus/annot
                     ReadableString
                     StringCI
-                    ReadableStringCI
-                    ;; temporary:
-                    (rename-out [ReadableString StringView])))
+                    ReadableStringCI))
 
 (module+ for-builtin
   (provide string-method-table))

--- a/rhombus/private/amalgam/syntax-meta.rkt
+++ b/rhombus/private/amalgam/syntax-meta.rkt
@@ -27,9 +27,7 @@
   (provide (for-space rhombus/namespace
                       syntax_meta)
            (for-space rhombus/annot
-                      SyntaxPhase)
-           ;; temporary backward compatibility:
-           (rename-out [syntax_meta.error Syntax.error]))
+                      SyntaxPhase))
 
   (define-name-root syntax_meta
     #:fields


### PR DESCRIPTION
Remove bindings like `MapView` and `Array.of` that have been replaced with newer names like `ReadableMap` and `Array.now_of`.