### PR TITLE
definitions and expression at the end of `class` effectively follow it

### DIFF
--- a/rhombus-draw-lib/rhombus/draw/private/dc.rhm
+++ b/rhombus-draw-lib/rhombus/draw/private/dc.rhm
@@ -214,14 +214,6 @@ interface DC:
   | layered_transformation := a :: LayeredTransformation:
       rkt.send handle.#{set-transformation}(_LayeredTransformation.hand(a))
 
-  export:
-    BitmapOverlay
-    TextCombine
-    Fill
-    Transformation
-    LayeredTransformation
-    Smoothing
-
   symbol_set_annot Smoothing:
     { unsmoothed, aligned, smoothed }
 
@@ -231,6 +223,14 @@ interface DC:
   symbol_map_annot Fill fill_convert:
     { odd_even: #{odd-even},
       winding: winding }
+
+  export:
+    BitmapOverlay
+    TextCombine
+    Fill
+    Transformation
+    LayeredTransformation
+    Smoothing
 
 fun from_handle(handle) :: DC:
   unless handle rkt.is_a rkt.#{dc<%>}

--- a/rhombus-lib/rhombus/private/amalgam/bounce-to-definition.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bounce-to-definition.rkt
@@ -1,0 +1,13 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     "srcloc.rkt")
+         "parse.rkt")
+
+(provide (for-syntax bounce-to-definition))
+
+(define-for-syntax (bounce-to-definition macro-id stx)
+  (syntax-parse stx
+    [(head . tail)
+     #`((group #,(relocate-id #'head macro-id) . tail))]))
+

--- a/rhombus-lib/rhombus/private/amalgam/class-clause-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-clause-macro.rkt
@@ -12,7 +12,9 @@
          "class+interface.rkt"
          "class-clause.rkt"
          "name-root.rkt"
-         "macro-macro.rkt")
+         "macro-macro.rkt"
+         "definition.rkt"
+         "bounce-to-definition.rkt")
 
 (provide (for-space rhombus/namespace
                     class_and_interface_clause))
@@ -51,3 +53,14 @@
     (unless (syntax*? defns)
       (raise-bad-macro-result (proc-name proc) "`class` clause" defns))
     (datum->syntax #f (unpack-multi defns proc #f))))
+
+;; Binding as a class clause ensures that use within a `class` takes
+;; effect for later `class forms
+(define-class-clause-syntax macro
+  (class-clause-transformer
+   (lambda (stx data)
+     (bounce-to-definition (defn-quote macro) stx))))
+(define-class-clause-syntax both_macro
+  (make-class+interface-clause-transformer
+   (lambda (stx data)
+     (bounce-to-definition (defn-quote both_macro) stx))))

--- a/rhombus-lib/rhombus/private/amalgam/class-clause-parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-clause-parse.rkt
@@ -212,6 +212,8 @@
                                                                     #,(and (syntax-e #'deserialize-fill-rhs)
                                                                            (extract-rhs #'deserialize-fill-rhs))))
                          'serializer-stx-params (car stx-paramss))]
+              [(#:post-forms (form ...)) ; added directly in "class-step.rkt"
+               (hash-set options 'post-forms (syntax->list #'(form ...)))]
               [_
                (parse-method-clause orig-stx options clause (car stx-paramss))]))
           (loop (cdr clauses) (cdr stx-paramss) new-options)]))]))

--- a/rhombus-lib/rhombus/private/amalgam/class-clause.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-clause.rkt
@@ -19,7 +19,8 @@
 (begin-for-syntax
   (provide (property-out class-clause-transformer)
            :class-clause
-           :class-clause-form)
+           :class-clause-form
+           class-clause?)
 
   (property class-clause-transformer transformer)
 
@@ -38,6 +39,7 @@
 
   (define-rhombus-transform
     #:syntax-class (:class-clause class-data)
+    #:predicate class-clause?
     #:desc "class clause"
     #:parsed-tag #:rhombus/class_clause
     #:in-space in-class-clause-space

--- a/rhombus-lib/rhombus/private/amalgam/class-step.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-step.rkt
@@ -1,34 +1,58 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse/pre)
-         "parse.rkt")
+         "parse.rkt"
+         "class-clause-tag.rkt"
+         "sentinel-declaration.rkt")
 
 (provide define-class-body-step)
 
 (define-syntax-rule (define-class-body-step class-body-step
                       :class-clause
+                      class-clause?
                       class-expand-data
                       class-clause-accum)
   (...
-   (define-syntax class-body-step
-     (lambda (stx)
-       ;; parse the first form as a class clause, if possible, otherwise assume
-       ;; an expression or definition
-       (syntax-parse stx
-         [(_ (data accum) form . rest)
-          #:with (~var clause (:class-clause (class-expand-data #'data #'accum))) (syntax-local-introduce #'form)
-          (syntax-parse (syntax-local-introduce #'clause.parsed)
-            #:datum-literals (group parsed)
-            [((group (parsed #:rhombus/class_clause p)) ...)
-             #:with (new-accum ...) (class-clause-accum #'(p ...))
-             #`(begin p ... (class-body-step (data (new-accum ... . accum)) . rest))]
-            [(form ...)
-             #`(class-body-step (data accum) form ... . rest)])]
-         [(_ (~and data+accum ([orig-stx base-stx scope-stx reflect-name . _] . _)) form . rest)
-          #`(rhombus-top-step
-             class-body-step
-             #f
-             reflect-name
-             (data+accum)
-             form . rest)]
-         [(_ data+accum) #'(begin)])))))
+   (begin
+     (define-syntax class-body-step
+       (lambda (stx)
+         (syntax-parse stx
+           [(_ data+accum) #'(begin)]
+           [(_ data+accum . forms)
+            ;; If there are no declaration or clause forms left, then it's
+            ;; expressions and definitions that we delay until after the
+            ;; class is expanded. Those definitions might be exported, but
+            ;; maybe they want to refer to the class annotation, or even
+            ;; its namespace.
+            (if (ormap (lambda (e) (or (nestable-declaration? e)
+                                       (class-clause? e)))
+                       (syntax->list #'forms))
+                #'(class-body-step/to-clause-or-decl data+accum . forms)
+                #'(quote-syntax (rhombus-class (#:post-forms ((rhombus-nested
+                                                               reflect-name
+                                                               . forms))))
+                                #:local))])))
+     (define-syntax class-body-step/to-clause-or-decl
+       (lambda (stx)
+         ;; parse the first form as a class clause, if possible, otherwise assume
+         ;; an expression or definition
+         (syntax-parse stx
+           [(_ (data accum) form . rest)
+            #:with (~var clause (:class-clause (class-expand-data #'data #'accum))) (syntax-local-introduce #'form)
+            (syntax-parse (syntax-local-introduce #'clause.parsed)
+              #:datum-literals (group parsed)
+              [((group (parsed #:rhombus/class_clause p)) ...)
+               #:with (new-accum ...) (class-clause-accum #'(p ...))
+               #`(begin p ... (class-body-step (data (new-accum ... . accum)) . rest))]
+              [(form ...)
+               #`(class-body-step (data accum) form ... (group sentinel_declaration) . rest)])]
+           [(_ (~and data+accum ([orig-stx base-stx scope-stx reflect-name . _] . _)) form . rest)
+            #`(rhombus-top-step
+               #,(if (nestable-declaration? #'form)
+                     #'class-body-step
+                     #'class-body-step/to-clause-or-decl)
+               #f
+               reflect-name
+               (data+accum)
+               form . rest)]
+           [(_ data+accum) #'(begin)]))))))

--- a/rhombus-lib/rhombus/private/amalgam/class.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class.rkt
@@ -12,6 +12,8 @@
          "forwarding-sequence.rkt"
          "definition.rkt"
          (submod "dot.rkt" for-dot-provider)
+         (only-in (submod "annotation.rkt" for-class)
+                  annotation-to-be-defined!)
          "space.rkt"
          "class-clause.rkt"
          "class-clause-parse.rkt"
@@ -79,6 +81,7 @@
                                       (field.ann-seq ...)]
                             ;; data accumulated from parsed clauses:
                             ()))
+     (annotation-to-be-defined! #'name)
      #`(#,(cond
             [(null? (syntax-e body))
              #`(class-annotation+finish #,finish-data [#:ctx base-stx base-stx] ())]
@@ -89,6 +92,7 @@
 
 (define-class-body-step class-body-step
   :class-clause
+  class-clause?
   class-expand-data
   class-clause-accum)
 
@@ -500,6 +504,8 @@
                              prefab? has-private-fields?))
        (define serializer-stx-params (hash-ref options 'serializer-stx-params #f))
 
+       (define post-forms (hash-ref options 'post-forms null))
+
        (define (temporary template)
          ((make-syntax-introducer) (datum->syntax #f (string->symbol (format template (syntax-e #'name))))))
 
@@ -835,7 +841,9 @@
                                                serializable
                                                deserializer-name
                                                constructor-name)))))
-           #`(begin . #,defns)))])))
+           #`(begin
+               #,@defns
+               #,@post-forms)))])))
 
 (define-for-syntax (build-class-struct super
                                        fields mutables constructor-keywords exposures final? authentic? prefab? opaque?

--- a/rhombus-lib/rhombus/private/amalgam/interface-clause-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/interface-clause-macro.rkt
@@ -8,7 +8,9 @@
                      "syntax-wrap.rkt")
          "space-provide.rkt"
          "interface-clause.rkt"
-         "macro-macro.rkt")
+         "macro-macro.rkt"
+         "definition.rkt"
+         "bounce-to-definition.rkt")
 
 (define+provide-space interface_clause rhombus/interface_clause
   #:fields
@@ -27,3 +29,9 @@
      (unless (syntax*? defns)
        (raise-bad-macro-result (proc-name proc) "`interface` clause" defns))
      (datum->syntax #f (unpack-multi defns proc #f)))))
+
+;; See use of `bounce-to-definition` in "class-clause-macro.rkt"
+(define-interface-clause-syntax macro
+  (interface-clause-transformer
+   (lambda (stx data)
+     (bounce-to-definition (defn-quote macro) stx))))

--- a/rhombus-lib/rhombus/private/amalgam/interface-clause-parse.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/interface-clause-parse.rkt
@@ -73,6 +73,8 @@
                (hash-set options 'primitive-properties
                          (cons (cons #'prop-id #'val-id)
                                (hash-ref options 'primitive-properties null)))]
+              [(#:post-forms (form ...)) ; added directly in "class-step.rkt"
+               (hash-set options 'post-forms (syntax->list #'(form ...)))]
               [_
                (parse-method-clause orig-stx options clause (car stx-paramss))]))
           (loop (cdr clauses) (cdr stx-paramss) new-options)]))]))

--- a/rhombus-lib/rhombus/private/amalgam/interface-clause.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/interface-clause.rkt
@@ -17,7 +17,8 @@
 (begin-for-syntax
   (provide (property-out interface-clause-transformer)
            :interface-clause
-           :interface-clause-form)
+           :interface-clause-form
+           interface-clause?)
 
   (property interface-clause-transformer transformer)
 
@@ -33,6 +34,7 @@
 
   (define-rhombus-transform
     #:syntax-class (:interface-clause intf-data)
+    #:predicate interface-clause?
     #:desc "interface clause"
     #:parsed-tag #:rhombus/class_clause
     #:in-space in-interface-clause-space

--- a/rhombus-lib/rhombus/private/amalgam/interface.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/interface.rkt
@@ -63,6 +63,7 @@
                                       reflect-name name name-extends tail-name]
                             ;; data accumulated from parsed clauses:
                             ()))
+     (annotation-to-be-defined! #'name)
      #`(#,(cond
             [(null? (syntax-e body))
              #`(interface-annotation+finish #,finish-data [#:ctx base base] ())]
@@ -73,6 +74,7 @@
 
 (define-class-body-step interface-body-step
   :interface-clause
+  interface-clause?
   interface-expand-data
   class-clause-accum)
 
@@ -238,6 +240,8 @@
          (able-method-status 'contains #f supers method-mindex method-vtable method-private
                              #:name 'contains))
 
+       (define post-forms (hash-ref options 'post-forms null))
+
        (define (temporary template #:name [name #'name])
          (and name
               ((make-syntax-introducer) (datum->syntax #f (string->symbol (format template (syntax-e name)))))))
@@ -319,7 +323,9 @@
                                      #'compare-statinfo-indirect comparable?
                                      #'contains-statinfo-indirect container?
                                      #'super-call-statinfo-indirect))))
-           #`(begin . #,defns)))])))
+           #`(begin
+               #,@defns
+               #,@post-forms)))])))
 
 (define-for-syntax (build-interface-property internal-internal-name names)
   (with-syntax ([(name prop:name name? name-ref name-ref-or-error

--- a/rhombus-lib/rhombus/private/amalgam/sentinel-declaration.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/sentinel-declaration.rkt
@@ -1,0 +1,15 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         "declaration.rkt"
+         "nestable-declaration.rkt")
+
+(provide (for-space rhombus/decl
+                    sentinel_declaration))
+
+;; Used in the expansion of a `class` body (and similar),
+;; where the expansion of a clause should not be treated
+;; as a sequence of tail expressions and definitions
+(define-decl-syntax sentinel_declaration
+  (nestable-declaration-transformer
+   (lambda (stx name-prefix)
+     #'())))

--- a/rhombus-lib/rhombus/private/amalgam/space-clause-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/space-clause-primitive.rkt
@@ -121,4 +121,6 @@
        (when (hash-ref options '#:meta_namespace #f)
          (raise-syntax-error #f "multiple meta namespaces declared" orig-stx #'name))
        (hash-set options '#:meta_namespace (cons #'name #'content))]
+      [(_ (#:post-forms (form ...))) ; added directly in `enforest-body-step`
+       (hash-set options '#:post-forms (syntax->list #'(form ...)))]
       [_ (error "unhandled option" option)])))

--- a/rhombus-lib/rhombus/private/amalgam/space-clause.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/space-clause.rkt
@@ -13,7 +13,8 @@
 
 (begin-for-syntax
   (provide (property-out space-clause-transformer)
-           :space-clause)
+           :space-clause
+           space-clause?)
 
   (property space-clause-transformer transformer)
 
@@ -21,6 +22,7 @@
 
   (define-rhombus-transform
     #:syntax-class :space-clause
+    #:predicate space-clause?
     #:desc "space transform clause"
     #:parsed-tag #:rhombus/space_clause
     #:in-space in-space-clause-space

--- a/rhombus-lib/rhombus/private/amalgam/space-meta-clause-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/space-meta-clause-primitive.rkt
@@ -175,5 +175,7 @@
       [(_ (#:identifier_transformer stx e))
        (check "identifier parser expressions" #:enforest-only? #t)
        (hash-set options '#:identifier_transformer #'e)]
+      [(_ (#:post-forms (form ...))) ; added directly in `enforest-meta-body-step`
+       (hash-set options '#:post-forms (syntax->list #'(form ...)))]
       [else
        (error "unhandled" option)])))

--- a/rhombus-lib/rhombus/private/amalgam/space-meta-clause.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/space-meta-clause.rkt
@@ -16,7 +16,8 @@
 
 (begin-for-syntax
   (provide (property-out space-meta-clause-transformer)
-           :space-meta-clause)
+           :space-meta-clause
+           space-meta-clause?)
 
   (property space-meta-clause-transformer transformer)
 
@@ -27,6 +28,7 @@
 
   (define-rhombus-transform
     #:syntax-class :space-meta-clause
+    #:predicate space-meta-clause?
     #:desc "class clause"
     #:parsed-tag #:rhombus/space_meta_clause
     #:in-space in-space-meta-clause-space

--- a/rhombus-lib/rhombus/private/amalgam/veneer-clause-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/veneer-clause-macro.rkt
@@ -8,7 +8,9 @@
                      "syntax-wrap.rkt")
          "space-provide.rkt"
          "veneer-clause.rkt"
-         "macro-macro.rkt")
+         "macro-macro.rkt"
+         "definition.rkt"
+         "bounce-to-definition.rkt")
 
 (define+provide-space veneer_clause rhombus/veneer_clause
   #:fields
@@ -27,3 +29,9 @@
      (unless (syntax*? defns)
        (raise-bad-macro-result (proc-name proc) "`veneer` clause" defns))
      (datum->syntax #f (unpack-multi defns proc #f)))))
+
+;; See use of `bounce-to-definition` in "class-clause-macro.rkt"
+(define-veneer-clause-syntax macro
+  (veneer-clause-transformer
+   (lambda (stx data)
+     (bounce-to-definition (defn-quote macro) stx))))

--- a/rhombus-lib/rhombus/private/amalgam/veneer-clause.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/veneer-clause.rkt
@@ -19,7 +19,8 @@
 (begin-for-syntax
   (provide (property-out veneer-clause-transformer)
            :veneer-clause
-           :veneer-clause-form)
+           :veneer-clause-form
+           veneer-clause?)
 
   (property veneer-clause-transformer transformer)
 
@@ -38,6 +39,7 @@
 
   (define-rhombus-transform
     #:syntax-class (:veneer-clause veneer-data)
+    #:predicate veneer-clause?
     #:desc "veneer clause"
     #:parsed-tag #:rhombus/veneer_clause
     #:in-space in-veneer-clause-space

--- a/rhombus-lib/rhombus/private/amalgam/veneer.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/veneer.rkt
@@ -57,6 +57,7 @@
                                           #,(attribute ann-op.check?) ann-op.name (ann-term ...)]
                                 ;; data accumulated from parsed clauses:
                                 ()))
+         (annotation-to-be-defined! #'name)
          #`(#,(cond
                 [(null? (syntax-e body))
                  #`(veneer-annotation+finish #,finish-data [#:ctx base-stx base-stx] ())]
@@ -67,6 +68,7 @@
 
 (define-class-body-step veneer-body-step
   :veneer-clause
+  veneer-clause?
   veneer-expand-data
   class-clause-accum)
 
@@ -222,7 +224,7 @@
 
        (define exs (parse-exports #'(combine-out . exports) expose))
        (define replaced-ht (check-exports-distinct stxes exs null method-mindex dots))
-<
+
        (define has-private?
          ((hash-count method-private) . > . 0))
 
@@ -238,6 +240,8 @@
        (define-values (container? here-container? public-container?)
          (able-method-status 'contains super interfaces method-mindex method-vtable method-private
                              #:name 'contains))
+
+       (define post-forms (hash-ref options 'post-forms null))
 
        (define (temporary template)
          ((make-syntax-introducer) (datum->syntax #f (string->symbol (format template (syntax-e #'name))))))
@@ -352,7 +356,9 @@
                                      #'super-call-statinfo-indirect
                                      #:checked-append? #f
                                      #:checked-compare? #f))))
-           #`(begin . #,defns)))])))
+           #`(begin
+               #,@defns
+               #,@post-forms)))])))
 
 (define-for-syntax (build-veneer-annotation converter? super interfaces names)
   (with-syntax ([(name name-extends name? name-convert

--- a/rhombus/rhombus/scribblings/guide/class-namespace.scrbl
+++ b/rhombus/rhombus/scribblings/guide/class-namespace.scrbl
@@ -33,7 +33,8 @@ definitions are accessible outside the class only if they are exported.
 
 There's a subtlety, however, when definitions within the @rhombus(class)
 body try to refer to the class. Unless the reference is sufficiently
-nested, it can't work, because the class is not defined until all of the
+nested or late enough in the @rhombus(class) body, it can't work,
+because the class is not defined until enough of the
 class body forms are processed.
 
 @examples(
@@ -45,7 +46,26 @@ class body forms are processed.
           origin
 )
 
-One way around this problem is to not put the definition inside the
+In this example, the solution can be simply to move the @rhombus(export)
+declaration earlier:
+
+@examples(
+  ~repl:
+    class Posn(x, y):
+      export:
+        origin
+      def origin = Posn(0, 0)
+    Posn.origin
+)
+
+This change works because definitions and expressions in a
+@rhombus(class) body are effectively moved after the class's definition
+when there is no class clause or declaration form afterward. Moving the
+@rhombus(export) declaration form before the definition of
+@rhombus(origin) means that @rhombus(Posn) can be defined before
+@rhombus(origin)'s right-hand side is evaluated.
+
+A related way around the problem is to not put the definition inside the
 class, but still export it from the class. Just like in
 @rhombus(namespace), an @rhombus(export) form in @rhombus(class) can
 export any binding that is visible in the environment, including things
@@ -63,8 +83,13 @@ defined outside the @rhombus(class) form.
     Posn.origin.x
 )
 
-Another solution is to use @rhombus(class.together), as described in the
-next section, but putting helper definitions after the class can avoid a
+The only drawback with this strategy is that the inferred name in a
+definition (typically for error-reporting purposes) will not have the
+class name as a prefix automatically.
+
+Yet another solution is to use @rhombus(class.together), as described in the
+next section, but putting helper definitions at the end of the @rhombus(class)
+body or after the class can avoid a
 small amount of overhead for instance checks.
 
 

--- a/rhombus/rhombus/scribblings/meta/class-clause-macro.scrbl
+++ b/rhombus/rhombus/scribblings/meta/class-clause-macro.scrbl
@@ -45,6 +45,7 @@
                    $body
                    ...
                | ...»'
+  class_clause.macro 'class_clause.macro $macro_decl'
   grammar option:
     ~op_stx: $id
     ~op_stx $id
@@ -56,7 +57,10 @@
 
  Like @rhombus(defn.macro), but defines a name in the
  @rhombus(class_clause, ~space) @tech{space} as a clause form for use
- within a @rhombus(class) body.
+ within a @rhombus(class) body. The @rhombus(class_clause.macro) is itself
+ bound as a @tech(~doc: ref_doc){class clause} so that it will take effect within a
+ @rhombus(class) body for later forms, even if no other clause
+ or declaration follows it.
 
  The compile-time @rhombus(body) block returns the expansion result. The
  result must be a sequence of groups to be spliced in place of the macro
@@ -104,6 +108,8 @@
                    $body
                    ...
                | ...»'
+
+  interface_clause.macro 'interface_clause.macro $macro_decl'
 ){
 
  Like @rhombus(class_clause.macro), but for @rhombus(interface)
@@ -128,6 +134,9 @@
                    $body
                    ...
                | ...»'
+
+  class_clause.macro 'class_and_interface_clause.macro $macro_decl'
+  interface_clause.macro 'class_and_interface_clause.macro $macro_decl'
 ){
 
  Like @rhombus(class_clause.macro), but defines for use both in
@@ -152,6 +161,8 @@
                    $body
                    ...
                | ...»'
+
+  veneer_clause.macro 'veneer_clause.macro $macro_decl'
 ){
 
  Like @rhombus(class_clause.macro), but for @rhombus(veneer)

--- a/rhombus/rhombus/scribblings/meta/decl-macro.scrbl
+++ b/rhombus/rhombus/scribblings/meta/decl-macro.scrbl
@@ -13,7 +13,7 @@
 ){
 
  The @tech{space} for bindings of identifiers that can be used in
- declaration and nestable-declaration positions.
+ @tech{declaration} and @tech{nestable-declaration} positions.
 
 }
 
@@ -37,8 +37,9 @@
   defn.macro 'decl.macro $prefix_macro_patterns'
 ){
 
- Like @rhombus(defn.macro) but for defining a macro that can be used
- only in a module or interactive position --- the same places where
+ Like @rhombus(defn.macro) but for defining a macro in
+ @deftech{declaration} positions, which are in
+ in a module or interactive position---the same places where
  @rhombus(meta) and @rhombus(module) are allowed, for example.
 
 }
@@ -50,7 +51,8 @@
 ){
 
  Like @rhombus(defn.macro), but for forms that can also be used in
- namespaces that are within a module or interactive position --- the same
+ @deftech{nestable-declaration} positions, which includes
+ namespaces that are within a module or interactive position---the same
  places where @rhombus(export) is allowed, for example.
 
 }
@@ -63,8 +65,8 @@
     kind: ~group
 ){
 
- Like @rhombus(defn_meta.Group, ~stxclass), but for declarations and
- nestable declarations. The @rhombus(decl_meta.Group, ~stxclass) syntax
+ Like @rhombus(defn_meta.Group, ~stxclass), but for @tech{declarations} and
+ @tech{nestable declarations}. The @rhombus(decl_meta.Group, ~stxclass) syntax
  class matches all groups that
  @rhombus(decl_meta.NestableGroup, ~stxclass) matches, plus ones that
  cannot be nested.

--- a/rhombus/rhombus/scribblings/meta/space.scrbl
+++ b/rhombus/rhombus/scribblings/meta/space.scrbl
@@ -97,7 +97,9 @@ driver and macro-definitions forms.
  defined as a @tech(~doc: ref_doc){namespace}. Among the
  @rhombus(space_clause_or_body_or_export)s, @rhombus(nestable_body)
  forms can add definitions and exports to the namespace, the same as for
- @rhombus(namespace). However, the namespace is particularly intended to
+ @rhombus(namespace) and @rhombus(class) (and definitions among the
+ @rhombus(space_clause_or_body_or_export)s are ordered as in a @rhombus(class)
+ body with respect to the definition of the space itself). However, the namespace is particularly intended to
  export the name specified by @rhombus(macro_definer, ~space_clause).
  That name is conventionally @rhombus(macro, ~datum).
  As a somewhat lower-level mechanism, @rhombus(bridge_definer, ~space_clause)

--- a/rhombus/rhombus/scribblings/reference/class.scrbl
+++ b/rhombus/rhombus/scribblings/reference/class.scrbl
@@ -193,11 +193,16 @@
  to @rhombus(namespace) in that local definitions can be exported.
  Exported names can replace non-private field, method, and property
  names, which are otherwise exported automatically, but exported names
- must be distinct from dot-syntax names. Since the definitions and expressions of a @rhombus(class)
- body must be processed to find @tech{class clauses} in the body, the
- class is not available for use until after the definitions and
- expressions, as if the definitions and expressions appeared before the
- @rhombus(class) form.
+ must be distinct from dot-syntax names. The definitions and expressions of a @rhombus(class)
+ body are expanded and parsed in order as mixed with @tech{class clauses}, and
+ a definition might even introduce a new class-clause form for use in the same
+ body. Any definition
+ or expression that is not followed by a class clause or @tech(~doc: meta_doc){nestable declaration}
+ is deferred until after the class is defined (but still can be exported).
+ Definitions and expressions before a class clause or nestable declaration are effectively
+ moved before the class definition, which limits the ways that the class name can be
+ used in those definitions. When an expression or definition is in the expansion
+ of a @tech{class clauses}, then it is treated as having a class clause afterward.
 
  When a @rhombus(class_clause) is a @rhombus(field, ~class_clause) or @rhombus(immutable, ~class_clause) form,
  then an additional field is added to the class, but the additional field

--- a/rhombus/rhombus/tests/class-clause.rhm
+++ b/rhombus/rhombus/tests/class-clause.rhm
@@ -545,3 +545,35 @@ check:
       _World
       _Some
   ~throws "internal: multiple ids not allowed"
+
+// Make sure `class_clause.macro` in `class` takes effect
+check:
+  class Posn(x, y):
+    class_clause.macro 'foo':
+      'method m(): "M"'
+    foo
+  Posn(0, 1).m()
+  ~is "M"
+check:
+  class Posn(x, y):
+    class_and_interface_clause.macro 'foo':
+      'method m(): "M2"'
+    foo
+  Posn(0, 1).m()
+  ~is "M2"
+check:
+  interface Pointy:
+    interface_clause.macro 'foo':
+      'method m(): "M2"'
+    foo
+  class Posn(x, y):
+    implements Pointy  
+  Posn(0, 1).m()
+  ~is "M2"
+check:
+  veneer Posn(this :: Int):
+    veneer_clause.macro 'foo':
+      'method m(): "M"'
+    foo
+  (10 :: Posn).m()
+  ~is "M"

--- a/rhombus/rhombus/tests/class.rhm
+++ b/rhombus/rhombus/tests/class.rhm
@@ -1228,3 +1228,34 @@ block:
   check Orange() ~is_a Pear
   check Orange() ~is_a Apple
   check Orange() ~is_a IB
+
+check:
+  ~eval
+  class Posn(x, y):
+    def origin = Posn(0, 0)
+    export:
+      origin
+  ~throws "cannot reference an identifier before its definition"
+
+check:
+  ~eval
+  class Posn(x, y):
+    fun make_origin() :: Posn: Posn(0, 0)
+    export:
+      make_origin
+  ~throws "use of an annotation before its definition is complete"
+
+block:
+  class Posn(x, y):
+    export:
+      origin
+    def origin = Posn(0, 0)
+  check Posn.origin ~is Posn(0, 0)
+
+block:
+  class Posn(x, y):
+    export:
+      make_origin
+    fun make_origin() :: Posn: Posn(0, 0)
+  check Posn.make_origin() ~is Posn(0, 0)
+

--- a/rhombus/rhombus/tests/enforest-intro.rhm
+++ b/rhombus/rhombus/tests/enforest-intro.rhm
@@ -122,3 +122,15 @@ meta:
       'myspace_meta.Parsed'
   fun bar('$(_ :: foo.Parsed)'):
     #void
+
+// check that edefinitions at the end of `meta_namespace` can
+// see the syntax class
+space.enforest myspace2:
+  space_path myspace
+  meta_namespace myspace2_meta:
+    parse_syntax_class Parsed
+    fun parse_1(stx):
+      let '$(parsed :: Parsed)' = stx
+      parsed
+    fun parse_2('$(parsed :: Parsed)'):
+      parsed


### PR DESCRIPTION
The change addresses #669 (because `space.enforest`, etc., bodies are treated like `class`) as well as the problem described in the "Class Namespaces" section of the guide (which is currently section 4.8). It doesn't add any new syntax, but instead adjusts the way that definitions and expressions at the end of a `class`, `interface`, `veneer`, `space.enforest`, or `meta_namespace` form are treated. Definitions and expressions that do not have any clauses or declaration afterward are handled after the definition of the enclosing class, etc., instead of before.

For example, this definition (from the Guide) is still an error, because `export` follows the definition of `origin`, and exports are needed to fully determine the definition of `Posn`:

```
class Posn(x, y):
    def origin = Posn(0, 0)
    export:
      origin
```

But the example can be repaired by simplying moving the `export` form to the start of the `class` body:

```
class Posn(x, y):
    export:
      origin
    def origin = Posn(0, 0)
```

This works because definitions and expressions that are not followed by any clauses or declarations are effectively moved after the class definition, instead of before.

This is a subtle rule. The idea is to still allow definitions within a `class` to affect later class clauses, but to take advantage of the fact that definitions after any clauses are not going to affect any clauses, so they can be delayed. (What if the definition introduces a new clause form that is later used within the same body? This problem is avoided by binding `class_clause.macro` itself as a class clause.) I expect that not much existing code will be affected, but the update in this commit to "rhombus-draw-lib/rhombus/draw/private/dc.rhm" illustrates how existng code might rely on tail definitions preceding a class (or one of its clauses).

More generally, the idea is that moving a definition later is a natural thing to try when things don't work, so when a Rhombus user encouteres a problem, they are likely to discover the right pattern without scrutinizing the documentation. To help a user more, the error message is improved here when a class name is used as an annotation too early, since that's seems to be the most common problem with a previously confusing error message ("not defined" instead of "used before it's ready").