### PR TITLE
use `ssl.Client.Context` for `http.Session`

### DIFF
--- a/rhombus-http-lib/info.rkt
+++ b/rhombus-http-lib/info.rkt
@@ -7,6 +7,7 @@
     "rhombus-lib"
     ["rhombus-json-lib" #:version "0.2"]
     "rhombus-url-lib"
+    "rhombus-ssl-lib"
     "http-easy-lib"))
 
 (define pkg-desc "implementation (no documentation) part of \"rhombus-http\"")

--- a/rhombus-http-lib/rhombus/net/http.rhm
+++ b/rhombus-http-lib/rhombus/net/http.rhm
@@ -11,11 +11,11 @@ import:
     expose:
       quote
   net/url
+  net/ssl
   json as json_lib
 
 // todo:
 annot.macro 'HTTPConn': 'Any'
-annot.macro 'SSLContext': 'Any'
 annot.macro 'CookieJar': 'Any'
 
 export:
@@ -325,7 +325,7 @@ class Proxy(_handle):
     https
 
   constructor (~matches: matches :: url.URL -> Boolean,
-               ~connect: connect :: (HTTPConn, url.URL, maybe(SSLContext)) -> Void) :~ Proxy:
+               ~connect: connect :: (HTTPConn, url.URL, maybe(ssl.Context.Client)) -> Void) :~ Proxy:
     super(easy.#{make-proxy}(fun (url_handle):
                                matches(url.URL.from_handle(url_handle)),
                              fun (conn_handle, url_handle, ssl_context_handle):
@@ -353,12 +353,12 @@ class Session(_handle):
   internal _Session
   property handle: _handle
   constructor (~pool_config: pool_config :: PoolConfig = PoolConfig(),
-               ~ssl_context: ssl_context :: maybe(SSLContext) = #false, // FIXME: don't default to `#false`
+               ~ssl_context: ssl_context :: maybe(ssl.Context.Client) = ssl.Context.Client(),
                ~cookie_jar: cookie_jar :: maybe(CookieJar) = #false,
                ~proxies: proxies :: List.of(Proxy) = []):
     let [p, ...] = proxies
     super(easy.#{make-session}(~#{pool-config}: pool_config.handle,
-                               ~#{ssl-context}: ssl_context,
+                               ~#{ssl-context}: ssl_context?.handle,
                                ~#{cookie-jar}: cookie_jar,
                                ~proxies: PairList(p.handle, ...)))
   override method close():

--- a/rhombus-http/info.rkt
+++ b/rhombus-http/info.rkt
@@ -11,7 +11,8 @@
     "rhombus"
     "rhombus-scribble-lib"
     "rhombus-json"
-    "rhombus-url"))
+    "rhombus-url"
+    "rhombus-ssl"))
 
 (define pkg-desc "Rhombus HTTP library")
 

--- a/rhombus-http/rhombus/net/scribblings/http/session.scrbl
+++ b/rhombus-http/rhombus/net/scribblings/http/session.scrbl
@@ -3,7 +3,8 @@
     meta_label:
       rhombus open
       net/http open
-      net/url)
+      net/url
+      net/ssl)
 
 @title(~tag: "session"){Sessions}
 
@@ -11,8 +12,8 @@
   class Session():
     constructor (
       ~pool_config: pool_config :: PoolConfig = PoolConfig(),
-      ~ssl_context: maybe(SSLContext) = #false,
-      ~cookie_jar: maybe(CookieJar) = #false,
+      ~ssl_context: context :: maybe(ssl.Context.Client) = ssl.Context.Client(),
+      ~cookie_jar: cookie_jar :: maybe(CookieJar) = #false,
       ~proxies: proxies :: List.of(Proxy) = []
     )
   method (session :: Session).close() :: Void
@@ -24,6 +25,10 @@
  A session has a pool of connections, and the pool is configured through
  the @rhombus(pool_config) structor argument, which is a
  @rhombus(PoolConfig, ~class).
+
+ The @rhombus(context) argument configures security properties for HTTP
+ requests. By default, connections are secure using the operating
+ system's default certificate store.
 
  A session is @rhombus(Closeable, ~class), where closing a session via
  the @rhombus(Session.close) method closes all of its associated connections and


### PR DESCRIPTION
this repair would close #712, but it's a backward-incompatible change for anything that passes a Racket-level `ssl-client-context?` as `~ssl_context`. Ok to merge, or is more work needed to create a compatibility path?