### PR TITLE
add `statinfo_meta.none_key` and specialize `||` and `statinfo_meta.or`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -1026,7 +1026,7 @@
 (void (set-primitive-contract! 'flonum? "Flonum"))
 (void (set-primitive-contract! 'fixnum? "Fixnum"))
 (define-annotation-syntax Any (identifier-annotation (lambda (x) #t) ()))
-(define-annotation-syntax None (identifier-annotation (lambda (x) #f) ()))
+(define-annotation-syntax None (identifier-annotation (lambda (x) #f) ((#%none #t))))
 (define-annotation-syntax Boolean (identifier-annotation boolean? ()))
 (define-annotation-syntax Int (identifier-annotation exact-integer? #,(get-int-static-infos)))
 (define-annotation-syntax PosInt (identifier-annotation exact-positive-integer? #,(get-int-static-infos)))
@@ -1269,7 +1269,9 @@
                        (lambda (v)
                          (or (equal-always? lit v)
                              ...)))
-                   #'())
+                   (if (null? (syntax->list #'(lit ...)))
+                       #'((#%none #true))
+                       #'()))
                   #'tail))]))))
 
 (define-annotation-syntax Any.to_boolean

--- a/rhombus-lib/rhombus/private/amalgam/control.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/control.rkt
@@ -15,6 +15,7 @@
          (submod "function-parse.rkt" for-build)
          (submod "equal.rkt" for-parse)
          "function-arity-key.rkt"
+         "call-result-key.rkt"
          "static-info.rkt"
          (submod "function.rkt" for-info)
          "if-blocked.rkt"
@@ -173,7 +174,10 @@
    '((default . weaker))
    'automatic
    (lambda (form1 op-stx)
-     #`(raise #,(discard-static-infos form1)))))
+     (wrap-static-info
+      #`(raise #,(discard-static-infos form1))
+      #'#%none
+      #'#true))))
 
 (void (set-primitive-who! 'call-with-composable-continuation 'Continuation.capture))
 (define-syntax capture
@@ -311,6 +315,7 @@
                #:tag [prompt-tag (default-continuation-prompt-tag)]
                . vals)
   #:primitive (abort-current-continuation)
+  #:static-infos ((#%call-result ((#%none #t))))
   (apply abort-current-continuation prompt-tag vals))
 
 (define Continuation.PromptTag.default

--- a/rhombus-lib/rhombus/private/amalgam/error.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/error.rhm
@@ -58,7 +58,7 @@ fun error(~srcloc: srcloc :: maybe(Srcloc) = #false,
           // or `error.text`; each `clause` starts its own line with
           // a 2-space prefix:
           clause :: error.Clause,
-          ...):
+          ...) :~ None:
   let msg = message(~srcloc: srcloc,
                     ~who: who,
                     ~realm: realm,

--- a/rhombus-lib/rhombus/private/amalgam/static-info-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/static-info-macro.rkt
@@ -97,7 +97,8 @@
      pairlist_bounds_key
      maybe_key
      values_key
-     indirect_key)))
+     indirect_key
+     none_key)))
 
 (define-for-syntax (make-static-info-macro-macro in-space convert-id)
   (definition-transformer
@@ -181,7 +182,7 @@
      [(group t) #'t]
      [g #'g])))
 
-(define-for-syntax (static-infos-merge who statinfos-unpacked merge)
+(define-for-syntax (static-infos-merge who statinfos-unpacked merge zero)
   (define statinfos
     (for/list ([stx (in-list statinfos-unpacked)])
       (check-syntax who stx)
@@ -189,7 +190,7 @@
   (unpack-static-infos
    who
    (if (null? statinfos)
-       #'()
+       zero
        (for/fold ([merged (car statinfos)]) ([statinfo (in-list (cdr statinfos))])
          (merge merged statinfo)))))
 
@@ -382,11 +383,11 @@
 
   (define/arity (statinfo_meta.or . statinfos)
     #:static-infos ((#%call-result #,(get-syntax-static-infos)))
-    (static-infos-merge who statinfos static-infos-or))
+    (static-infos-merge who statinfos static-infos-or #'((#%none #t))))
 
   (define/arity (statinfo_meta.and . statinfos)
     #:static-infos ((#%call-result #,(get-syntax-static-infos)))
-    (static-infos-merge who statinfos static-infos-and)))
+    (static-infos-merge who statinfos static-infos-and #'())))
 
 (define-syntax-rule (define-key key id)
   (begin-for-syntax
@@ -412,3 +413,4 @@
 (define-key fixnum_key #%fixnum)
 (define-key values_key #%values)
 (define-key indirect_key #%indirect-static-info)
+(define-key none_key #%none)

--- a/rhombus-lib/rhombus/private/amalgam/syntax-meta.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/syntax-meta.rkt
@@ -12,6 +12,7 @@
                      "call-result-key.rkt"
                      "name-root.rkt"
                      (submod "annotation.rkt" for-class)
+                     (only-in "static-info.rkt" #%none)
                      (for-syntax racket/base)
                      (submod "syntax-object.rkt" for-quasiquote)
                      "srcloc.rkt"
@@ -125,6 +126,7 @@
                                    form/msg
                                    [form unsafe-undefined]
                                    [detail unsafe-undefined])
+    #:static-infos ((#%call-result ((#%none #t))))
     (define who-in
       (cond
         [(or (not m-who) (symbol? m-who)) m-who]

--- a/rhombus/rhombus/scribblings/meta/static-info.scrbl
+++ b/rhombus/rhombus/scribblings/meta/static-info.scrbl
@@ -279,17 +279,23 @@
  is the ``and'' or ``or'' of all given information.
 
  An ``and'' combination corresponds to the @rhombus(&&, ~annot)
- annotation operator; from the perspective of static-information keys and
+ annotation operator. From the perspective of static-information keys and
  values, it's like a union: any key that is in a @rhombus(statinfo_stx)
  argument is included in the result, and if multiple
  @rhombus(statinfo_stx) arguments have the key, the values associated
- with those keys will be ``and''ed.
+ with those keys will be ``and''ed. That combination is true even if
+ one of the @rhombus(statinfo_stx) arguments has the static information of
+ @rhombus(None, ~annot) as represented by @rhombus(statinfo_meta.none_key).
 
- An ``or combination corresponds to the @rhombus(||, ~annot) annotation
- operator; from the perspective of static-information keys and values,
+ An ``or'' combination corresponds to the @rhombus(||, ~annot) annotation
+ operator. From the perspective of static-information keys and values,
  it's like an intersection: only a key that is in all
  @rhombus(statinfo_stx) arguments is included in the result, and the
  value in each @rhombus(statinfo_stx) is ``or''ed for the result.
+ However, if a @rhombus(statinfo_stx) argument has the static information of
+ @rhombus(None, ~annot), that @rhombus(statinfo_stx) is effectively discarded.
+ If no @rhombus(statinfo_stx) arguments are provided to @rhombus(statinfo_meta.or),
+ the result is the same static information as for @rhombus(None, ~annot).
 
 }
 
@@ -350,6 +356,7 @@
   def statinfo_meta.fixnum_key :: Identifier
   def statinfo_meta.values_key :: Identifier
   def statinfo_meta.indirect_key :: Identifier
+  def statinfo_meta.none_key :: Identifier
 ){
 
  Values that can be used to associate static information with an
@@ -453,6 +460,11 @@
   @item{@rhombus(statinfo_meta.indirect_key): An identifier whose
         static information is lazily spliced in place of this key
         and identifier.}
+
+  @item{@rhombus(statinfo_meta.none_key): Any value, but normally
+        @rhombus(#true), where the presence of this key indicates
+        the static information of @rhombus(None, ~annot): a claim
+        that no value is possible at run time.}
 
 )
 

--- a/rhombus/rhombus/scribblings/reference/annotation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/annotation.scrbl
@@ -90,8 +90,17 @@
 
  The @rhombus(None, ~annot) annotation matches no values, or in other
  words, is equivalent to @rhombus(Any.of(), ~annot). It is useful for
- asserting that something never returns, such as a function that
- always throws.
+ asserting that something never returns, such as a function that always
+ throws an exception. The annotation
+ @rhombus(None || #,(@rhombus(ann, ~var)), ~annot) is equivalent to
+ @rhombus(ann, ~var), since any value that satisfies the annotation must
+ satisfy @rhombus(ann, ~var). In principle, @rhombus(None, ~annot) would
+ imply any other annotation and provide all static information; instead,
+ as a pratical compromise, @rhombus(None, ~annot) provides no oher static
+ information. As a further practical choice along those lines, the annotation
+ @rhombus(None && #,(@rhombus(ann, ~var)), ~annot) implies all the static
+ information of @rhombus(ann, ~var), while still behaving like
+ @rhombus(None, ~annot) for further combinations via @rhombus(||, ~annot).
 
  See @secref(~doc: guide_doc, "annotation-satisfying") for information
  about the time that @rhombus(expr) is evaluated.

--- a/rhombus/rhombus/scribblings/reference/boolean.scrbl
+++ b/rhombus/rhombus/scribblings/reference/boolean.scrbl
@@ -96,8 +96,9 @@
  Creates an annotation that accepts a value satisfying either
  @rhombus(left_annot) or @rhombus(right_annot). The static information
  implied by the annotation is the @rhombus(statinfo_meta.or) of information for
- @rhombus(left_annot) and @rhombus(right_annot), which means information for a key
- must appear in both for the key to be part of the implied annotation.
+ @rhombus(left_annot) and @rhombus(right_annot), which means that information for a key
+ must appear in both for the key to be part of the implied annotation (except
+ that @rhombus(None, ~annot) is treated specially).
 
  The annotations are checked in other. Either or both of
  @rhombus(left_annot) and @rhombus(right_annot) can be a @tech(~doc: guide_doc){converter

--- a/rhombus/rhombus/scribblings/reference/exn.scrbl
+++ b/rhombus/rhombus/scribblings/reference/exn.scrbl
@@ -125,6 +125,9 @@
  thrown, but typically thrown values are instances of a subclass of
  @rhombus(Exn, ~class).
 
+ Since it does not return a value, a @rhombus(throw) expression has the
+ static information of @rhombus(None, ~annot).
+
 }
 
 

--- a/rhombus/rhombus/tests/annotation.rhm
+++ b/rhombus/rhombus/tests/annotation.rhm
@@ -363,3 +363,19 @@ check:
 check:
   error("left") is_a converting(fun (x :: satisfying(error("right"))): x)
   ~throws "left"
+
+block:
+  use_static
+  check ([] || (0 :: None)).length() ~is 0
+  check ((0 :: None) || []).length() ~throws error.annot_msg()
+  check ((dynamic([]) :: maybe(List))!! || error("oops")).length() ~is 0
+  check ((dynamic([]) :: maybe(List))!! || throw #'bye).length() ~is 0
+  check (fun (x :: (List || None)): x.length()) ~completes
+  check (fun (x :: (List && None)): x.length()) ~completes // analogous to `List && String`
+  check 10 is_a (Int && None) ~is #false
+
+check:
+  ~eval
+  use_static
+  fun (x :: None): x.length()
+  ~throws "no such field or method"

--- a/rhombus/rhombus/tests/static_arity.rhm
+++ b/rhombus/rhombus/tests/static_arity.rhm
@@ -85,7 +85,7 @@ expr.macro 'static_arity_check $(pattern:
            | '($(_ :: Identifier), $arg, ...)':
                let '$annot ... . $(method :: Term)' = pres
                let annot = method_annot || '$annot ...'
-               let pres = '($(make_error(#false)) :~ $annot) . $method'
+               let pres = '(dynamic($(make_error(#false))) :~ $annot) . $method'
                let args = '($arg, ...)'
                finish("method", pres, args)
            | ~else:

--- a/rhombus/rhombus/tests/statinfo-macro.rhm
+++ b/rhombus/rhombus/tests/statinfo-macro.rhm
@@ -85,7 +85,7 @@ block:
     meta -1: rhombus/meta open
   check:
     statinfo_meta.and() ~matches '()'
-    statinfo_meta.or() ~matches '()'
+    statinfo_meta.or() ~matches '(($(statinfo_meta.none_key), #true))'
 
 block:
   use_static


### PR DESCRIPTION
Change the `None` annotation to imply `statinfo_meta.none_key`, which is specially recognized by the `||` annotation so that `None || ann` is the same as `ann`.

The `&&` turns out not to treat `None` specially, and so something like `(error("oops") :~ List).length()` is allowed in static mode. In principle, `(x :~ None).length()` also should be allowed, but `None` here doesn't attempt to provide all static information for all annotations; it just provides the static information with key `statinfo_meta.none_key`.