### PR TITLE
add support for annotations on `syntax_class` fields

### DIFF
--- a/rhombus-lib/info.rkt
+++ b/rhombus-lib/info.rkt
@@ -17,4 +17,4 @@
 (define license '(Apache-2.0 OR MIT))
 
 ;; keep in sync with runtime version at "rhombus/private/amalgam/version.rkt"
-(define version "0.35")
+(define version "0.36")

--- a/rhombus-lib/rhombus/private/amalgam/pattern-clause-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/pattern-clause-primitive.rkt
@@ -6,7 +6,9 @@
          "parens.rkt"
          "parse.rkt"
          "op-literal.rkt"
-         (submod "equal.rkt" for-parse))
+         "syntax-wrap.rkt"
+         (submod "equal.rkt" for-parse)
+         (submod "annotation.rkt" for-class))
 
 (provide (for-space rhombus/pattern_clause
                     field
@@ -17,23 +19,44 @@
                     description))
 
 (begin-for-syntax
-  (define-syntax-class :field-lhs
+  (define-splicing-syntax-class :field-lhs
+    #:attributes (id depth converter static-infos annotation-str)
     #:datum-literals (group)
-    (pattern id:identifier
-             #:with depth #'0)
-    (pattern (_::brackets (group a::field-lhs) (group _::...-bind))
+    (pattern (~seq id:identifier)
+             #:with depth #'0
+             #:with converter #'#f
+             #:with static-infos #'()
+             #:with annotation-str "none")
+    (pattern (~seq id:identifier ann::inline-annotation)
+             #:with depth #'0
+             #:with converter #'ann.converter
+             #:with static-infos #'ann.static-infos
+             #:with annotation-str #'ann.annotation-str)
+    (pattern (~seq (_::brackets (group a::field-lhs) (group _::...-bind)))
              #:with id #'a.id
+             #:with converter #'a.converter
+             #:with static-infos #'a.static-infos
+             #:with annotation-str #'a.annotation-str
              #:with depth #`#,(+ 1 (syntax-e #'a.depth)))))
+
+(define (ensure-syntax val who fail)
+  (if (syntax*? val)
+      val
+      (fail val who)))
 
 (define-pattern-clause-syntax field
   (pattern-clause-transformer
    (lambda (stx)
      (syntax-parse stx
-       #:datum-literals (op)
-       [(_ field::field-lhs (tag::block in-block ...))
-        #'(#:field field.id field.depth (rhombus-body-at tag in-block ...))]
-       [(_ field::field-lhs _::equal rhs ...)
-        #`(#:field field.id field.depth (rhombus-expression (#,group-tag rhs ...)))]))))
+       #:datum-literals (op group)
+       [(_ fld ... (tag::block in-block ...))
+        #:with (group field::field-lhs) #'(group fld ...)
+        #'(#:field field.id field.depth (rhombus-body-at tag in-block ...)
+           field.converter field.static-infos  field.annotation-str)]
+       [(_ fld ... _::equal rhs ...)
+        #:with (group field::field-lhs) #'(group fld ...)
+        #`(#:field field.id field.depth (rhombus-expression (#,group-tag rhs ...))
+           field.converter field.static-infos  field.annotation-str)]))))
 
 (define-pattern-clause-syntax match_def
   (pattern-clause-transformer

--- a/rhombus-lib/rhombus/private/amalgam/pattern-variable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/pattern-variable.rkt
@@ -110,7 +110,7 @@
     (lambda (stx)
       (syntax-parse stx
         [(_ . tail) (values (if (null? (syntax-e attributes))
-                                (wrap-static-info* temp-id (get-syntax-static-infos))
+                                (wrap-static-info* temp-id statinfos)
                                 (wrap-static-info* #`(maybe-syntax-wrap
                                                       (syntax-unwrap #,temp-id)
                                                       0

--- a/rhombus/rhombus/scribblings/reference/syntax-class.scrbl
+++ b/rhombus/rhombus/scribblings/reference/syntax-class.scrbl
@@ -234,8 +234,13 @@
     $id_maybe_rep: #,(@rhombus(kind, ~syntax_class_clause)) $kind_decl
 
   grammar id_maybe_rep:
-    $id
+    $id_maybe_annot
     [$id_maybe_rep, $ellipsis]
+
+  grammar id_maybe_annot:
+    $id
+    $id #,(@rhombus(::, ~bind)) $annot
+    $id #,(@rhombus(:~, ~bind)) $annot
 
   grammar ellipsis:
     #,(dots)
@@ -247,11 +252,20 @@
  @rhombus(..., ~bind) like a repetition binding. If no @rhombus(spec)
  is present at all, no fields will be provided.
 
+ If an @rhombus(annot) is supplied for a @rhombus(id_maybe_annot), then
+ the field has the static information of @rhombus(annot), and the
+ annotation is checked or converted when @rhombus(::, ~bind) is used. If
+ a field with the same name has an annotation in a pattern clause, then
+ the one supplied in @rhombus(fields, ~syntax_class_clause) applies
+ afterward, and static information is combined as with
+ @rhombus(statinfo_meta.and). When not within @brackets, a field with an
+ @rhombus(annot) must be in its own group (i.e., on its own line, usually).
+
  If a @rhombus(kind, ~syntax_class_clause) is not declared for a field
  identifier, then the context kind is inferred from patterns within the
  syntax class. If @rhombus(kind, ~syntax_class_clause) is declared, then
  it must match the context kind that would be inferred for the field from
- all patterns.
+ all patterns, and an @rhombus(annot) cannot be provided.
 
 }
 
@@ -271,6 +285,9 @@
  Meanwhile, the matching terms that would otherwise be the variable's
  value are associated instead with a fresh field named by the second
  @rhombus(root_to_field_id).
+
+ A @rhombus(:: Syntax, ~bind) annotation is implicitly added to
+ @rhombus(field_to_root_id) to ensure that its value is a syntax object.
 
 @examples(
   ~defn:
@@ -366,8 +383,13 @@
   pattern_clause.macro 'field $id_maybe_rep = $expr'
 
   grammar id_maybe_rep:
-    $id
+    $id_maybe_annot
     [$id_maybe_rep, $ellipsis]
+
+  grammar id_maybe_annot:
+    $id
+    $id #,(@rhombus(::, ~bind)) $annot
+    $id #,(@rhombus(:~, ~bind)) $annot
 
   grammar ellipsis:
     #,(dots)
@@ -383,6 +405,13 @@
  lists. If the field is referenced so that it's value is included in a
  syntax template, a non-syntax value is converted to syntax at that point.
  Otherwise, the field can be used directly to access non-syntax values.
+
+ If an @rhombus(annot) is supplied in @rhombus(id_maybe_annot), then the
+ field has the static information of @rhombus(annot), and the annotation
+ is checked or converted when @rhombus(::, ~bind) is used. Annotations
+ from different pattern clauses are combined using
+ @rhombus(statinfo_meta.or) to determine static information for accesses
+ of the field.
 
  See also @rhombus(syntax_class).
 

--- a/rhombus/rhombus/tests/syntax-class.rhm
+++ b/rhombus/rhombus/tests/syntax-class.rhm
@@ -1238,8 +1238,7 @@ check:
   ~completes
 
 block:
-  syntax_class Option:
-    root_swap: o orig
+  syntax_class Option
   | '~opt_a: $n':
       field o = {#'a: n}
   | '~opt_b':
@@ -1248,10 +1247,10 @@ block:
   syntax_class.together:
     syntax_class Options:
       fields: o
-    | '$(opt :: Option)': field o = opt
+    | '$(opt :: Option)': field o = opt.o
     | '$(opt :: Option)
        $(tail :: Options)': // multi-group escape allowed here
-        field o = opt ++ tail.o
+        field o = opt.o ++ tail.o
 
   check:
     match '~opt_a: 10; ~opt_b'
@@ -1366,3 +1365,175 @@ block:
   check [matched.wrapped.elem, ...] ~matches ['1', '2', '3']
   let matched_wrapped = matched.wrapped;
   check [matched_wrapped.elem, ...] ~matches ['1', '2', '3']
+
+block:
+  // annotation on field
+  use_static
+  syntax_class C
+  | '~val $n':
+      field val :: Int = n.unwrap()
+  check:
+    match '~val 1'
+    | '$(v :: C)': v.val
+    ~is 1
+  check:
+    match '~val 1'
+    | '$(v :: C)': v.val < v.val // `<` specialized to `Int`
+    ~is #false
+  check:
+    match '~val #false'
+    | '$(v :: C)': v.val
+    ~throws values(error.annot_msg(),
+                   error.annot("Int").msg)
+
+block:
+  // different annotations on different fields
+  use_static
+  syntax_class C
+  | '~str $v':
+      field val :: String = v.unwrap()
+  | '~int $v':
+      field val :: Int = v.unwrap()
+  check:
+    match '~int 1'
+    | '$(v :: C)': v.val
+    ~is 1
+  check:
+    match '~str "1"'
+    | '$(v :: C)': v.val
+    ~is "1"
+  check:
+    match '~str 1'
+    | '$(v :: C)': v.val
+    ~throws values(error.annot_msg(),
+                   error.annot("String").msg)
+
+check:
+  // different annotations => no static info
+  ~eval
+  use_static
+  syntax_class C
+  | '~str $v':
+      field val :: String = v.unwrap()
+  | '~int $v':
+      field val :: Int = v.unwrap()
+  match '~str "1"'
+  | '$(v :: C)': v.val.length()
+  ~throws values("length",
+                 "no such field or method",
+                 "based on static information")
+
+block:
+  // declared field => static info, but one case cannot succeed
+  use_static
+  syntax_class C:
+    fields:
+      val :: String
+  | '~str $v':
+      field val :: String = v.unwrap()
+  | '~int $v':
+      field val :: Int = v.unwrap()
+  check:
+    match '~str "1"'
+    | '$(v :: C)': v.val
+    ~is "1"
+  check:
+    match '~str "100"'
+    | '$(v :: C)': v.val.length()
+    ~is 3
+  check:
+    match '~int 1'
+    | '$(v :: C)': v.val
+    ~throws values(error.annot_msg(),
+                   error.annot("String").msg)
+
+check:
+  syntax_class Option:
+    // root swap implies `:: Syntax`
+    root_swap: o orig
+  | '~opt_a: $n':
+      field o = {#'a: n}
+  | '~opt_b':
+      field o = {#'b: #true}
+  def '$(o :: Option)' = '~opt_b'
+  o
+  ~throws values(error.annot_msg(),
+                 error.annot("Syntax").msg)
+
+block:
+  // converting annotations
+  use_static
+  syntax_class C:
+    fields:
+      val :: ReadableString.to_string
+  | '~str $v':
+      field val = String.copy(v.unwrap())
+  syntax_class C2
+  | '~str $v':
+      field val :: ReadableString.to_string = String.copy(v.unwrap())
+  check:
+    match '~str "1"'
+    | '$(v :: C)': v.val
+    ~is "1"
+  check:
+    match '~str "1"'
+    | '$(v :: C2)': v.val
+    ~is "1"
+
+check:
+  use_static
+  match '~str "abc"'
+  | '$(pattern
+       | '~str $v':
+           field val :: String = v.unwrap())':
+      val.length()
+  ~is 3
+
+check:
+  use_static
+  match '~str "abc"'
+  | '$(pattern:
+         fields:
+           val :: String
+       | '~str $v':
+           field val = v.unwrap())':
+      val.length()
+  ~is 3
+
+// check interaction of lifting to avoid duplicated code and
+// whether state for that code is instantiated every time
+block:
+  import rhombus/meta open
+  annot.macro 'WeirdCounter':
+    annot_meta.pack_predicate('block:
+                                 let mutable count = 0
+                                 fun (x):
+                                   count := count + 1
+                                   x == count',
+                              '()')
+  syntax_class C:
+    fields:
+      w :: WeirdCounter
+  | '$w_stx':
+      field w = w_stx.unwrap()
+  check:
+    match '1'
+    | '$(c :: C)':
+        c.w
+    ~is 1  
+  check:
+    match '1'
+    | '$(pattern:
+           fields:
+             w :: WeirdCounter
+         | '$w_stx':
+             field w = w_stx.unwrap())':
+        w
+    ~is 1
+  check:
+    match '1'
+    | '$(c :: C)':
+        c.w
+    | ~else:
+        "no"
+    ~is 1


### PR DESCRIPTION
This commit adds support for annotations on `field` and `fields` declarations within `syntax_class` (and, more generally, `field` in a pattern clause).

The commit also removes the implicit `:~ Syntax` on fields, because it is not always right (#672), and it adds an implicit `:: Syntax` annotation for a field in a `root_swap` declaration. Both of these are backward-incompatible changes.
