### PR TITLE
add `any` and `all` expression forms

### DIFF
--- a/rhombus/private/amalgam/boolean-repet.rkt
+++ b/rhombus/private/amalgam/boolean-repet.rkt
@@ -1,0 +1,38 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre)
+         "expression.rkt"
+         "parens.rkt"
+         "parse.rkt"
+         (submod "ellipsis.rkt" for-parse)
+         "op-literal.rkt"
+         "repetition.rkt")
+
+(provide all
+         any)
+
+(define-for-syntax (combiner comb for/comb)
+  (expression-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(_ (_::parens g ...) . tail)
+        (values
+         (let loop ([gs #'(g ...)])
+           (define (combine e gs)
+             (if (null? (syntax-e gs))
+                 e
+                 #`(#,comb #,e #,(loop gs))))
+           (syntax-parse gs
+             #:datum-literals (group)
+             [(g (group _::...-expr) . pre-tail)
+              (define-values (tail count) (consume-extra-ellipses #'pre-tail))
+              (syntax-parse #'g
+                [repet::repetition
+                 (combine (render-repetition for/comb #'repet.parsed #:depth (add1 count))
+                          tail)])]
+             [(e::expression . tail)
+              (combine #'e.parsed #'tail)]))
+         #'tail)]))))
+
+(define-syntax all (combiner #'and #'for/and))
+(define-syntax any (combiner #'or #'for/or))

--- a/rhombus/private/amalgam/core.rkt
+++ b/rhombus/private/amalgam/core.rkt
@@ -140,6 +140,7 @@
         "boolean-pattern.rkt"
         "boolean-annotation.rkt"
         "boolean-reducer.rkt"
+        "boolean-repet.rkt"
         "equatable.rkt"
         "sequenceable.rkt"
         "eval.rkt"

--- a/rhombus/private/amalgam/repetition.rkt
+++ b/rhombus/private/amalgam/repetition.rkt
@@ -166,8 +166,9 @@
 (define-for-syntax (repetition-as-list/unchecked rep-parsed depth)
   (render-repetition/direct rep-parsed depth 'unchecked #'for/list))
 
-(define-for-syntax (render-repetition for-form rep-parsed)
-  (render-repetition/direct rep-parsed 1 'checked for-form))
+(define-for-syntax (render-repetition for-form rep-parsed
+                                      #:depth [depth 1])
+  (render-repetition/direct rep-parsed depth 'checked for-form))
 
 (define-for-syntax (render-repetition/direct rep-parsed depth mode for-form)
   (syntax-parse rep-parsed

--- a/rhombus/scribblings/ref-boolean.scrbl
+++ b/rhombus/scribblings/ref-boolean.scrbl
@@ -97,11 +97,18 @@
 }
 
 @doc(
+  ~nonterminal:
+    ellipses: List
   reducer.macro 'any'
+  expr.macro 'any($expr_or_splice, ...)'
+  grammar expr_or_splice:
+    $expr
+    $repet #,(@litchar{,}) $ellipses
 ){
 
- A @tech{reducer} that stops an iteration as soon as a non-@rhombus(#false)
- value is produced for an element and returns that value, otherwise
+ The @rhombus(any, ~reducer) form as a @tech{reducer} is like
+ @rhombus(||): it stops an iteration as soon as a non-@rhombus(#false)
+ value is produced for an element and it returns that value, otherwise it
  returns @rhombus(#false).
 
 @examples(
@@ -109,6 +116,17 @@
     i == 5 && to_string(i)
   for any (i: 0..10):
     i == 10
+)
+
+ The @rhombus(any) expression form is like @rhombus(||), but
+ @rhombus(any) supports repetition arguments, and it stops iterating
+ through a repetition as soon as a non-@rhombus(#false) result is found.
+ When the last @rhombus(expr_or_splice) is an @nontermref(expr), it is in
+ tail position.
+
+@examples(
+  def [x, ...] = [1, 2, 3, 4]
+  any(x > 2 && x, ...)
 )
 
 }
@@ -198,18 +216,33 @@
 
 
 @doc(
+  ~nonterminal:
+    expr_or_splice: any ~reducer
   reducer.macro 'all'
+  expr.macro 'all($expr_or_splice, ...)'
 ){
 
- A @tech{reducer} that stops an iteration as soon as a @rhombus(#false) value
- is produced for an element and otherwise returns the result of the last
- iteration.
+ The @rhombus(all, ~reducer) form as a @tech{reducer} is like
+ @rhombus(&&): it stops an iteration as soon as a @rhombus(#false) value
+ is produced for an element, and it otherwise returns the result of the
+ last iteration.
 
 @examples(
   for all (i: 0..10):
     i == 5
   for all (i: 0..10):
     i < 10 && to_string(i)
+)
+
+ The @rhombus(all) expression form is like @rhombus(&&), but
+ @rhombus(all) supports repetition arguments, and it stops iterating
+ through a repetition as soon as a @rhombus(#false) result is found. When
+ the last @rhombus(expr_or_splice) is a @nontermref(expr), it is in tail
+ position.
+
+@examples(
+  def [x, ...] = [1, 2, 3, 4]
+  all(x < 2, ...)
 )
 
 }

--- a/rhombus/tests/boolean.rhm
+++ b/rhombus/tests/boolean.rhm
@@ -3,22 +3,38 @@
 check:
   #false || !(#false || #false) ~is #true
   #false && !(#false || #false) ~is #false
+  any(#false, 1) ~is 1
+  all(#false, 2) ~is #false
 
 check:
   #true || !(#true || #true) ~is #true
   #true && !(#true || #true) ~is #false
+  any(#true, 1) ~is #true
+  all(#true, 2) ~is 2
 
 check:
   #true || print("reached") ~prints ""
   #true && print("reached") ~prints "reached"
   #false || print("reached") ~prints "reached"
   #false && print("reached") ~prints ""
+  any(#true, print("reached")) ~prints ""
+  all(#true, print("reached")) ~prints "reached"
+  any(#false, print("reached")) ~prints "reached"
+  all(#false, print("reached")) ~prints ""
 
 block:
   def [x, ...] = [#true, #true, #false]
   def [y, ...] = [#true, #false, #false]
   check [x || y, ...] ~is [#true, #true, #false]
   check [x && y, ...] ~is [#true, #false, #false]
+  check all(!x, ...) ~is #false
+  check any(!x, ...) ~is #true
+  check all(x || !y, ...) ~is #true
+  check any(!x && y, ...) ~is #false
+  check all(#true, x || !y, ...) ~is #true
+  check any(#false, !x && y, ...) ~is #false
+  check all(x, ..., print("end")) ~prints ""
+  check all(!y && error("oops"), ...) ~is #false
 
 block:
   def [x, ...] = [#true, #true, #false]


### PR DESCRIPTION
These expression forms are like `||` and `&&`, but they can work with repetitions, as in `all(x == y, ...)`.