### PR TITLE
add `protected`

### DIFF
--- a/rhombus/pict/private/static.rhm
+++ b/rhombus/pict/private/static.rhm
@@ -128,7 +128,7 @@ class Pict():
   abstract method ghost(do_ghost = #true) :~ Pict
   abstract method refocus(to_p :: Pict) :~ Pict
 
-  abstract method
+  abstract protected method
   | _pad(amt :: Real) :~ Pict
   | _pad(h_amt :: Real, v_amt :: Real) :~ Pict
   | _pad(left_amt :: Real, top_amt :: Real,
@@ -169,7 +169,7 @@ class Pict():
 
   abstract method freeze(~scale: scale :: Real = 2.0) :~ Pict
 
-  abstract method _time_pad(before :: Int, after :: Int) :~ Pict
+  abstract protected method _time_pad(before :: Int, after :: Int) :~ Pict
   abstract method time_clip(~keep: keep :: maybe(TimeOrder) = #false) :~ Pict
   method delay(n :: NonnegInt) :~ Pict: time_clip(~keep: #'after).time_pad(~before: 1)
   abstract method sustain(n :: Int = 1) :~ Pict
@@ -1216,7 +1216,8 @@ fun table(rows :: List.of(List.of(Pict)),
                         if hsep is_a List | PairList[& hsep] | hsep,
                         if vsep is_a List | PairList[& vsep] | vsep)
       if !hline && !vline && !line_c
-      | static_pict(r, [elem, ..., ...], [elem._instances, ..., ...])._pad(& if ins is_a List | ins | [ins])
+      | let p :~ _Pict = static_pict(r, [elem, ..., ...], [elem._instances, ..., ...])
+        p._pad(& if ins is_a List | ins | [ins])
       | let picts = [& picts]
         let col_length = rows.length()
         let ws:

--- a/rhombus/private/amalgam/class-constructor.rkt
+++ b/rhombus/private/amalgam/class-constructor.rkt
@@ -25,7 +25,7 @@
 ;; Note: `constructor.macro` is handed in "class-dot.rkt"
 
 (define-for-syntax (build-class-constructor super constructor-rhs constructor-stx-params
-                                            added-fields constructor-private?s
+                                            added-fields constructor-exposures
                                             constructor-fields super-constructor-fields super-constructor+-fields
                                             keywords super-keywords super-constructor+-keywords
                                             defaults super-defaults super-constructor+-defaults
@@ -223,7 +223,7 @@
                                                       super-constructor-fields constructor-fields
                                                       super-keywords keywords
                                                       super-defaults defaults
-                                                      constructor-private?s
+                                                      constructor-exposures
                                                       #'make-name)
                             constructor-rhs)
                       #,constructor-stx-params))])
@@ -466,21 +466,21 @@
                                              super-constructor-fields constructor-fields
                                              super-keywords constructor-keywords
                                              super-defaults constructor-defaults
-                                             constructor-private?s
+                                             constructor-exposures
                                              make-name)
   (define proto (encode-protocol constructor-keywords constructor-defaults
                                  constructor-keywords constructor-defaults))
   (define all-formal-args (generate-protocol-formal-arguments proto))
   (define (filter-map-arg proc)
-    (let loop ([args all-formal-args] [private?s constructor-private?s])
+    (let loop ([args all-formal-args] [exposures constructor-exposures])
       (cond
         [(null? args) '()]
-        [(keyword? (syntax-e (car args))) (cons (car args) (loop (cdr args) private?s))]
+        [(keyword? (syntax-e (car args))) (cons (car args) (loop (cdr args) exposures))]
         [else
-         (define a (proc (car args) (car private?s)))
+         (define a (proc (car args) (not (eq? (car exposures) 'public))))
          (if a
-             (cons a (loop (cdr args) (cdr private?s)))
-             (loop (cdr args) (cdr private?s)))])))
+             (cons a (loop (cdr args) (cdr exposures)))
+             (loop (cdr args) (cdr exposures)))])))
   (define formal-args (filter-map-arg (lambda (arg private?)
                                         (and (not private?) arg))))
   (define all-args (filter-map-arg (lambda (arg private?)

--- a/rhombus/private/amalgam/class-meta.rkt
+++ b/rhombus/private/amalgam/class-meta.rkt
@@ -135,7 +135,7 @@
                         constructor-keywords
                         constructor-defaults
                         constructor-mutables
-                        constructor-privates)
+                        constructor-exposes)
           (class-expand-data-internal-info-fields info))
         (case key
           [(field_names)
@@ -151,18 +151,18 @@
                    (map syntax-e
                         (class-clause-extract who (class-expand-data-accum-stx info) 'field-mutabilities)))]
           [(field_visibilities)
-           (append (for/list ([private? (in-list (syntax->list constructor-privates))])
-                     (if (syntax-e private?) 'private 'public))
+           (append (for/list ([expose (in-list (syntax->list constructor-exposes))])
+                     (syntax-e expose))
                    (map syntax-e
                         (class-clause-extract who (class-expand-data-accum-stx info) 'field-visibilities)))]
           [(field_constructives)
-           (append (for/list ([private? (in-list (syntax->list constructor-privates))]
+           (append (for/list ([expose (in-list (syntax->list constructor-exposes))]
                               [default (in-list (syntax->list constructor-defaults))])
-                     (if (syntax-e private?)
-                         'absent
+                     (if (eq? (syntax-e expose) 'public)
                          (if (syntax-e default)
                              'optional
-                             'required)))
+                             'required)
+                         'absent))
                    (map (lambda (x) 'absent)
                         (class-clause-extract who (class-expand-data-accum-stx info) 'field-names)))]
           [else (error "internal error: key")])]

--- a/rhombus/private/amalgam/class-primitive.rkt
+++ b/rhombus/private/amalgam/class-primitive.rkt
@@ -261,6 +261,7 @@
                                     #f ; not final
                                     (quote-syntax Name)
                                     #,(and (syntax-e #'Parent) #'(quote-syntax Parent))
+                                    #f
                                     (quote-syntax struct:name)
                                     (get-name-instances)
                                     #f ; `ref-id` would only used by the normal class dot provider

--- a/rhombus/private/amalgam/class-static-info.rkt
+++ b/rhombus/private/amalgam/class-static-info.rkt
@@ -17,7 +17,9 @@
                      build-class-static-infos))
 
 
-(define-for-syntax (extract-instance-static-infoss name-id options super interfaces private-interfaces intro)
+(define-for-syntax (extract-instance-static-infoss name-id options super interfaces
+                                                   private-interfaces protected-interfaces
+                                                   intro)
   (define call-statinfo-indirect-id
     (able-statinfo-indirect-id 'call super interfaces name-id intro))
   (define index-statinfo-indirect-id
@@ -48,7 +50,9 @@
            append
            (for/list ([intf (in-list interfaces)]
                       #:unless (and (not internal?)
-                                    (hash-ref private-interfaces intf #f)))
+                                    (or
+                                     (hash-ref private-interfaces intf #f)
+                                     (hash-ref protected-interfaces intf #f))))
              (syntax->list
               (objects-desc-static-infos intf))))))
 

--- a/rhombus/private/amalgam/interface.rkt
+++ b/rhombus/private/amalgam/interface.rkt
@@ -121,7 +121,9 @@
 
                        indirect-static-infos
                        internal-indirect-static-infos)
-         (extract-instance-static-infoss #'name options #f supers #hasheq() intro))
+         (extract-instance-static-infoss #'name options #f supers
+                                         #hasheq() #hasheq()
+                                         intro))
 
        (with-syntax ([name? (temporary "~a?")]
                      [name-instance (temporary "~a-instance")]
@@ -188,7 +190,9 @@
                        method-private-inherit ; symbol -> (vector ref-id index maybe-result-id)
                        method-decls    ; symbol -> identifier, intended for checking distinct
                        abstract-name)  ; #f or identifier
-         (extract-method-tables stxes added-methods #f supers #hasheq() #f #f))
+         (extract-method-tables stxes added-methods #f supers
+                                #hasheq() #hasheq()
+                                #f #f))
 
        (define dots (hash-ref options 'dots '()))
        (define dot-provider-rhss (map cdr dots))
@@ -254,9 +258,11 @@
                (build-methods method-results
                               added-methods method-mindex method-names method-private method-private-inherit
                               #f #f #f
+                              #hasheq() #hasheq()
                               #'(name name-instance internal-name? #f #f
                                       internal-name-ref
                                       ()
+                                      []
                                       []
                                       []
                                       []
@@ -279,7 +285,8 @@
                                                      [export ...]
                                                      base-stx scope-stx))
                (build-interface-desc supers parent-names options
-                                     method-mindex method-names method-vtable method-results method-private dots
+                                     method-mindex method-names method-vtable method-results method-private
+                                     dots
                                      internal-name
                                      callable? indexable? setable? appendable? comparable?
                                      primitive-properties
@@ -352,7 +359,8 @@
                                        . indirect-static-infos)))))))))
 
 (define-for-syntax (build-interface-desc supers parent-names options
-                                         method-mindex method-names method-vtable method-results method-private dots
+                                         method-mindex method-names method-vtable method-results method-private
+                                         dots
                                          internal-name
                                          callable? indexable? setable? appendable? comparable?
                                          primitive-properties

--- a/rhombus/scribblings/private-implement.scrbl
+++ b/rhombus/scribblings/private-implement.scrbl
@@ -6,18 +6,22 @@
 
 @title(~tag: "private-implement"){Private Implementation}
 
-An @rhombus(internal, ~class_clause) name for a class can provide access
-to all internal methods of the class. For more selective control over
-sets of private methods, an interface can be privately implemented.
-Private implementation of a method also supports implementing a publicly
-known interface but without exposing the implementation of of the method
-to untrusted callers.
+Although @rhombus(private, ~class_clause) and
+@rhombus(protected, ~class_clause) are normally used on methods and
+fields, an @rhombus(implements, ~class_clause) clause also can be
+modified by @rhombus(private, ~class_clause) or
+@rhombus(protected, ~class_clause). A private or protected
+implementation of an interface avoids exposing the implementation of the
+interface's method to untrusted callers. The implementation of the
+interface is still accessible via the interface's
+@rhombus(internal, ~class_clause) name, which might be made available
+only to trusted contexts.
 
 For example, suppose that we'd like to customize printing by
-implementing the @rhombus(Printable) interface, but we don't want a public
+implementing the @rhombus(Printable, ~class) interface, but we don't want a public
 @rhombus(print) method. Printing and string conversion access
-customization methods using an internal name for @rhombus(Printable), so
-privately implementing @rhombus(Printable) will achieve the goal.
+customization methods using an internal name for @rhombus(Printable, ~class), so
+privately implementing @rhombus(Printable, ~class) will achieve the goal.
 
 To privately implement an interface, use
 @rhombus(private, ~class_clause) @rhombus(implements, ~class_clause),
@@ -36,5 +40,9 @@ and override the interfaces methods with
       Posn(1, 2).describe(#'expr, Function.pass)
 )
 
+A @rhombus(protected, ~class_clause) implementation of an interface is
+similar to a @rhombus(private, ~class_clause) one, but the implemented
+methods are visible in subclasses, and the methods can be overridden in
+subclasses.
 
 @(close_eval(method_eval))

--- a/rhombus/scribblings/private-method.scrbl
+++ b/rhombus/scribblings/private-method.scrbl
@@ -102,5 +102,9 @@ class's implementation, or via an @rhombus(internal, ~class_clause) name
 that is selectively exported, they can be used to limit access to
 some methods.
 
+Fields and methods can be @rhombus(protected, ~class_clause), which is
+like @rhombus(private, ~class_clause), except that
+@rhombus(protected, ~class_clause) fields and methods are accessible in
+subclasses, and they can be overridden when not @rhombus(final, ~class_clause).
 
 @(close_eval(method_eval))

--- a/rhombus/scribblings/ref-class.scrbl
+++ b/rhombus/scribblings/ref-class.scrbl
@@ -30,6 +30,8 @@
     #,(@rhombus(private, ~class_clause))
     #,(@rhombus(mutable, ~bind))
     #,(@rhombus(private, ~class_clause)) #,(@rhombus(mutable, ~bind))
+    #,(@rhombus(protected, ~class_clause))
+    #,(@rhombus(protected, ~class_clause)) #,(@rhombus(mutable, ~bind))
     #,(epsilon)
 
   grammar maybe_annot:
@@ -53,15 +55,19 @@
     #,(@rhombus(immutable, ~class_clause)) #,(@rhombus(field, ~class_clause)) $field_impl
     #,(@rhombus(private, ~class_clause)) #,(@rhombus(field, ~class_clause)) $field_impl
     #,(@rhombus(private, ~class_clause)) #,(@rhombus(immutable, ~class_clause)) #,(@rhombus(field, ~class_clause)) $field_impl
+    #,(@rhombus(protected, ~class_clause)) #,(@rhombus(field, ~class_clause)) $field_impl
+    #,(@rhombus(protected, ~class_clause)) #,(@rhombus(immutable, ~class_clause)) #,(@rhombus(field, ~class_clause)) $field_impl
     #,(@rhombus(method, ~class_clause)) $method_impl
     #,(@rhombus(override, ~class_clause)) $method_impl
     #,(@rhombus(final, ~class_clause)) $method_impl
     #,(@rhombus(private, ~class_clause)) $method_impl
+    #,(@rhombus(protected, ~class_clause)) $method_impl
     #,(@rhombus(abstract, ~class_clause)) $method_decl
     #,(@rhombus(property, ~class_clause)) $property_impl
     #,(@rhombus(extends, ~class_clause)) $id_name
     #,(@rhombus(implements, ~class_clause)) $implements_decl
     #,(@rhombus(private, ~class_clause)) #,(@rhombus(implements, ~class_clause)) $implements_decl
+    #,(@rhombus(protected, ~class_clause)) #,(@rhombus(implements, ~class_clause)) $implements_decl
     #,(@rhombus(final, ~class_clause))
     #,(@rhombus(nonfinal, ~class_clause))
     #,(@rhombus(internal, ~class_clause)) $id
@@ -86,7 +92,7 @@
  @item{in the @top_rhombus(expr, ~space) space,
   a constructor function or form, which by default is a function that
   takes as many arguments
-  as the supplied non-@rhombus(private, ~class_clause) @rhombus(field_spec)s
+  as the supplied non-@rhombus(private, ~class_clause)/@rhombus(protected, ~class_clause) @rhombus(field_spec)s
   in parentheses, and it returns an instance of the class;},
 
  @item{in the @top_rhombus(annot, ~space) space,
@@ -94,13 +100,13 @@
   and by default an annotation constructor @rhombus(id_name.of) or
   @rhombus(id_name.now_of), which
   default takes as many annotation arguments as supplied
-  non-@rhombus(private, ~class_clause) @rhombus(field_spec)s in
+  non-@rhombus(private, ~class_clause)/@rhombus(protected, ~class_clause) @rhombus(field_spec)s in
   parentheses; the name is @rhombus(id_name.of) if all such
   @rhombus(field_spec)s are for immutable fields;},
 
  @item{in the @rhombus(bind, ~space) space,
   a binding-pattern constructor, which by default takes as many
-  patterns as the supplied non-@rhombus(private, ~class_clause)
+  patterns as the supplied non-@rhombus(private, ~class_clause)/@rhombus(protected, ~class_clause)
   @rhombus(field_spec)s in parentheses and matches an instance of the
   class where the fields match the corresponding patterns;},
 
@@ -114,7 +120,7 @@
   @rhombus(id_name#,(rhombus(.))#,(@rhombus(dot,~var))),
   and a field accessor
   @rhombus(id_name#,(rhombus(.))#,(@rhombus(field,~var))) for each
-  non-@rhombus(private, ~class_clause) method, property, dot syntax, and field in the class
+  non-@rhombus(private, ~class_clause)/@rhombus(protected, ~class_clause) method, property, dot syntax, and field in the class
   (including inherited methods, properties, dot syntax, and fields), respectively; and}
 
  @item{in the @rhombus(class, ~space) space, a representation of the
@@ -125,9 +131,11 @@
  Fields, methods, properties, and dot syntax declared in a class can be accessed
  from an object (as opposed to just a class) using @rhombus(.), but fields,
  methods, and properties
- declared as @rhombus(private, ~class_clause) can only be accessed by
+ declared as @rhombus(private, ~class_clause) or @rhombus(protected, ~class_clause) can only be accessed by
  @rhombus(.) within methods and properties of the class or through an identifier bound
- by an @rhombus(internal, ~class_clause) form. In static mode (see
+ by an @rhombus(internal, ~class_clause) form. Fields, methods, and properties
+ declared as @rhombus(protected, ~class_clause) can be accessed in subclass methods,
+ in addition. In static mode (see
  @rhombus(use_static)), a non-@rhombus(property, ~class_clause) method
  must be called like a function; in dynamic mode, a
  method accessed from an object
@@ -143,7 +151,8 @@
  instead of a by-position form for the corresponding fields. The name of
  the field for access with @rhombus(.) is the identifier, if present,
  otherwise the name is the symbolic form of the keyword. When a
- @rhombus(field_spec) has the @rhombus(private, ~class_clause) modifier,
+ @rhombus(field_spec) has the @rhombus(private, ~class_clause)
+ or @rhombus(protected, ~class_clause) modifier,
  however, then it is not included as an argument for the default
  constructor, binding form, or annotation form.
 
@@ -152,7 +161,7 @@
  @rhombus(default_expr) or @rhombus(default_body)s to obtain a value for the argument when it is not
  supplied. If a by-position field has a default-value expression or block, then
  all later by-position fields must have a default. If the class extends a
- superclass that has a non- @rhombus(private, ~class_clause) by-position
+ superclass that has a non-@rhombus(private, ~class_clause)/@rhombus(protected, ~class_clause) by-position
  argument with a default, then all by-position arguments of the subclass
  must have a default. A @rhombus(default_expr) or @rhombus(default_body) can refer to earlier field
  names in the same @rhombus(class) to produce a default value. If a
@@ -192,13 +201,13 @@
  @tech{assignment operators} such as @rhombus(:=). The
  @rhombus(field, ~class_clause) or @rhombus(immutable, ~class_clause) form can appear any number of times as a
  @rhombus(class_clause), with or without a
- @rhombus(private, ~class_clause) prefix.
+ @rhombus(private, ~class_clause) or @rhombus(protected, ~class_clause) prefix.
 
  When a @rhombus(class_clause) is a @rhombus(method, ~class_clause)
  form, @rhombus(override, ~class_clause) form,
- @rhombus(abstract, ~class_clause) form, method-shaped
- @rhombus(final, ~class_clause) or @rhombus(private, ~class_clause) form,
- or @rhombus(property, ~class_clause) form,
+ @rhombus(abstract, ~class_clause) form, @rhombus(property, ~class_clause) form,m
+ or method- or property-shaped
+ @rhombus(final, ~class_clause), @rhombus(private, ~class_clause), or @rhombus(protected, ~class_clause) form,
  then the clause declares a method or property for the class. These clauses can
  appear any number of times as a @rhombus(class_clause) to add or
  override any number of methods or properties. See @rhombus(method, ~class_clause)
@@ -215,11 +224,11 @@
  implementations (that can be overridden) and have abstract methods and properties,
  but an interface does not have fields; see @rhombus(interface) for more
  information. Prefixing @rhombus(implements, ~class_clause) with
- @rhombus(private, ~class_clause) makes the interface privately
- implemented; see @rhombus(interface) for information on privately
- implementing an interface. A @rhombus(class_clause) can have any number
+ @rhombus(private, ~class_clause) or @rhombus(protected, ~class_clause) makes the interface privately or protectedly
+ implemented, and the interface's methods are private or protected; see @rhombus(interface) for information on privately
+ or protectedly implementing an interface. A @rhombus(class_clause) can have any number
  of @rhombus(implements, ~class_clause) clauses (with or without
- @rhombus(private, ~class_clause)). Any rule that applies to the
+ @rhombus(private, ~class_clause) and @rhombus(protected, ~class_clause)). Any rule that applies to the
  superinterface of an interface also applies to the implemented
  interfaces of class, as well as any superinterface of those interfaces.
 
@@ -236,7 +245,7 @@
  form, binding pattern form, and namespace. A use of the internal
  @rhombus(id) as a constructor creates an instance of the same
  class, but the constructor expects arguments for all fields declared
- with @rhombus(field_spec)s, including private fields. For more
+ with @rhombus(field_spec)s, including private and protected fields. For more
  information on internal names, see @rhombus(constructor, ~class_clause),
  since the details of internal names are closely related to constructor,
  annotation, and binding pattern customization. Any number of
@@ -347,6 +356,7 @@
     #,(@rhombus(override, ~interface_clause)) $method_impl
     #,(@rhombus(final, ~interface_clause)) $method_impl
     #,(@rhombus(private, ~interface_clause)) $method_impl
+    #,(@rhombus(protected, ~interface_clause)) $method_impl
     #,(@rhombus(abstract, ~interface_clause)) $method_decl
     #,(@rhombus(property, ~interface_clause)) $property_impl
     #,(@rhombus(extends, ~interface_clause)) $extends_decl
@@ -378,7 +388,7 @@
 
  Interfaces cannot be instantiated. They are implemented by classes via
  the @rhombus(implements, ~class_clause) form. When a class implements an
- interface (not privately), it has all methods and properties of the interface, and its
+ interface (not privately or protectedly), it has all methods and properties of the interface, and its
  instances satisfy the interface as an annotation.
 
  Typically, an interface declares methods and properties with
@@ -387,21 +397,27 @@
  implementations; those implementations are inherited by classes that implement the
  interface or any subinterface that extends the interface. An interface can
  also have private helper methods and properties, but they are useful only when an
- interface also has implemented public methods or properties that refer to them.
+ interface also has implemented public or protected methods or properties that refer to them.
 
  When a class implements an interface privately using
- @rhombus(#,(@rhombus(private, ~class_clause)) #,(@rhombus(implements, ~class_clause))),
+ @rhombus(#,(@rhombus(private, ~class_clause)) #,(@rhombus(implements, ~class_clause)))
+or protectedly using
+ or @rhombus(#,(@rhombus(protected, ~class_clause)) #,(@rhombus(implements, ~class_clause))),
  its instances do not satisfy the interface as an annotation. If the
- privately implemented interface has an internal name declared with
+ privately or protectedly implemented interface has an internal name declared with
  @rhombus(internal, ~interface_clause), however, instances satisfy the
- internal name as an annotation. Methods and properties of a privately implemented
+ internal name as an annotation. Methods and properties of a privately or protectedly implemented
  instance can be accessed only with static @rhombus(.) via the
- internal-name annotation. As long as a method or property belongs to only privately
- implemented interfaces, it can be overridden with
+ internal-name annotation. As long as a method or property belongs to only
+ to privately implemented interfaces, it can be overridden with
  @rhombus(#,(@rhombus(private, ~class_clause)) #,(@rhombus(override, ~class_clause))),
- otherwise it is overidden normally. If a class declares the
- implementation of a interface both normally and privately, then the
- interface is implemented normally. Abstract private methods and properties must be
+ otherwise it is overidden normally. Methods of a protectedly implemented interface
+ are treated as protected in the implementing class, even when the
+ methods are declared as non-protected in the interfaces. If a class declares
+ the implementation of a interface both normally and privately or protectedly, then the
+ interface is implemented normally; if an interface is declared as implemented both privately
+ and protectedly, then it is protectedly implemented.
+ Abstract private methods and properties must be
  implemented immediately in the class that privately implements the
  associated interface.
 
@@ -496,6 +512,9 @@
   class_clause.macro 'final #,(@rhombus(override, ~class_clause)) #,(@rhombus(method, ~class_clause)) $method_impl'
   class_clause.macro 'final #,(@rhombus(property, ~class_clause)) $property_impl'
   class_clause.macro 'final #,(@rhombus(override, ~class_clause)) #,(@rhombus(property, ~class_clause)) $property_impl'
+  class_clause.macro 'final #,(@rhombus(protected, ~class_clause)) $method_impl'
+  class_clause.macro 'final #,(@rhombus(protected, ~class_clause)) #,(@rhombus(method, ~class_clause)) $method_impl'
+  class_clause.macro 'final #,(@rhombus(protected, ~class_clause)) #,(@rhombus(property, ~class_clause)) $property_impl'
   interface_clause.macro 'final $method_impl'
   interface_clause.macro 'final #,(@rhombus(method, ~interface_clause)) $method_impl'
   interface_clause.macro 'final #,(@rhombus(override, ~interface_clause)) $method_impl'
@@ -503,6 +522,9 @@
   interface_clause.macro 'final #,(@rhombus(override, ~interface_clause)) #,(@rhombus(method, ~interface_clause)) $method_impl'
   interface_clause.macro 'final #,(@rhombus(property, ~interface_clause)) $property_impl'
   interface_clause.macro 'final #,(@rhombus(override, ~interface_clause)) #,(@rhombus(property, ~interface_clause)) $property_impl'
+  interface_clause.macro 'final #,(@rhombus(protected, ~interface_clause)) $method_impl'
+  interface_clause.macro 'final #,(@rhombus(protected, ~interface_clause)) #,(@rhombus(method, ~interface_clause)) $method_impl'
+  interface_clause.macro 'final #,(@rhombus(protected, ~interface_clause)) #,(@rhombus(property, ~interface_clause)) $method_impl'
 ){
 
  The @rhombus(final, ~class_clause) form as a @tech{class clause} or
@@ -587,8 +609,8 @@
 
  These @tech{class clauses} and @tech{interface clauses} are recognized
  by @rhombus(class) and @rhombus(interface) to declare methods and properties, along
- with the method and property forms of @rhombus(final, ~class_clause) and
- @rhombus(private, ~class_clause). The combination
+ with the method and property forms of @rhombus(final, ~class_clause),
+ @rhombus(private, ~class_clause), and @rhombus(protected, ~class_clause). The combination
  @rhombus(override, ~class_clause) followed by
  @rhombus(method, ~class_clause) is the same as just
  @rhombus(override, ~class_clause).
@@ -698,6 +720,33 @@
 
 @doc(
   ~nonterminal:
+    method_impl: method ~class_clause
+    property_impl: method ~class_clause
+    field_impl: field ~class_clause
+
+  class_clause.macro 'protected #,(@rhombus(implements, ~class_clause)) $id_name ...'
+  class_clause.macro 'protected #,(@rhombus(implements, ~class_clause)): $id_name ...; ...'
+  class_clause.macro 'protected #,(@rhombus(field, ~class_clause)) $field_impl'
+  class_clause.macro 'protected #,(@rhombus(immutable, ~class_clause)) $field_impl'
+  class_clause.macro 'protected #,(@rhombus(immutable, ~class_clause)) #,(@rhombus(field, ~class_clause)) $field_impl'
+  class_clause.macro 'protected $method_impl'
+  class_clause.macro 'protected #,(@rhombus(method, ~class_clause)) $method_impl'
+  class_clause.macro 'protected #,(@rhombus(property, ~class_clause)) $property_impl'
+  interface_clause.macro 'protected $method_impl'
+  interface_clause.macro 'protected #,(@rhombus(method, ~interface_clause)) $method_impl'
+  interface_clause.macro 'protected #,(@rhombus(property, ~interface_clause)) $property_impl'
+){
+
+ Like @rhombus(private, ~class_clause), but protected fields, methods,
+ and properties, can be referenced within subclasses, subinterfaces, and
+ subveneers, and they can be overridden when not
+ @rhombus(final, ~class_clause). An overriding declaration does not use
+ @rhombus(protected, ~class_clause) again.
+
+}
+
+@doc(
+  ~nonterminal:
     method_decl: method ~class_clause
     property_decl: method ~class_clause
 
@@ -706,11 +755,17 @@
   class_clause.macro 'abstract #,(@rhombus(override, ~class_clause)) $method_decl'
   class_clause.macro 'abstract #,(@rhombus(property, ~class_clause)) $property_decl'
   class_clause.macro 'abstract #,(@rhombus(override, ~class_clause)) #,(@rhombus(property, ~class_clause)) $property_decl'
+  class_clause.macro 'abstract #,(@rhombus(protected, ~class_clause)) $method_decl'
+  class_clause.macro 'abstract #,(@rhombus(protected, ~class_clause)) #,(@rhombus(method, ~class_clause)) $method_decl'
+  class_clause.macro 'abstract #,(@rhombus(protected, ~class_clause)) #,(@rhombus(property, ~class_clause)) $property_decl'
   interface_clause.macro 'abstract $method_decl'
   interface_clause.macro 'abstract #,(@rhombus(method, ~interface_clause)) $method_decl'
   interface_clause.macro 'abstract #,(@rhombus(override, ~interface_clause)) $method_decl'
   interface_clause.macro 'abstract #,(@rhombus(property, ~interface_clause)) $property_decl'
   interface_clause.macro 'abstract #,(@rhombus(override, ~interface_clause)) #,(@rhombus(property, ~interface_clause)) $property_decl'
+  interface_clause.macro 'abstract #,(@rhombus(protected, ~interface_clause)) $method_decl'
+  interface_clause.macro 'abstract #,(@rhombus(protected, ~interface_clause)) #,(@rhombus(method, ~interface_clause)) $method_decl'
+  interface_clause.macro 'abstract #,(@rhombus(protected, ~interface_clause)) #,(@rhombus(property, ~interface_clause)) $property_decl'
 ){
 
  A @tech{class clause} or @tech{interface clause} that declares a method
@@ -777,11 +832,11 @@
  information.
 
  When used as a @tech{namespace}, @rhombus(id) can access the
- immediate private fields, methods, and properties of the class or interface
+ immediate private and protected fields, methods, and properties of the class or interface
  containing the @rhombus(internal, ~class_clause) declaration. Along
  similar lines, @rhombus(id) as an annotation associates static
  information with an expression or binding so that @rhombus(.) can be
- used to access private fields, methods and properties, but only with @rhombus(.) as
+ used to access private and protected fields, methods and properties, but only with @rhombus(.) as
  statically resolved.
 
 }
@@ -853,7 +908,7 @@
   superclass constructor. Instead of returning an instance of the class,
   it returns a function that accepts arguments as declared by
   @rhombus(field_spec, ~var)s in the new subclass, including
-  @rhombus(private, ~class_clause) clause fields; the result of that function is
+  @rhombus(private, ~class_clause)/@rhombus(protected, ~class_clause) clause fields; the result of that function is
   an instance of the new class. Again, the result instance might be an
   instance of a subclass if the new class is not @tech{final}.}
 
@@ -896,7 +951,7 @@
  patterns; instead, use @rhombus(internal, ~class_clause) to bind an
  internal name that acts similar to the class's default binding form, but
  with two differences: it does not expect bindings for superclass fields,
- but it does expect bindings for private fields declared with a
+ but it does expect bindings for private and protected fields declared with a
  @rhombus(field_spec, ~var). When a class has a superclass, then a custom
  binding form is typically implemented using an internal binding form,
  the superclass's binding form, and the @rhombus(&&, ~bind) binding
@@ -914,7 +969,7 @@
  annotation form normally needs an internal annotation name bound with
  @rhombus(internal, ~class_clause); the @rhombus(of) form of that
  annotation expects annotations for only immediate fields of the class,
- but including private ones declared with @rhombus(field_spec, ~var)s.
+ but including private and protected ones declared with @rhombus(field_spec, ~var)s.
  Use the @rhombus(&&, ~annot) annotation operator to combine the internal
  annotation with a superclass annotation. When a superclass has a custom
  annotation form, then a class must have a custom annotation form, too.

--- a/rhombus/scribblings/ref-veneer.scrbl
+++ b/rhombus/scribblings/ref-veneer.scrbl
@@ -34,6 +34,7 @@
     #,(@rhombus(extends, ~veneer_clause)) $id_name
     #,(@rhombus(implements, ~veneer_clause)) $implements_decl
     #,(@rhombus(private, ~veneer_clause)) #,(@rhombus(implements, ~class_clause)) $implements_decl
+    #,(@rhombus(protected, ~veneer_clause)) #,(@rhombus(implements, ~class_clause)) $implements_decl
     #,(@rhombus(expression, ~veneer_clause)) $expression_decl
     #,(@rhombus(dot, ~veneer_clause)) $dot_decl
     #,(@rhombus(static_info, ~veneer_clause)) $static_info_decl
@@ -81,7 +82,7 @@
   @rhombus(id_name#,(rhombus(.))#,(@rhombus(property,~var))),
   and a syntactic form
   @rhombus(id_name#,(rhombus(.))#,(@rhombus(dot,~var))) for each
-  non-@rhombus(private, ~class_clause) method, property, and dot syntax in the veneer
+  non-@rhombus(private, ~class_clause)/@rhombus(protected, ~class_clause) method, property, and dot syntax in the veneer
   (including inherited methods, properties, and dot syntax), respectively; and}
 
  @item{in the @rhombus(class, ~space) space, a representation of the
@@ -244,6 +245,24 @@
 ){
 
  Like @rhombus(private, ~class_clause) as a class clause, but as a
+ @tech{veneer clause}. See @rhombus(veneer).
+
+}
+
+
+@doc(
+  ~nonterminal:
+    method_impl: method ~class_clause
+    property_impl: method ~class_clause
+
+  veneer_clause.macro 'protected #,(@rhombus(implements, ~class_clause)) $id_name ...'
+  veneer_clause.macro 'protected #,(@rhombus(implements, ~class_clause)): $id_name ...; ...'
+  veneer_clause.macro 'protected $method_impl'
+  veneer_clause.macro 'protected #,(@rhombus(method, ~class_clause)) $method_impl'
+  veneer_clause.macro 'protected #,(@rhombus(property, ~class_clause)) $property_impl'
+){
+
+ Like @rhombus(protected, ~class_clause) as a class clause, but as a
  @tech{veneer clause}. See @rhombus(veneer).
 
 }

--- a/rhombus/tests/class-protected.rhm
+++ b/rhombus/tests/class-protected.rhm
@@ -1,0 +1,519 @@
+#lang rhombus/static
+
+check:
+  ~eval
+  class C():
+    nonfinal
+    protected m(): 1
+  class D():
+    extends C
+    method m(): 1
+  ~throws "method is already in superclass"
+
+check:
+  ~eval
+  class C():
+    nonfinal
+    method m(): 1
+  class D():
+    extends C
+    protected m(): 1
+  ~throws "method is already in superclass"
+
+check:
+  ~eval
+  class C():
+    nonfinal
+    final protected m(): 1
+  class D():
+    extends C
+    override m(): 1
+  ~throws "cannot override superclass's final method"
+
+check:
+  class C():
+    nonfinal
+    abstract protected m()
+  class D():
+    nonfinal
+    extends C
+  D()
+  ~throws "cannot instantiate class with abstract methods"
+
+// basic
+check:
+  class V(n)
+  class C():
+    protected m() :~ V:
+      V(1)
+    protected property p :~ V:
+      V(10)
+    method m1():
+      m().n
+    method m2():
+      this.m().n
+    method m3(c :: C):
+      c.m().n
+    method o1():
+      p.n
+    method o2():
+      this.p.n
+    method o3(c :: C):
+      c.p.n
+  let c = C()
+  [c.m1(), c.m2(), c.m3(c),
+   c.o1(), c.o2(), c.o3(c),
+   try:
+     use_dynamic
+     dynamic(c).m()
+     ~catch x:
+       "ok",
+   try:
+     use_dynamic
+     dynamic(c).p
+     ~catch x:
+       "also ok"]
+  ~is [1, 1, 1,
+       10, 10, 10,
+       "ok",
+       "also ok"]
+
+// `protected` combinations
+check:
+  class V(n)
+  class C():
+    protected m():
+      1
+    protected method n():
+      2
+    final protected o():
+      3
+    final protected method k():
+      4
+    protected property p:
+      10
+    final protected property q:
+      10
+    method m1():
+      [m(), n(), o(), k(), p, q]
+  C().m1()
+  ~is [1, 2, 3, 4, 10, 10]
+
+// subclass
+check:
+  class V(n)
+  class C():
+    nonfinal
+    protected m() :~ V:
+      V(1)
+    protected property p :~ V:
+      V(10)
+    method m1():
+      [m().n, p.n]
+    method m2():
+      [this.m().n, this.p.n]
+    method m3(c :: C):
+      [c.m().n, c.p.n]
+  class D():
+    extends C
+    method n1():
+      [m().n, p.n]
+    method n2():
+      [this.m().n, this.p.n]
+    method n3(c :: C):
+      [c.m().n, c.p.n]
+  class E():
+    extends C
+    override m():
+      V(2)
+    override property p:
+      V(20)
+  let c = C()
+  let d = D()
+  let e = E()
+  [c.m1(), c.m2(), c.m3(c),
+   d.m1(), d.m2(), d.m3(d),
+   e.m1(), e.m2(), e.m3(e)]
+  ~is [[1, 10], [1, 10], [1, 10],
+       [1, 10], [1, 10], [1, 10],
+       [2, 20], [2, 20], [2, 20]]
+
+// mutable property
+check:
+  class V(n)
+  class C():
+    nonfinal
+    private field secret = 10
+    protected property
+    | p :~ V: V(secret)
+    | p := V(n): secret := n
+    method m1():
+      p := V(p.n + 1)
+      p.n
+    method m2():
+      this.p := V(p.n + 2)
+      this.p.n
+    method m3(c :: C):
+      c.p := V(c.p.n + 3)
+      c.p.n
+  class D():
+    extends C
+    method n1():
+      p := V(p.n + 10)
+      p.n
+    method n2():
+      this.p := V(p.n + 20)
+      this.p.n
+    method n3(c :: C):
+      c.p := V(c.p.n + 30)
+      c.p.n
+  class E():
+    extends C
+    override property
+    | p: V(super.p.n - 1)
+    | p := V(n): super.p := V(n-1)
+  let c = C()
+  let d = D()
+  let e = E()
+  [c.m1(), c.m2(), c.m3(c),
+   d.m1(), d.m2(), d.m3(d),
+   d.n1(), d.n2(), d.n3(d),
+   e.m1(), e.m2(), e.m3(e)]
+  ~is [11, 13, 16,
+       11, 13, 16,
+       26, 46, 76,
+       8, 8, 9]
+
+// via internal annotations
+check:
+  class V(n)
+  class C():
+    nonfinal
+    internal _C
+    protected m() :~ V:
+      V(1)
+    protected property p :~ V:
+      V(10)
+  class D():
+    extends C
+    internal _D
+  class E():
+    extends C
+    internal _E
+    override m():
+      V(2)
+    override property p :~ V:
+      V(20)
+  let c = C()
+  let d = D()
+  let e = E()
+  [[(c :: _C).m().n,
+    (d :: _C).m().n,
+    (d :: _D).m().n,
+    (e :: _C).m().n,
+    (e :: _E).m().n],
+   [(c :: _C).p.n,
+    (d :: _C).p.n,
+    (d :: _D).p.n,
+    (e :: _C).p.n,
+    (e :: _E).p.n]]
+  ~is [[1, 1, 1, 2, 2],
+       [10, 10, 10, 20, 20]]
+
+// interface
+check:
+  class V(n)
+  interface I:
+    abstract protected m() :~ V
+    protected n() :~ V:
+      V(10)
+  class C():
+    implements I
+    override m():
+      V(1)
+    method m1():
+      m().n
+    method m2():
+      this.m().n
+    method m3(i :: I):
+      i.m().n
+    method m4():
+      n().n    
+  let c = C()
+  [c.m1(), c.m2(), c.m3(c), c.m4()]
+  ~is [1, 1, 1, 10]
+
+// interface internal annotation
+check:
+  class V(n)
+  interface I:
+    internal _I
+    abstract protected method m() :~ V
+    protected n() :~ V:
+      V(10)
+  class C():
+    implements I
+    override m():
+      V(1)
+  let c = C()
+  [(c :~ _I).m().n,
+   (c :~ _I).n().n]
+  ~is [1, 10]
+
+// subinterface
+check:
+  class V(n)
+  interface I:
+    abstract protected m() :~ V
+    protected n() :~ V:
+      V(10)
+  interface J:
+    extends I
+  class C():
+    implements J
+    final override m():
+      V(1)
+    method m1():
+      m().n
+    method m2():
+      this.m().n
+    method m3(j :: J):
+      j.m().n
+    method m4():
+      n().n    
+  let c = C()
+  [c.m1(), c.m2(), c.m3(c), c.m4()]
+  ~is [1, 1, 1, 10]
+
+check:
+  ~eval
+  class C():
+    protected m():
+      1
+  C().m()
+  ~throws "no such field or method"
+
+check:
+  ~eval
+  use_static
+  class C():
+    protected m():
+      1
+  C().m()
+  ~throws values("no such field or method",
+                 "based on static information")
+
+check:
+  ~eval
+  interface I:
+    abstract protected m()
+  class C():
+    implements I
+    override m():
+      V(1)
+  (C() :~ I).m()
+  ~throws "no such field or method"
+
+check:
+  ~eval
+  interface I:
+    abstract protected m()
+  class C():
+    implements I
+    override m():
+      V(1)
+  C().m()
+  ~throws "no such field or method"
+
+check:
+  ~eval
+  interface I:
+    internal _I
+    abstract protected m()
+  class C():
+    implements I
+    override m():
+      V(1)
+  (C() :~ I).m()
+  ~throws "no such field or method"
+
+// fields
+check:
+  class Posn(x, y, protected dist = x + y):
+    method m():
+      [x, y, dist]
+  Posn(1, 2).m()
+  ~is [1, 2, 3]
+
+check:
+  ~eval
+  class Posn(x, y, protected dist = x + y):
+    method m():
+      [x, y, dist]
+  Posn(1, 2).dist
+  ~throws "no such field or method"
+
+// constructor
+check:
+  class Posn(x, y, protected dist):
+    constructor (v):
+      super(v-1, 1, v)      
+    method m():
+      [x, y, dist]
+  Posn(4).m()
+  ~is [3, 1, 4]
+
+check:
+  ~eval
+  class Posn(x, y, protected dist)
+  ~throws "class needs a custom constructor to initialize protected fields"
+
+// mutable
+check:
+  class Posn(x, y, protected mutable dist = x + y):
+    method m():
+      [x, y, dist]
+    method inflate():
+      dist := dist + 1
+  let p = Posn(1, 2)
+  p.inflate()
+  p.m()
+  ~is [1, 2, 4]
+
+// immutable outside of field-spec sequence
+check:
+  class Posn(x, y):
+    protected immutable dist = x + y
+    method m():
+      [x, y, dist]
+  Posn(1, 2).m()
+  ~is [1, 2, 3]
+
+// `immutable field`
+check:
+  class Posn(x, y):
+    protected immutable field dist = x + y
+    method m():
+      [x, y, dist]
+  Posn(1, 2).m()
+  ~is [1, 2, 3]
+
+// mutablle outside of field-spec sequence
+check:
+  class Posn(x, y):
+    protected field dist = x + y
+    method m():
+      [x, y, dist]
+    method inflate():
+      dist := dist + 1
+  let p = Posn(1, 2)
+  p.inflate()
+  p.m()
+  ~is [1, 2, 4]
+
+check:
+  ~eval
+  class Posn(x, y):
+    protected field dist = x + y
+    method m():
+      [x, y, dist]
+  Posn(1, 2).dist
+  ~throws "no such field or method"
+
+// subclass
+check:
+  class Posn(x, y, protected dist = x + y):
+    nonfinal
+    protected slope(): y/x
+    method m():
+      [x, y, dist, slope()]
+  class Posn3D(z):
+    extends Posn
+    method n():
+      [x, y, z, dist, slope(), m()]
+  Posn3D(2, 3, 1).n()
+  ~is [2, 3, 1, 5, 3/2, [2, 3, 5, 3/2]]
+
+// check access of allowed protected members based on shared inheritance
+check:
+  interface I:
+    protected i(): 0
+    abstract protected i2()
+  interface J:
+    extends I
+    method j(): 0
+  class C(protected a = -1):
+    nonfinal
+    protected field b = 0
+    protected m_c(): 1
+    abstract protected n_c()
+  class D():
+    nonfinal
+    extends C
+    method m():
+      [a, b, m_c(), n_c()]
+    method m2(e :: E):
+      [e.a, e.b, e.m_c(), e.n_c()]
+    method m3(f :: F):
+      [f.a, f.b, f.m_c(), f.n_c()]
+  class E():
+    nonfinal
+    implements I
+    extends C
+    method m():
+      [a, b, m_c(), n_c(), i(), i2()]
+    method m2(i :: I):
+      [i.i(), i.i2()]
+    method m3(j :: J):
+      [j.i(), j.i2()]
+  class F():
+    nonfinal
+    extends E
+    method m10():
+      [a, b, m_c(), n_c(), i(), i2()]
+    method m20(i :: I):
+      [i.i(), i.i2()]
+    method m30(j :: J):
+      [j.i(), j.i2()]
+  class G():
+    nonfinal
+    extends C
+    implements J
+    method m2():
+      [a, b, m_c(), n_c(), i(), i2(), j()]
+    method m3(i :: I):
+      [i.i(), i.i2()]
+    method m4(j :: J):
+      [j.i(), j.i2(), j.j()]
+  class Gprot():
+    nonfinal
+    extends C
+    protected implements J
+    method m2():
+      [a, b, m_c(), n_c(), i(), i2(), j()]
+    method m3(i :: I):
+      [i.i(), i.i2()]
+    method m4(j :: J):
+      [j.i(), j.i2(), j.j()]
+  class H():
+    nonfinal
+    extends Gprot
+    method m20():
+      [a, b, m_c(), n_c(), i(), i2(), j()]
+    method m30(i :: I):
+      [i.i(), i.i2()]
+    method m40(j :: J):
+      [j.i(), j.i2(), j.j()]
+  class Gpriv():
+    nonfinal
+    extends C
+    private implements J
+    private override i2(): "ok"
+    method m2():
+      [a, b, m_c(), n_c(), i(), i2(), j()]
+    method m3(i :: I):
+      [i.i(), i.i2()]
+    method m4(j :: J):
+      [j.i(), j.i2(), j.j()]
+  #void
+  ~completes  

--- a/rhombus/tests/interface.rhm
+++ b/rhombus/tests/interface.rhm
@@ -574,3 +574,71 @@ check:
     private implements: I J
     private override m(): 1
   ~throws "cannot override method from multiple privately implemented interfaces"
+
+// Protected implementation
+check:
+  interface I:
+    method m()
+  class C():
+    nonfinal
+    protected implements: I
+    override m(): 1
+  class D():
+    extends C
+    method n():
+      m()
+  [D().n(),
+   try:
+     use_dynamic
+     dynamic(D()).m()
+     ~catch x:
+       "ok"]
+  ~is [1,
+       "ok"]
+
+// Protected implementation promoted to public
+check:
+  interface I:
+    method m()
+  interface J:
+    extends I
+  class C():
+    nonfinal
+    protected implements: I
+    implements: J
+    override m(): 1
+  class D():
+    extends C
+    method n():
+      m()
+  [D().n(),
+   D().m(),
+   block:
+     use_dynamic
+     dynamic(D()).m()]
+  ~is [1, 1, 1]
+
+// Private implementation promoted to protected
+check:
+  interface I:
+    method m()
+  interface J:
+    extends I
+  class C():
+    nonfinal
+    private implements: I
+    protected implements: J
+    override m(): 1
+  class D():
+    extends C
+    method n():
+      m()
+  [D().n(),
+   try:
+     use_dynamic
+     dynamic(D()).m()
+     ~catch x:
+       "ok"]
+  ~is [1,
+       "ok"]
+


### PR DESCRIPTION
A protected field or method is similar to a private one, except that the method is visible within subclasses and can be overridden in subclasses.  Although privately implementing interfaces covers similar ground, when working on `rhombus/pict`, using `protected` is clearer and simpler than a private-interface encoding.