### PR TITLE
add a `deepen` repetition form

### DIFF
--- a/rhombus-lib/info.rkt
+++ b/rhombus-lib/info.rkt
@@ -16,4 +16,4 @@
 (define license '(Apache-2.0 OR MIT))
 
 ;; keep in sync with runtime version at "rhombus/private/amalgam/version.rkt"
-(define version "0.41")
+(define version "0.42")

--- a/rhombus-lib/rhombus/private/amalgam/version.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/version.rkt
@@ -3,4 +3,4 @@
 (provide version)
 
 ;; keep in sync with package version at "../../../info.rkt"
-(define version "0.41")
+(define version "0.42")

--- a/rhombus/rhombus/scribblings/reference/repetition.scrbl
+++ b/rhombus/rhombus/scribblings/reference/repetition.scrbl
@@ -87,6 +87,8 @@ to match a repetition of depth 2:
 In other words, unless otherwise documented, the depth of a repetition
 formed by combining repetitions is the maximum of the depths of the
 combined repetitions, so @rhombus(z+y) is a repetition of depth 2.
+See also @rhombus(deepen, ~repet) for more explicit control over
+repetition deepening.
 
 Expressions with side effects or short-circuiting operators can appear
 within a repetition. Each effect and control-flow choice is applied on
@@ -221,7 +223,55 @@ positions.
  to provide a clearer message when @rhombus(index) was meant to be used
  in a repetition context.
 
+}
 
+
+@doc(
+  ~nonterminal:
+    shallow_repet: block repet
+    deep_repet: block repet
+  repet.macro 'deepen $shallow_repet ~like $deep_repet'
+  repet.macro 'deepen $shallow_repet ~like_inner $deep_repet'
+  expr.macro 'deepen'
+){
+
+ Creates a repetition that has the elements of @rhombus(shallow_repet),
+ but the depth of @rhombus(deep_repet). The @rhombus(shallow_repet) is
+ deepened by repeating elements in a way that depends on whether
+ @rhombus(~like) or @rhombus(~like_inner) is used:
+
+ @itemlist(
+  
+  @item{With @rhombus(~like), the overall repetition
+  @rhombus(shallow_repet) is repeated as many times as needed to match the
+  outermost layers of @rhombus(deep_repet). This is the same kind of
+  deepening that is performed automatically when repetitions of different
+  depths are under a shared @dots_expr.}
+
+  @item{With @rhombus(~like_inner), the repetition
+  @rhombus(shallow_repet) is expected to match the outermost repetitions
+  of @rhombus(deep_repet) in lengths, and the innermost element of
+  @rhombus(shallow_repet) is repeated for each further inner repetition
+  layer of @rhombus(deep_repet). If the outermost repetition counts of
+  @rhombus(shallow_repet) and @rhombus(deep_repet) do not match, a
+  mismatch exception is thrown when the repetition is used.}
+)
+
+@examples(
+  ~repl:
+    def [x, ...] = ["a", "b"]
+    [deepen 0 ~like x, ...]
+  ~repl:
+    def [[y, ...], ...] = [[1, 2, 3], [4, 5]]
+    [[deepen 0 ~like y, ...], ...]
+    [[deepen x ~like y, ...], ...]
+    [[deepen x ~like_inner y, ...], ...]
+    [[{deepen x ~like_inner y, y}, ...], ...]
+)
+
+ The @rhombus(deepen) expression form is always an error. It is intended
+ to provide a clearer message when @rhombus(deepen) was meant to be used
+ in a repetition context.
 
 }
 

--- a/rhombus/rhombus/tests/repetition.rhm
+++ b/rhombus/rhombus/tests/repetition.rhm
@@ -524,3 +524,18 @@ version_guard.at_least "9.0.0.2":
     let [y, ...] = [1, 2]
     [[x, y], ...]
     ~throws "incompatible repetition lengths for ellipsis"
+
+block:
+  let [x, ...] = ["a", "b"]
+  check [{0, x}, ...] ~is [{0, "a"}, {0, "b"}]
+  check [deepen 0 ~like x, ...] ~is [0, 0]
+  let [[y, ...], ...] = [[1, 2, 3], [4, 5]]
+  check [[{0, y}, ...], ...] ~is [[{0, 1}, {0, 2}, {0, 3}], [{0, 4}, {0, 5}]]
+  check [[{deepen 0 ~like y, y}, ...], ...] ~is [[{0, 1}, {0, 2}, {0, 3}], [{0, 4}, {0, 5}]]
+  check [[deepen 0 ~like y, ...], ...] ~is [[0, 0, 0], [0, 0]]
+  check [[deepen x ~like y, ...], ...] ~is  [["a", "b"], ["a", "b"]]
+  check [[deepen x ~like_inner y, ...], ...] ~is [["a", "a", "a"], ["b", "b"]]
+  check [[{deepen x ~like_inner y, y}, ...], ...] ~is [[{"a", 1}, {"a", 2}, {"a", 3}], [{"b", 4}, {"b", 5}]]
+  version_guard.at_least "9.0.0.2":
+    check [[{x, y}, ...], ...] ~throws "incompatible repetition lengths for ellipsis"
+    check [[{deepen x ~like y, y}, ...], ...] ~throws "incompatible repetition lengths for ellipsis"


### PR DESCRIPTION
The repetition `deepen a ~like b` performs the same kind of deepening of `a` that is implicit when it is under the same set of ellipses as `b`, but without returning the elements of `b`. Due to that implicit deepening, it turns out to equivalent to the repetition `block: b; a`, but expressed more directly. Either way, the repetition `a` is deepened by repeating the whole repetition as many times as needed to match the outer repetitions of `b`. The innermost reptitions of `a` and `b` must have the same lengths (or else using the repetition will throw a mismatch error).

```
> def [x, ...] = ["a", "b"]
> [deepen 0 ~like x, ...]
[0, 0]

> def [[z, ...], ...] = [[1, 2], [3, 4], [5, 6]]
> [[{x, z}, ...], ...]
[[{1, "a"}, {2, "b"}], [{3, "a"}, {4, "b"}], [{5, "a"}, {6, "b"}]]
> [[{deepen x ~like z, z}, ...], ...]
[[{1, "a"}, {2, "b"}], [{3, "a"}, {4, "b"}], [{5, "a"}, {6, "b"}]]

> def [[z2, ...], ...] = [[1, 2], [3, 4, 7], [5, 6]]
> [[{deepen x ~like z2, z2}, ...], ...]
error: incompatible repetition lengths
```

The repetition `deepen a ~like_inner b` also produces a repetition with the same depth as `b`, but by repeating the innermost elements of `a` as many times as needed to match the inner repetitions of `b`. The outermost repetitions of `a` and `b` must have the same lengths (or else using the repetition will throw a mismatch error).

```
> def [[y, ...], ...] = [[1, 2, 3], [4, 5]]
> [[{x, y}, ...], ...]
error: incompatible repetition lengths
> [[{deepen x ~like_inner y, y}, ...], ...]
[[{1, "a"}, {2, "a"}, {3, "a"}], [{4, "b"}, {5, "b"}]]
```

This last example illustrates how `deepen` can solve a problem where a repetition like `x` really wants to be connected to an ellipsis further out, but it's adjacent to a repetition `y` that needs an extra ellipsis, and that ellipsis also applies to `x`. It's a relatively rare problem, but it happens in the `datatype` expansion for Shplait, for example.

Redex has a different solution for this kind of problem, which is to label different ellipses so that you can be more specific about which ellipsis applies to which variables. That solution seems nicer overall, but it would require a whole new layer of machinery to make it work in Rhombus.