### PR TITLE
implement `compare_to` operator

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/bytes.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bytes.rkt
@@ -40,7 +40,8 @@
                           (#%index-set Bytes.set)
                           (#%append Bytes.append)
                           (#%sequence-constructor Bytes.to_sequence/optimize)
-                          (#%compare ((< bytes<?)
+                          (#%compare ((compare_to bytes-compare-to)
+                                      (< bytes<?)
                                       (<= bytes<=?)
                                       (= bytes=?)
                                       (!= bytes!=?)
@@ -173,20 +174,31 @@
   #:static-infos ((#%call-result #,(get-bytes-static-infos)))
   (bytes->immutable-bytes bstr))
 
+(define (raise-bytes-comp-failure who a b)
+  (raise-annotation-failure who (if (bytes? a) b a) "Bytes"))
+
 (define (bytes!=? a b)
   (if (and (bytes? a) (bytes? b))
       (not (bytes=? a b))
-      (raise-annotation-failure '!= (if (bytes? a) b a) "Bytes")))
+      (raise-bytes-comp-failure '!= a b)))
 
 (define (bytes<=? a b)
   (if (and (bytes? a) (bytes? b))
       (not (bytes>? a b))
-      (raise-annotation-failure '<= (if (bytes? a) b a) "Bytes")))
+      (raise-bytes-comp-failure '<= a b)))
 
 (define (bytes>=? a b)
   (if (and (bytes? a) (bytes? b))
       (not (bytes<? a b))
-      (raise-annotation-failure '>= (if (bytes? a) b a) "Bytes")))
+      (raise-bytes-comp-failure '>= a b)))
+
+(define (bytes-compare-to a b)
+  (unless (and (bytes? a) (bytes? b))
+    (raise-bytes-comp-failure 'compare_to a b))
+  (cond
+    [(bytes=? a b) 0]
+    [(a . bytes<? . b) -1]
+    [else 1]))
 
 (begin-for-syntax
   (install-get-literal-static-infos! 'bytes get-bytes-static-infos))

--- a/rhombus-lib/rhombus/private/amalgam/class-method.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/class-method.rkt
@@ -470,10 +470,10 @@
                         [else
                          ;; veneer case: need to name methods explicitly, since
                          ;; there's no vtable associated with an instance
-                         (let ([methods '(less less_or_equal
-                                               compares_equal compares_unequal
-                                               greater_or_equal greater)]
-                               [ops '(< <= = != >= >)]
+                         (let ([methods '(compare_to less less_or_equal
+                                                     compares_equal compares_unequal
+                                                     greater_or_equal greater)]
+                               [ops '(compare_to < <= = != >= >)]
                                [addeds (for/hasheq ([a (in-list added-methods)])
                                          (values (syntax-e (added-method-id a)) a))])
                            (for/list ([name (in-list methods)]

--- a/rhombus-lib/rhombus/private/amalgam/keyword.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/keyword.rkt
@@ -18,7 +18,8 @@
   (provide (for-syntax get-keyword-static-infos)))
 
 (define-static-info-getter get-keyword-static-infos
-  (#%compare ((< keyword<?)
+  (#%compare ((compare_to keyword-compare-to)
+              (< keyword<?)
               (<= keyword<=?)
               (= keyword=?)
               (!= keyword!=?)
@@ -64,6 +65,13 @@
 (define (keyword>? a b)
   (check-keywords '> a b)
   (keyword<? b a))
+
+(define (keyword-compare-to a b)
+  (check-keywords 'compare_to a b)
+  (cond
+    [(eq? a b) 0]
+    [(a . keyword<? . b) -1]
+    [else 1]))
 
 (begin-for-syntax
   (install-get-keyword-static-infos! get-keyword-static-infos))

--- a/rhombus-lib/rhombus/private/amalgam/path-order.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-order.rkt
@@ -1,0 +1,38 @@
+#lang racket/base
+(require (submod "annotation.rkt" for-class))
+
+(provide cross-path-order)
+
+(define (cross-path-order who a b)
+  (cond
+    [(path? a)
+     (cond
+       [(path? b) (cond
+                    [(equal? a b) 0]
+                    [(a . path<? . b) -1]
+                    [else 1])]
+       [else
+        (unless (or (not who)
+                    (path-for-some-system? b))
+          (raise-annotation-failure who b "CrossPath"))
+        (if (eq? (path-convention-type a) 'unix)
+            -1
+            1)])]
+    [else
+     (unless (or (not who)
+                 (and (path-for-some-system? a)
+                      (path-for-some-system? b)))
+       (raise-annotation-failure who (if (path-for-some-system? a) b a) "CrossPath"))
+     (cond
+       [(eq? (path-convention-type a)
+             (path-convention-type b))
+        (define a-bstr (path->bytes a))
+        (define b-bstr (path->bytes b))
+        (cond
+          [(bytes=? a-bstr b-bstr) 0]
+          [(a-bstr . bytes<? . b-bstr) -1]
+          [else 1])]
+       [else
+        (if (eq? (path-convention-type a) 'unix)
+            -1
+            1)])]))

--- a/rhombus-lib/rhombus/private/amalgam/string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/string.rkt
@@ -68,7 +68,8 @@
   (#%index-result #,(get-char-static-infos))
   (#%append String.append)
   (#%sequence-constructor String.to_sequence/optimize)
-  (#%compare ((< string<?)
+  (#%compare ((compare_to string-compare-to)
+              (< string<?)
               (<= string<=?)
               (= string=?)
               (!= string!=?)
@@ -181,7 +182,8 @@
 (define-for-syntax (convert-string-ci-compare-static-info static-info)
   (syntax-parse static-info
     #:datum-literals (#%compare)
-    [(#%compare . _) #'(#%compare ((< string-ci<?)
+    [(#%compare . _) #'(#%compare ((compare_to string-ci-compare-to)
+                                   (< string-ci<?)
                                    (<= string-ci<=?)
                                    (= string-ci=?)
                                    (!= string-ci!=?)
@@ -208,7 +210,8 @@
 (define-for-syntax (convert-string-locale-compare-static-info static-info)
   (syntax-parse static-info
     #:datum-literals (#%compare)
-    [(#%compare . _) #'(#%compare ((< string-locale<?)
+    [(#%compare . _) #'(#%compare ((compare_to string-locale-compare-to)
+                                   (< string-locale<?)
                                    (<= string-locale<=?)
                                    (= string-locale=?)
                                    (!= string-locale!=?)
@@ -227,7 +230,8 @@
 (define-for-syntax (convert-string-locale-ci-compare-static-info static-info)
   (syntax-parse static-info
     #:datum-literals (#%compare)
-    [(#%compare . _) #'(#%compare ((< string-locale-ci<?)
+    [(#%compare . _) #'(#%compare ((compare_to string-locale-ci-compare-to)
+                                   (< string-locale-ci<?)
                                    (<= string-locale-ci<=?)
                                    (= string-locale-ci=?)
                                    (!= string-locale-ci!=?)
@@ -613,17 +617,33 @@
   (in-string str))
 
 (define (raise-string-comp-failure who a b)
-  (raise-annotation-failure '!= (if (string? a) b a) "ReadableString"))
+  (raise-annotation-failure who (if (string? a) b a) "ReadableString"))
 
 (define (string!=? a b)
   (if (and (string? a) (string? b))
       (not (string=? a b))
       (raise-string-comp-failure '!= a b)))
 
+(define (string-compare-to a b)
+  (unless (and (string? a) (string? b))
+    (raise-string-comp-failure 'compare_to a b))
+  (cond
+    [(string=? a b) 0]
+    [(a . string<? . b) -1]
+    [else 1]))
+
 (define (string-ci!=? a b)
   (if (and (string? a) (string? b))
       (not (string-ci=? a b))
       (raise-string-comp-failure '!= a b)))
+
+(define (string-ci-compare-to a b)
+  (unless (and (string? a) (string? b))
+    (raise-string-comp-failure 'compare_to a b))
+  (cond
+    [(string-ci=? a b) 0]
+    [(a . string-ci<? . b) -1]
+    [else 1]))
 
 (define (string-locale!=? a b)
   (if (and (string? a) (string? b))
@@ -633,12 +653,20 @@
 (define (string-locale<=? a b)
   (if (and (string? a) (string? b))
       (not (string-locale>? a b))
-      (raise-string-comp-failure '!= a b)))
+      (raise-string-comp-failure '<= a b)))
 
 (define (string-locale>=? a b)
   (if (and (string? a) (string? b))
       (not (string-locale<? a b))
-      (raise-string-comp-failure '!= a b)))
+      (raise-string-comp-failure '>= a b)))
+
+(define (string-locale-compare-to a b)
+  (unless (and (string? a) (string? b))
+    (raise-string-comp-failure 'compare_to a b))
+  (cond
+    [(string-locale=? a b) 0]
+    [(a . string-locale<? . b) -1]
+    [else 1]))
 
 (define (string-locale-ci!=? a b)
   (if (and (string? a) (string? b))
@@ -648,12 +676,20 @@
 (define (string-locale-ci<=? a b)
   (if (and (string? a) (string? b))
       (not (string-locale-ci>? a b))
-      (raise-string-comp-failure '!= a b)))
+      (raise-string-comp-failure '<= a b)))
 
 (define (string-locale-ci>=? a b)
   (if (and (string? a) (string? b))
       (not (string-locale-ci<? a b))
-      (raise-string-comp-failure '!= a b)))
+      (raise-string-comp-failure '>= a b)))
+
+(define (string-locale-ci-compare-to a b)
+  (unless (and (string? a) (string? b))
+    (raise-string-comp-failure 'compare_to a b))
+  (cond
+    [(string-locale-ci=? a b) 0]
+    [(a . string-locale-ci<? . b) -1]
+    [else 1]))
 
 (begin-for-syntax
   (install-get-literal-static-infos! 'string get-string-static-infos)

--- a/rhombus-lib/rhombus/private/amalgam/symbol.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/symbol.rkt
@@ -16,7 +16,8 @@
   (provide (for-syntax get-symbol-static-infos)))
 
 (define-static-info-getter get-symbol-static-infos
-  (#%compare ((< symbol<?)
+  (#%compare ((compare_to symbol-compare-to)
+              (< symbol<?)
               (<= symbol<=?)
               (= symbol=?)
               (!= symbol!=?)
@@ -73,3 +74,10 @@
 (define (symbol>? a b)
   (check-symbols '> a b)
   (symbol<? b a))
+
+(define (symbol-compare-to a b)
+  (check-symbols 'compare_to a b)
+  (cond
+    [(eq? a b) 0]
+    [(a . symbol<? . b) -1]
+    [else 1]))

--- a/rhombus/rhombus/scribblings/reference/comparable.scrbl
+++ b/rhombus/rhombus/scribblings/reference/comparable.scrbl
@@ -12,10 +12,12 @@ A @deftech{comparable} value is one that supports @rhombus(<),
 @rhombus(<=), @rhombus(>=),@rhombus(>=), @rhombus(compares_equal), and
 @rhombus(compares_unequal). Real numbers, @tech{characters},
 @tech{strings}, @tech{byte strings}, @tech{symbols}, @tech{keywords},
-and @tech{paths} are all comparable, as are instances of classes that
+and @tech{cross-platform paths} are all comparable, as are instances of classes that
 implement @rhombus(Comparable, ~class).
 
 @doc(
+  operator ((v1 :: Comparable) compare_to (v2 :: Comparable)) :: Int:
+    ~order: order_comparison
   operator ((v1 :: Comparable) < (v2 :: Comparable)) :: Boolean:
     ~order: order_comparison
   operator ((v1 :: Comparable) > (v2 :: Comparable)) :: Boolean:
@@ -34,7 +36,7 @@ implement @rhombus(Comparable, ~class).
 
  Compares @rhombus(v1) and @rhombus(v2), which uses a primitive
  comparison operation for real numbers, characters, strings, byte strings,
- symbols, keywords, and paths, or it calls the @rhombus(compare_to, ~datum)
+ symbols, keywords, and cross-platform paths, or it calls the relevant
  method for a @rhombus(Comparable, ~class) instance.
 
  See also @rhombus(.<), @rhombus(.>), @rhombus(.<=), @rhombus(.>=),
@@ -56,7 +58,7 @@ implement @rhombus(Comparable, ~class).
  @rhombus(Comparable, ~class) operation.
 
  The comparison implementations for @rhombus(Number, ~annot) arguments
- is is specialized like @rhombus(+) for arguments with
+ are specialized like @rhombus(+) for arguments with
  @rhombus(Flonum, ~annot) static information. That specialization does
  not mean that a @rhombus(Number, ~annot) argument combined with a
  @rhombus(Flonum, ~annot) argument will trigger an ambiguous-comparison

--- a/rhombus/rhombus/tests/comparable.rhm
+++ b/rhombus/rhombus/tests/comparable.rhm
@@ -1,12 +1,15 @@
 #lang rhombus/static
 
+check (1 compare_to 2) < 0 ~is #true
 check 1 < 2 ~is #true
 check 1 <= 2 ~is #true
 check 1 compares_equal 2 ~is #false
 check 1 compares_unequal 2 ~is #true
 check 1 >= 2 ~is #false
+check (2 compare_to 2) == 0 ~is #true
 check 2 >= 2 ~is #true
 check 1 > 2 ~is #false
+check (10 compare_to 2) > 0 ~is #true
 check 10 < 2 ~is #false
 check 10 <= 2 ~is #false
 check 10 <= 10 ~is #true
@@ -15,6 +18,7 @@ check 10 compares_unequal 10 ~is #false
 check 10 >= 2 ~is #true
 check 10 > 2 ~is #true
 
+check (1/2 compare_to 2) < 0 ~is #true
 check 1/2 < 2 ~is #true
 check 1/2 <= 2 ~is #true
 check 1/2 compares_equal 2 ~is #false
@@ -22,13 +26,16 @@ check 1/2 compares_unequal 2 ~is #true
 check 1/2 >= 2 ~is #false
 check 1/2 > 2 ~is #false
 
+check (Char"a" compare_to Char"b") < 0 ~is #true
 check Char"a" < Char"b" ~is #true
 check Char"a" <= Char"b" ~is #true
 check Char"a" compares_equal Char"b" ~is #false
 check Char"a" compares_unequal Char"b" ~is #true
 check Char"a" >= Char"b" ~is #false
+check (Char"a" compare_to Char"a") == 0 ~is #true
 check Char"a" >= Char"a" ~is #true
 check Char"a" > Char"b" ~is #false
+check (Char"a" compare_to Char"B") > 0 ~is #true
 check Char"a" < Char"B" ~is #false
 check Char"a" <= Char"B" ~is #false
 check Char"a" <= Char"a" ~is #true
@@ -37,13 +44,16 @@ check Char"a" compares_unequal Char"a" ~is #false
 check Char"a" >= Char"B" ~is #true
 check Char"a" > Char"B" ~is #true
 
+check (Byte#"a" compare_to Byte#"b") < 0 ~is #true
 check Byte#"a" < Byte#"b" ~is #true
 check Byte#"a" <= Byte#"b" ~is #true
 check Byte#"a" compares_equal Byte#"b" ~is #false
 check Byte#"a" compares_unequal Byte#"b" ~is #true
 check Byte#"a" >= Byte#"b" ~is #false
+check (Byte#"a" compare_to Byte#"a") == 0 ~is #true
 check Byte#"a" >= Byte#"a" ~is #true
 check Byte#"a" > Byte#"b" ~is #false
+check (Byte#"a" compare_to Byte#"B") > 0 ~is #true
 check Byte#"a" < Byte#"B" ~is #false
 check Byte#"a" <= Byte#"B" ~is #false
 check Byte#"a" <= Byte#"a" ~is #true
@@ -52,13 +62,16 @@ check Byte#"a" compares_unequal Byte#"a" ~is #false
 check Byte#"a" >= Byte#"B" ~is #true
 check Byte#"a" > Byte#"B" ~is #true
 
+check ("a" compare_to "b") < 0 ~is #true
 check "a" < "b" ~is #true
 check "a" <= "b" ~is #true
 check "a" compares_equal "b" ~is #false
 check "a" compares_unequal "b" ~is #true
 check "a" >= "b" ~is #false
+check ("a" compare_to "a") == 0 ~is #true
 check "a" >= "a" ~is #true
 check "a" > "b" ~is #false
+check ("a" compare_to "B") > 0 ~is #true
 check "a" < "B" ~is #false
 check "a" <= "B" ~is #false
 check "a" <= "a" ~is #true
@@ -67,12 +80,15 @@ check "a" compares_unequal "a" ~is #false
 check "a" >= "B" ~is #true
 check "a" > "B" ~is #true
 
+check (#"a" compare_to #"b") < 0 ~is #true
 check #"a" < #"b" ~is #true
 check #"a" <= #"b" ~is #true
 check #"a" compares_equal #"b" ~is #false
 check #"a" >= #"b" ~is #false
+check (#"a" compare_to #"a") == 0 ~is #true
 check #"a" >= #"a" ~is #true
 check #"a" > #"b" ~is #false
+check (#"a" compare_to #"B") > 0 ~is #true
 check #"a" < #"B" ~is #false
 check #"a" <= #"B" ~is #false
 check #"a" <= #"a" ~is #true
@@ -80,13 +96,16 @@ check #"a" compares_equal #"a" ~is #true
 check #"a" >= #"B" ~is #true
 check #"a" > #"B" ~is #true
 
+check (#'a compare_to #'b) < 0 ~is #true
 check #'a < #'b ~is #true
 check #'a <= #'b ~is #true
 check #'a compares_equal #'b ~is #false
 check #'a compares_unequal #'b ~is #true
 check #'a >= #'b ~is #false
+check (#'a compare_to #'a) == 0 ~is #true
 check #'a >= #'a ~is #true
 check #'a > #'b ~is #false
+check (#'a compare_to #'B) > 0 ~is #true
 check #'a < #'B ~is #false
 check #'a <= #'B ~is #false
 check #'a <= #'a ~is #true
@@ -95,13 +114,16 @@ check #'a compares_unequal #'a ~is #false
 check #'a >= #'B ~is #true
 check #'a > #'B ~is #true
 
+check (#'~a compare_to #'~b) < 0 ~is #true
 check #'~a < #'~b ~is #true
 check #'~a <= #'~b ~is #true
 check #'~a compares_equal #'~b ~is #false
 check #'~a compares_unequal #'~b ~is #true
 check #'~a >= #'~b ~is #false
+check (#'~a compare_to #'~a) == 0 ~is #true
 check #'~a >= #'~a ~is #true
 check #'~a > #'~b ~is #false
+check (#'~a compare_to #'~B) > 0 ~is #true
 check #'~a < #'~B ~is #false
 check #'~a <= #'~B ~is #false
 check #'~a <= #'~a ~is #true
@@ -117,55 +139,123 @@ block:
   let a :: Real = 5
   check a <= a ~is #true
 
+// `compare_to` result info
+check (1 compare_to 2) < dynamic(0) ~is #true
+
+// repetitions
+block:
+  def [x :: Comparable, ...] = [1, Char"a", Byte#"a", "a", #"a", #'a, #'~a]
+  def [y :: Comparable, ...] = [2, Char"b", Byte#"b", "b", #"b", #'b, #'~b]
+  check all((x compare_to y) < dynamic(0), ...) ~is #true
+  check all(x < y, ...) ~is #true
+
 block:
   use_dynamic
+
+  check (dynamic(1) compare_to dynamic(2)) < 0 ~is #true
+  check (dynamic(10) compare_to dynamic(2)) > 0 ~is #true
+  check (dynamic(Char"a") compare_to dynamic(Char"b")) < 0 ~is #true
+  check (dynamic(Char"a") compare_to dynamic(Char"B")) > 0 ~is #true
+  check (dynamic(Byte#"a") compare_to dynamic(Byte#"b")) < 0 ~is #true
+  check (dynamic(Byte#"a") compare_to dynamic(Byte#"B")) > 0 ~is #true
+  check (dynamic("a") compare_to dynamic("b")) < 0 ~is #true
+  check (dynamic("a") compare_to dynamic("B")) > 0 ~is #true
+  check (dynamic(#"a") compare_to dynamic(#"b")) < 0 ~is #true
+  check (dynamic(#"a") compare_to dynamic(#"B")) > 0 ~is #true
+  check (dynamic(#'a) compare_to dynamic(#'b)) < 0 ~is #true
+  check (dynamic(#'a) compare_to dynamic(#'B)) > 0 ~is #true
+  check (dynamic(#'~a) compare_to dynamic(#'~b)) < 0 ~is #true
+  check (dynamic(#'~a) compare_to dynamic(#'~B)) > 0 ~is #true
+
   check dynamic(1) < dynamic(2) ~is #true
+  check dynamic(10) < dynamic(2) ~is #false
   check dynamic(Char"a") < dynamic(Char"b") ~is #true
+  check dynamic(Char"a") < dynamic(Char"B") ~is #false
   check dynamic(Byte#"a") < dynamic(Byte#"b") ~is #true
+  check dynamic(Byte#"a") < dynamic(Byte#"B") ~is #false
   check dynamic("a") < dynamic("b") ~is #true
+  check dynamic("a") < dynamic("B") ~is #false
   check dynamic(#"a") < dynamic(#"b") ~is #true
+  check dynamic(#"a") < dynamic(#"B") ~is #false
   check dynamic(#'a) < dynamic(#'b) ~is #true
+  check dynamic(#'a) < dynamic(#'B) ~is #false
   check dynamic(#'~a) < dynamic(#'~b) ~is #true
+  check dynamic(#'~a) < dynamic(#'~B) ~is #false
 
   check dynamic(1) <= dynamic(2) ~is #true
+  check dynamic(10) <= dynamic(2) ~is #false
   check dynamic(Char"a") <= dynamic(Char"b") ~is #true
+  check dynamic(Char"a") <= dynamic(Char"B") ~is #false
   check dynamic(Byte#"a") <= dynamic(Byte#"b") ~is #true
+  check dynamic(Byte#"a") <= dynamic(Byte#"B") ~is #false
   check dynamic("a") <= dynamic("b") ~is #true
+  check dynamic("a") <= dynamic("B") ~is #false
   check dynamic(#"a") <= dynamic(#"b") ~is #true
+  check dynamic(#"a") <= dynamic(#"B") ~is #false
   check dynamic(#'a) <= dynamic(#'b) ~is #true
+  check dynamic(#'a) <= dynamic(#'B) ~is #false
   check dynamic(#'~a) <= dynamic(#'~b) ~is #true
+  check dynamic(#'~a) <= dynamic(#'~B) ~is #false
 
   check dynamic(1) >= dynamic(2) ~is #false
+  check dynamic(10) >= dynamic(2) ~is #true
   check dynamic(Char"a") >= dynamic(Char"b") ~is #false
+  check dynamic(Char"a") >= dynamic(Char"B") ~is #true
   check dynamic(Byte#"a") >= dynamic(Byte#"b") ~is #false
+  check dynamic(Byte#"a") >= dynamic(Byte#"B") ~is #true
   check dynamic("a") >= dynamic("b") ~is #false
+  check dynamic("a") >= dynamic("B") ~is #true
   check dynamic(#"a") >= dynamic(#"b") ~is #false
+  check dynamic(#"a") >= dynamic(#"B") ~is #true
   check dynamic(#'a) >= dynamic(#'b) ~is #false
+  check dynamic(#'a) >= dynamic(#'B) ~is #true
   check dynamic(#'~a) >= dynamic(#'~b) ~is #false
+  check dynamic(#'~a) >= dynamic(#'~B) ~is #true
 
   check dynamic(1) > dynamic(2) ~is #false
+  check dynamic(10) > dynamic(2) ~is #true
   check dynamic(Char"a") > dynamic(Char"b") ~is #false
+  check dynamic(Char"a") > dynamic(Char"B") ~is #true
   check dynamic(Byte#"a") > dynamic(Byte#"b") ~is #false
+  check dynamic(Byte#"a") > dynamic(Byte#"B") ~is #true
   check dynamic("a") > dynamic("b") ~is #false
+  check dynamic("a") > dynamic("B") ~is #true
   check dynamic(#"a") > dynamic(#"b") ~is #false
+  check dynamic(#"a") > dynamic(#"B") ~is #true
   check dynamic(#'a) > dynamic(#'b) ~is #false
+  check dynamic(#'a) > dynamic(#'B) ~is #true
   check dynamic(#'~a) > dynamic(#'~b) ~is #false
+  check dynamic(#'~a) > dynamic(#'~B) ~is #true
 
   check dynamic(1) compares_equal dynamic(2) ~is #false
+  check dynamic(10) compares_equal dynamic(2) ~is #false
   check dynamic(Char"a") compares_equal dynamic(Char"b") ~is #false
+  check dynamic(Char"a") compares_equal dynamic(Char"B") ~is #false
   check dynamic(Byte#"a") compares_equal dynamic(Byte#"b") ~is #false
+  check dynamic(Byte#"a") compares_equal dynamic(Byte#"B") ~is #false
   check dynamic("a") compares_equal dynamic("b") ~is #false
+  check dynamic("a") compares_equal dynamic("B") ~is #false
   check dynamic(#"a") compares_equal dynamic(#"b") ~is #false
+  check dynamic(#"a") compares_equal dynamic(#"B") ~is #false
   check dynamic(#'a) compares_equal dynamic(#'b) ~is #false
+  check dynamic(#'a) compares_equal dynamic(#'B) ~is #false
   check dynamic(#'~a) compares_equal dynamic(#'~b) ~is #false
+  check dynamic(#'~a) compares_equal dynamic(#'~B) ~is #false
 
   check dynamic(1) compares_unequal dynamic(2) ~is #true
+  check dynamic(10) compares_unequal dynamic(2) ~is #true
   check dynamic(Char"a") compares_unequal dynamic(Char"b") ~is #true
+  check dynamic(Char"a") compares_unequal dynamic(Char"B") ~is #true
   check dynamic(Byte#"a") compares_unequal dynamic(Byte#"b") ~is #true
+  check dynamic(Byte#"a") compares_unequal dynamic(Byte#"B") ~is #true
   check dynamic("a") compares_unequal dynamic("b") ~is #true
+  check dynamic("a") compares_unequal dynamic("B") ~is #true
   check dynamic(#"a") compares_unequal dynamic(#"b") ~is #true
+  check dynamic(#"a") compares_unequal dynamic(#"B") ~is #true
   check dynamic(#'a) compares_unequal dynamic(#'b) ~is #true
+  check dynamic(#'a) compares_unequal dynamic(#'B) ~is #true
   check dynamic(#'~a) compares_unequal dynamic(#'~b) ~is #true
+  check dynamic(#'~a) compares_unequal dynamic(#'~B) ~is #true
 
 class A(v):
   nonfinal
@@ -201,8 +291,11 @@ veneer S(this :: Flonum):
     math.exact(math.round(this - 2 * other))
 
 check:
+  (A(1) compare_to A(2)) < 0 ~is #true
   A(1) < A(2) ~is #true
+  (A(1) compare_to A(1)) == 0 ~is #true
   A(1) < A(1) ~is #false
+  (A(1) compare_to A(-1)) > 0 ~is #true
   A(1) < A(-1) ~is #false
   A(1) <= A(2) ~is #true
   A(1) <= A(1) ~is #true
@@ -218,27 +311,36 @@ check:
   A(1) > A(1) ~is #false
   A(-1) > A(1) ~is #false
 
+  (B(2) compare_to B(1)) < 0 ~is #true
   B(2) < B(1) ~is #true
   B(2) > B(1) ~is #false
 
+  (C(2) compare_to C(1)) < 0 ~is #true
   C(2) < C(1) ~is #true
   C(2) > C(1) ~is #false
 
+  (C(2) compare_to B(1)) < 0 ~is #true
   C(2) < B(1) ~is #true
+  (B(2) compare_to C(1)) < 0 ~is #true
   B(2) > C(1) ~is #false
 
+  (A3(2) compare_to A3(4)) < 0 ~is #true
   A3(2) < A3(4) ~is #true
   A3(2) > A3(4) ~is #false
 
+  (A4(2) compare_to A4(2)) < 0 ~is #true
   A4(2) < A4(2) ~is #true
   A4(2) > A4(2) ~is #false
 
+  (S(2.0) compare_to S(4.0)) < 0 ~is #true
   S(2.0) < S(2.0) ~is #true
   S(2.0) > S(2.0) ~is #false
 
   (if #true | C(2) | B(2)) < B(1) ~is #true
 
-  A(1).compare_to(A(2)) compares_equal A(1).compare_to(A(2)) ~is #true
+  (A(1) compare_to A(2)) < dynamic(0) ~is #true
+  A(1).compare_to(A(2)) < dynamic(0) ~is #true
+  (A(1) compare_to A(2)) == A(1).compare_to(A(2)) ~is #true
 
 block:
   use_dynamic
@@ -269,15 +371,86 @@ check:
   #'apple is_a Comparable ~is #true
   #'~apple is_a Comparable ~is #true
   Path("x/y") is_a Comparable ~is #true
+  CrossPath.Unix(#"x") is_a Comparable ~is #true
+  CrossPath.Windows(#"x") is_a Comparable ~is #true
 
+// .< and friends only work on real numbers
 check:
-  class NotComparable()
-  (NotComparable() :~ Comparable) < NotComparable()
-  ~throws values(
-    "Comparable.compare_to: " ++ error.annot_msg(),
-    error.annot("Comparable").msg,
-    error.text(~label: "value", "NotComparable()").msg,
+  math.sqrt(-1) < math.sqrt(-2) ~throws values(
+    ".<: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val(math.sqrt(-1)).msg,
   )
+  math.sqrt(-1) <= math.sqrt(-2) ~throws values(
+    ".<=: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val(math.sqrt(-1)).msg,
+  )
+  math.sqrt(-1) >= math.sqrt(-2) ~throws values(
+    ".>=: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    // FIXME error should say LHS
+    #//
+    error.val(math.sqrt(-1)).msg,
+  )
+  math.sqrt(-1) > math.sqrt(-2) ~throws values(
+    ".>: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    #//
+    error.val(math.sqrt(-1)).msg,
+  )
+
+// by extension, `compare_to` also requires real numbers
+check:
+  math.sqrt(-1) compare_to math.sqrt(-2) ~throws values(
+    "compare_to: " ++ error.annot_msg(),
+    error.annot("Real").msg,
+    error.val(math.sqrt(-1)).msg,
+  )
+
+// but .= and .!= work on all numbers
+check:
+  math.sqrt(-1) compares_equal math.sqrt(-2) ~is #false
+  math.sqrt(-1) compares_unequal math.sqrt(-2) ~is #true
+
+// dynamic dispatch requires real numbers, too
+block:
+  use_dynamic
+  check:
+    dynamic(math.sqrt(-1)) compare_to dynamic(math.sqrt(-2)) ~throws values(
+      "Comparable.compare_to: " ++ error.annot_msg(),
+      error.annot("Comparable").msg,
+      error.val(math.sqrt(-1)).msg,
+    )
+    dynamic(math.sqrt(-1)) < dynamic(math.sqrt(-2)) ~throws values(
+      "Comparable.compare_to: " ++ error.annot_msg(),
+      error.annot("Comparable").msg,
+      error.val(math.sqrt(-1)).msg,
+    )
+    dynamic(math.sqrt(-1)) compares_equal dynamic(math.sqrt(-2)) ~throws values(
+      "Comparable.compare_to: " ++ error.annot_msg(),
+      error.annot("Comparable").msg,
+      error.val(math.sqrt(-1)).msg,
+    )
+
+block:
+  class NotComparable(val)
+  check:
+    (NotComparable(1) :~ Comparable) compare_to NotComparable(2) ~throws values(
+      "Comparable.compare_to: " ++ error.annot_msg(),
+      error.annot("Comparable").msg,
+      error.val(NotComparable(1)).msg,
+    )
+    (NotComparable(1) :~ Comparable) < NotComparable(2) ~throws values(
+      "Comparable.compare_to: " ++ error.annot_msg(),
+      error.annot("Comparable").msg,
+      error.val(NotComparable(1)).msg,
+    )
+    (NotComparable(1) :~ Comparable) compares_equal NotComparable(2) ~throws values(
+      "Comparable.compare_to: " ++ error.annot_msg(),
+      error.annot("Comparable").msg,
+      error.val(NotComparable(1)).msg,
+    )
 
 block:
   use_dynamic
@@ -381,7 +554,7 @@ check:
   ~throws "cannot compare a comparable object and other comparable object"
 
 block:
-  // says that 1 is < and > anything
+  // says that 1(0) is < and > anything
   class Weird(v):
     implements Comparable
     override method compare_to(other :~ Weird):
@@ -390,17 +563,24 @@ block:
       if v == 1 | #true | compare_to(other) < 0
     override method greater(other):
       if v == 10 | #true | compare_to(other) > 0
+  check (Weird(1) compare_to Weird(0)) < 0 ~is #false
   check Weird(1) < Weird(0) ~is #true
+  check (Weird(10) compare_to Weird(20)) > 0 ~is #false
   check Weird(10) > Weird(20) ~is #true
+  check (Weird(2) compare_to Weird(0)) < 0 ~is #false
   check Weird(2) < Weird(0) ~is #false
+  check (Weird(0) compare_to Weird(20)) > 0 ~is #false
   check Weird(0) > Weird(20) ~is #false
+  check (Weird(1) compare_to Weird(0)) <= 0 ~is #false
   check Weird(1) <= Weird(0) ~is #false
+  check (Weird(1) compare_to Weird(2)) >= 0 ~is #false
   check Weird(1) >= Weird(2) ~is #false
+  check (Weird(1) compare_to Weird(0)) == 0 ~is #false
   check Weird(1) compares_equal Weird(0) ~is #false
   check Weird(1) compares_unequal Weird(0) ~is #true
 
 block:
-  // says that 1 is <=, >=, =, and !=  anything
+  // says that 1(0(0(0))) is <=, >=, =, and != anything
   class Weird(v):
     implements Comparable
     override method compare_to(other :~ Weird):
@@ -413,19 +593,29 @@ block:
       if v == 100 | #true | compare_to(other) == 0
     override method compares_unequal(other):
       if v == 1000 | #true | compare_to(other) != 0
+  check (Weird(1) compare_to Weird(0)) <= 0 ~is #false
   check Weird(1) <= Weird(0) ~is #true
+  check (Weird(10) compare_to Weird(20)) >= 0 ~is #false
   check Weird(10) >= Weird(20) ~is #true
+  check (Weird(100) compare_to Weird(0)) == 0 ~is #false
   check Weird(100) compares_equal Weird(0) ~is #true
+  check (Weird(1000) compare_to Weird(0)) != 0 ~is #true
   check Weird(1000) compares_unequal Weird(0) ~is #true
+  check (Weird(1) compare_to Weird(0)) < 0 ~is #false
   check Weird(1) < Weird(0) ~is #false
+  check (Weird(1) compare_to Weird(2)) > 0 ~is #false
   check Weird(1) > Weird(2) ~is #false
+  check (Weird(2) compare_to Weird(0)) <= 0 ~is #false
   check Weird(2) <= Weird(0) ~is #false
+  check (Weird(0) compare_to Weird(20)) >= 0 ~is #false
   check Weird(0) >= Weird(20) ~is #false
+  check (Weird(200) compare_to Weird(0)) == 0 ~is #false
   check Weird(200) compares_equal Weird(0) ~is #false
+  check (Weird(0) compare_to Weird(0)) != 0 ~is #false
   check Weird(0) compares_unequal Weird(0) ~is #false
 
 block:
-  // says that 1 is < and > anything, veneer variant
+  // says that 1(0) is < and > anything, veneer variant
   veneer Weird(this :: Int):
     implements Comparable
     override method compare_to(other :~ Weird):
@@ -434,17 +624,24 @@ block:
       if this == 1 | #true | compare_to(other) < 0
     override method greater(other):
       if this == 10 | #true | compare_to(other) > 0
+  check (Weird(1) compare_to Weird(0)) < 0 ~is #false
   check Weird(1) < Weird(0) ~is #true
+  check (Weird(10) compare_to Weird(20)) > 0 ~is #false
   check Weird(10) > Weird(20) ~is #true
+  check (Weird(2) compare_to Weird(0)) < 0 ~is #false
   check Weird(2) < Weird(0) ~is #false
+  check (Weird(0) compare_to Weird(20)) > 0 ~is #false
   check Weird(0) > Weird(20) ~is #false
+  check (Weird(1) compare_to Weird(0)) <= 0 ~is #false
   check Weird(1) <= Weird(0) ~is #false
+  check (Weird(1) compare_to Weird(2)) >= 0 ~is #false
   check Weird(1) >= Weird(2) ~is #false
+  check (Weird(1) compare_to Weird(0)) == 0 ~is #false
   check Weird(1) compares_equal Weird(0) ~is #false
   check Weird(1) compares_unequal Weird(0) ~is #true
 
 block:
-  // says that 1 is <=, >=, =, and !=  anything, veneer variant
+  // says that 1(0(0(0))) is <=, >=, =, and != anything, veneer variant
   veneer Weird(this :: Int):
     implements Comparable
     override method compare_to(other :~ Weird):
@@ -457,13 +654,23 @@ block:
       if this == 100 | #true | compare_to(other) == 0
     override method compares_unequal(other):
       if this == 1000 | #true | compare_to(other) != 0
+  check (Weird(1) compare_to Weird(0)) <= 0 ~is #false
   check Weird(1) <= Weird(0) ~is #true
+  check (Weird(10) compare_to Weird(20)) >= 0 ~is #false
   check Weird(10) >= Weird(20) ~is #true
+  check (Weird(100) compare_to Weird(0)) == 0 ~is #false
   check Weird(100) compares_equal Weird(0) ~is #true
+  check (Weird(1000) compare_to Weird(0)) != 0 ~is #true
   check Weird(1000) compares_unequal Weird(0) ~is #true
+  check (Weird(1) compare_to Weird(0)) < 0 ~is #false
   check Weird(1) < Weird(0) ~is #false
+  check (Weird(1) compare_to Weird(2)) > 0 ~is #false
   check Weird(1) > Weird(2) ~is #false
+  check (Weird(2) compare_to Weird(0)) <= 0 ~is #false
   check Weird(2) <= Weird(0) ~is #false
+  check (Weird(0) compare_to Weird(20)) >= 0 ~is #false
   check Weird(0) >= Weird(20) ~is #false
+  check (Weird(200) compare_to Weird(0)) == 0 ~is #false
   check Weird(200) compares_equal Weird(0) ~is #false
+  check (Weird(0) compare_to Weird(0)) != 0 ~is #false
   check Weird(0) compares_unequal Weird(0) ~is #false

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -24,6 +24,10 @@ block:
     Path.normal_case(p) ~method
     Path.simplify(p) ~method
     Path.as_relative_to(p, wrt) ~method
+    CrossPath(p, [conv])
+    CrossPath.Unix(p)
+    CrossPath.Windows(p)
+    CrossPath.Convention.current()
 
 module path_help ~lang rhombus/and_meta:
   export:
@@ -75,6 +79,55 @@ block:
 block:
   def p = Path("/")
   def q = Path("/etc")
+  check (p compare_to q) < 0 ~is #true
+  check (q compare_to p) > 0 ~is #true
+  check (p compare_to p) == 0 ~is #true
+  check (q compare_to q) == 0 ~is #true
+  check p < q ~is #true
+  check q > p ~is #true
+  check p compares_equal p ~is #true
+  check p compares_equal q ~is #false
+  check p compares_unequal p ~is #false
+  check p compares_unequal q ~is #true
+  check p <= p ~is #true
+  check p <= q ~is #true
+  check p >= p ~is #true
+  check p >= q ~is #false
+  check p == Path("/") ~is #true
+  check p == q ~is #false
+  check p != Path("/") ~is #false
+  check p != q ~is #true
+
+block:
+  def p = CrossPath.Unix(#"x")
+  def q = CrossPath.Unix(#"y")
+  def r = CrossPath.Windows(#"y")
+  def s = CrossPath.Windows(#"z")
+  check (p compare_to q) < 0 ~is #true
+  check (q compare_to r) < 0 ~is #true
+  check (r compare_to s) < 0 ~is #true
+  check (p compare_to p) == 0 ~is #true
+  check (r compare_to r) == 0 ~is #true
+  check (s compare_to r) > 0 ~is #true
+  check (r compare_to q) > 0 ~is #true
+  check (q compare_to p) > 0 ~is #true
+  check p < q ~is #true
+  check q < r ~is #true
+  check r < s ~is #true
+  check p compares_equal p ~is #true
+  check r compares_equal r ~is #true
+  check s > r ~is #true
+  check r > q ~is #true
+  check q > p ~is #true
+
+block:
+  use_dynamic
+  def p = dynamic(Path("/"))
+  def q = dynamic(Path("/etc"))
+  check (p compare_to q) < 0 ~is #true
+  check (q compare_to p) > 0 ~is #true
+  check (p compare_to p) == 0 ~is #true
+  check (q compare_to q) == 0 ~is #true
   check p < q ~is #true
   check q > p ~is #true
   check p compares_equal p ~is #true
@@ -92,22 +145,26 @@ block:
 
 block:
   use_dynamic
-  def p = dynamic(Path("/"))
-  def q = dynamic(Path("/etc"))
+  def p = dynamic(CrossPath.Unix(#"x"))
+  def q = dynamic(CrossPath.Unix(#"y"))
+  def r = dynamic(CrossPath.Windows(#"y"))
+  def s = dynamic(CrossPath.Windows(#"z"))
+  check (p compare_to q) < 0 ~is #true
+  check (q compare_to r) < 0 ~is #true
+  check (r compare_to s) < 0 ~is #true
+  check (p compare_to p) == 0 ~is #true
+  check (r compare_to r) == 0 ~is #true
+  check (s compare_to r) > 0 ~is #true
+  check (r compare_to q) > 0 ~is #true
+  check (q compare_to p) > 0 ~is #true
   check p < q ~is #true
-  check q > p ~is #true
+  check q < r ~is #true
+  check r < s ~is #true
   check p compares_equal p ~is #true
-  check p compares_equal q ~is #false
-  check p compares_unequal p ~is #false
-  check p compares_unequal q ~is #true
-  check p <= p ~is #true
-  check p <= q ~is #true
-  check p >= p ~is #true
-  check p >= q ~is #false
-  check p == Path("/") ~is #true
-  check p == q ~is #false
-  check p != Path("/") ~is #false
-  check p != q ~is #true
+  check r compares_equal r ~is #true
+  check s > r ~is #true
+  check r > q ~is #true
+  check q > p ~is #true
 
 block:
   def s = "/etc"


### PR DESCRIPTION
This operator exposes the underlying `Comparable.compare_to` method, which should return an integer that indicates whether LHS is less than, equal to, or greater than RHS.  Similar constructs exist as `<=>` in C++ and `Ord::cmp` in Rust.

This commit also fixes comparison operations for cross-platform paths.  Previously, dynamic dispatch (and `Comparable` annotation) only worked for non–cross-platform paths, and the results could be sometimes wrong.