### PR TITLE
Repair default `#%effect` not printing multiple values

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/effect.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/effect.rkt
@@ -6,11 +6,15 @@
 
 (provide #%effect)
 
+(define (print-values . vals)
+  (for-each (current-print) vals)
+  (apply values vals))
+
 (define-syntax #%effect
   (expression-transformer
    (lambda (stx)
      (syntax-parse stx
        [(_ . tail)
         #:with e::expression #`(group . tail)
-        (values #'(call-with-values (lambda () e.parsed) (current-print))
+        (values #'(call-with-values (lambda () e.parsed) print-values)
                 #'())]))))


### PR DESCRIPTION
The default `#%effect` implementation introduced in b7949a0776 does not handle multiple return values.