### PR TITLE
adjust `export` on a dotted definition

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/maybe-provide.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/maybe-provide.rkt
@@ -4,7 +4,8 @@
                      "id-binding.rkt"
                      "introducer.rkt")
          "only-spaces-out.rkt"
-         "all-spaces-out.rkt")
+         "all-spaces-out.rkt"
+         "dotted-sequence-parse.rkt")
 
 (provide maybe-provide-id
          maybe-provide-req)
@@ -25,7 +26,13 @@
                          #:when (and (free-identifier=? maybe-id-in-space (intro id))
                                      (or (not space-sym)
                                          (identifier-distinct-binding* maybe-id-in-space maybe-id))))
-               #`(only-spaces-out (all-spaces-out #,maybe-id) #,space-sym)))])))
+               (define id/rename
+                 (cond
+                   [(identifier-extension-binding-tail-name maybe-id-in-space)
+                    => (lambda (tail-name)
+                         #`(#,maybe-id #,tail-name))]
+                   [else maybe-id]))
+               #`(only-spaces-out (all-spaces-out #,id/rename) #,space-sym)))])))
 
 (define-syntax (maybe-provide-req stx)
   (syntax-parse stx

--- a/rhombus/rhombus/scribblings/reference/export.scrbl
+++ b/rhombus/rhombus/scribblings/reference/export.scrbl
@@ -84,7 +84,9 @@
  @rhombus(id) are exported. Defined names are exported only in
  the @tech(~doc: meta_doc){spaces} where they are bound by @rhombus(defn), and not in other
  spaces where the same name happens to be defined in the same definition
- context.
+ context. If @rhombus(defn) extends a namespace, then just the added name is
+ exported (the same as providing a dotted name to a plain @rhombus(export)),
+ not the extended namespace.
 
 @(block:
     let defn = "hack to avoid nonterminal"


### PR DESCRIPTION
When `export` prefixes a definition that extends a namespace, export the same as providing a dotted name to `export`. Don't export a raw extension, instead, which does not work in general.

Closes #681