### PR TITLE
shrubbery: handle tabs in column counting

### DIFF
--- a/shrubbery/private/column.rkt
+++ b/shrubbery/private/column.rkt
@@ -1,0 +1,95 @@
+#lang racket/base
+
+
+(provide count-graphemes
+
+         column+
+         column=?
+         column<?
+         column>?
+         column<=>?)
+
+;; represent a column in general as
+;;   (list num-chars num-tabs ... num-chars)
+;; where the start of the list is the rightmost set of chars/tabs,
+;; always starting with a number of chars, always ending with a number
+;; of chars, with 0s only potentially at the start and end, and
+;; with a plain number as a shorthand for a list containing that number
+
+;; add `c1` columns (on right) to base column offset `c2`
+(define (column+ c1 c2)
+  (cond
+    [(and (number? c1) (number? c2))
+     (+ c1 c2)]
+    [(number? c1)
+     (cons (+ c1 (car c2)) (cdr c2))]
+    [else
+     (let loop ([c1 c1])
+       (cond
+         [(null? c1) (if (number? c2)
+                         (list c2)
+                         c2)]
+         [(null? (cdr c1)) (if (number? c2)
+                               (list (+ (car c1) c2))
+                               (cons (+ (car c1) (car c2)) (cdr c2)))]
+         [else (list* (car c1) (cadr c1) (loop (cddr c1)))]))]))
+
+(define (column=? c1 c2 #:incomparable [incomparable (lambda () #f)])
+  (column<=>? = c1 c2 incomparable))
+
+(define (column<? c1 c2 #:incomparable [incomparable (lambda () #f)])
+  (column<=>? < c1 c2 incomparable))
+
+(define (column>? c1 c2 #:incomparable [incomparable (lambda () #f)])
+  (column<=>? > c1 c2 incomparable))
+
+(define (column<=>? <=>? c1 c2 incomparable)
+  (cond
+    [(and (number? c1) (number? c2)) (<=>? c1 c2)]
+    [(number? c1) (column<=>? <=>? (list c1) c2 incomparable)]
+    [(number? c2) (column<=>? <=>? c1 (list c2) incomparable)]
+    [else
+     (let loop ([rev-c1 (reverse c1)]
+                [rev-c2 (reverse c2)])
+       (cond
+         [(null? rev-c2) (if (null? rev-c1)
+                             (<=>? 1 1)
+                             (<=>? 1 0))]
+         [(null? rev-c1) (if (null? rev-c2)
+                             (<=>? 1 1)
+                             (<=>? 0 1))]
+         [else
+          (if (= (car rev-c1) (car rev-c2))
+              (loop (cdr rev-c1) (cdr rev-c2))
+              (if (> (car rev-c1) (car rev-c2))
+                  (if (null? (cdr rev-c2))
+                      (<=>? 1 0)
+                      ;; allow half a column up before a tab
+                      (if (and (= (car rev-c1) (+ (car rev-c2) 0.5))
+                               (null? (cdr rev-c1)))
+                          #f
+                          (incomparable)))
+                  (if (null? (cdr rev-c1))
+                      (<=>? 0 1)
+                      ;; allow half a column up before a tab
+                      (if (and (= (+ (car rev-c1) 0.5) (car rev-c2))
+                               (null? (cdr rev-c2)))
+                          #f
+                          (incomparable)))))]))]))
+
+(define (count-graphemes s [lines 0] [columns 0])
+  (let loop ([i 0] [lines lines] [columns columns])
+    (cond
+      [(= i (string-length s)) (values lines columns)]
+      [(char=? #\return (string-ref s i))
+       (if (and ((add1 i) . < . (string-length s))
+                (char=? #\newline (string-ref s (add1 i))))
+           (loop (+ i 2) (add1 lines) 0)
+           (loop (+ i 1) (add1 lines) 0))]
+      [(char=? #\newline (string-ref s i))
+       (loop (+ i 1) (add1 lines) 0)]
+      [(char=? #\tab (string-ref s i))
+       (loop (+ i 1) lines (column+ '(0 1 0) columns))]
+      [else
+       (define n (string-grapheme-span s i))
+       (loop (+ i n) lines (column+ 1 columns))])))

--- a/shrubbery/scribblings/group-and-block.scrbl
+++ b/shrubbery/scribblings/group-and-block.scrbl
@@ -73,7 +73,7 @@ Overall, a document is a sequence of groups:
 @section{Grouping by Lines}
 
 The main grouping rule is that sequences on different lines with the
-same indentation create separate @tech{groups}, one for each line.
+same @tech{indentation} create separate @tech{groups}, one for each line.
 
 @rhombusblock(
   this is the first group
@@ -89,7 +89,7 @@ An @opener_closer pair @parens, @brackets, @braces, or @quotes forms a @tech{ter
 can span lines and encloses nested groups. Within most @opener_closer
 pairs, @litchar{,} separates groups, but @litchar{;} separates group
 with @quotes. Groups can be on separate lines at the same
-indentation, but groups on separate lines still must be separated by
+@tech{indentation}, but groups on separate lines still must be separated by
 @litchar{,} in @parens, @brackets, or @braces. Parsing
 retains whether a term is formed by @parens, @brackets,
 @braces, or @quotes.
@@ -160,7 +160,7 @@ preserved in the parsed representation.
 
 @section{Blocking with @litchar{:} and Indentation}
 
-A sequence of groups has a particular indentation that is determined by
+A sequence of groups has a particular @tech{indentation} that is determined by
 the first group in the sequence. Subsequent groups in a sequence must
 start with the same indentation as the first group.
 
@@ -249,7 +249,7 @@ preceding line does @emph{not} end with @litchar{:}, then the indented line
 does not form a block, and it may instead continue the previous line.
 The operator-starting line continues only if the previous line was not a
 continuing line; however, additional continuing lines can start with an
-operator (not necessarily the same one) at the same indentation as the
+operator (not necessarily the same one) at the same @tech{indentation} as the
 original continuing line. The following two groups are the same:
 
 @rhombusblock(
@@ -286,7 +286,7 @@ with a block that has a @litchar{+ 3} group:
 
 A group can end with a sequence of @tech{alternatives}, each of which
 starts with @litchar{|}. The initial @litchar{|} of the sequence can be
-on a new line, in which case it must have the same indentation as the
+on a new line, in which case it must have the same @tech{indentation} as the
 beginning of its enclosing group, but it does not have to be on a new
 line. If a later @litchar{|} for the same alternative sequence starts a
 new line, it must be indented the same as the initial @litchar{|}
@@ -637,7 +637,7 @@ the start of a group. To comment out an alternative, @litchar{#//} must appear
 on its own line before the alternative or just before a @litchar{|} that does
 @emph{not} start a new line.
 
-The interaction between @litchar{#//} and indentation depends on how it is
+The interaction between @litchar{#//} and @tech{indentation} depends on how it is
 used:
 
 @itemlist(

--- a/shrubbery/scribblings/token-parsing.scrbl
+++ b/shrubbery/scribblings/token-parsing.scrbl
@@ -81,6 +81,24 @@ escape must @emph{not} describe a pair, because pairs are used to represent a
 parsed shrubbery, and allowing pairs would create ambiguous or
 ill-formed representations.
 
+Lines and indentation-influencing whitespace are not represented as
+tokens. Instead, each token conceptually has a line and column derived
+from its position in the input sequence of characters. The line for an
+input sequence increments at a linefeed character (code point 0x0A), a
+two-character sequence of return (code point 0x0C) and linefeed, or a
+return character that is not followed by a linefeed character. The
+column of an input sequence for measuring @deftech{indentation}
+increments once per Unicode @defterm{grapheme cluster}, except that tabs
+are treated specially.@margin_note{Note that the use of grapheme
+ clusters is a different counting of columns than built into a Racket or
+ Rhombus input port, which counts by Unicode code points.} More
+generally, a column corresponds to a sequence of spaces and tabs, where
+all non-tab grapheme clusters are treated like a space. A column is more
+indented than another only if it extends the other column's sequence.
+When neither of two columns is a prefix of the other, then the columns
+are incomparable; if parsing depends on an order between incomparable
+columns, then it fails with a ``mix tabs'' error.
+
 For more details on @litchar("@") parsing, see @secref("at-parsing"),
 but the table below describes the shape of @litchar("@") forms.
 


### PR DESCRIPTION
Instead of treating each tab as rounding up to a particular multiple of columns, a "column" is defined to be a sequence of spaces and tabs, where every non-tab grapheme cluster is treated like a space. If neither of two columns is a prefix of the other, then they are incomparable, and any parsing decision that would depend on a comparison instead fails with a "mixed tabs" error.