### PR TITLE
add `rhombus/date`

### DIFF
--- a/rhombus-lib/rhombus/date.rhm
+++ b/rhombus-lib/rhombus/date.rhm
@@ -1,0 +1,426 @@
+#lang rhombus/static
+import:
+  lib("racket/base.rkt") as rkt
+  lib("racket/date.rkt") as rkt_date
+  "private/date.rhm" as util
+
+export:
+  Time
+  Date
+  DateTime
+  ZonedDateTime
+  Format
+  TimeFormat
+  TimeZoneFormat
+  util.is_leap_year
+  util.days_in_year
+  util.days_in_month
+  util.year_day
+  util.week_day
+
+// for referencing in annotatons with a `date.` prefix:
+namespace date:
+  export:
+    Time
+    Date
+    DateTime
+    ZonedDateTime
+    Format
+    TimeFormat
+    TimeZoneFormat
+    util.days_in_month
+    util.year_day
+    util.week_day
+
+fun rhm_to_string(s): to_string(s)
+alias 'rhombus_compare_to': 'compare_to'
+
+fun str_2d(n) :~ String:
+  str.d(n, ~width: 2, ~pad: Char"0", ~align: #'right)
+
+fun date_string(year, month, day, ~iso = #false) :~ String:
+  (if iso
+   | str.d(year, ~min_width: 4, ~pad: Char"0", ~align: #'right, ~sign_align: #'left)
+   | str.d(year))
+    ++ "-" ++ str_2d(month) ++ "-" ++ str_2d(day)
+
+fun time_string(hour, minute, second, nanosecond, format):
+  str_2d(hour)
+    ++ ":" ++ str_2d(minute)
+    ++ (if (format == #'minutes
+              || (format == #'auto_subminutes && second == 0 && nanosecond == 0))
+        | ""
+        | ":" ++ str_2d(second))
+    ++ (if (format == #'seconds
+              || format == #'minutes
+              || ((format == #'auto_subseconds || format == #'auto_subminutes)
+                    && nanosecond == 0))
+        | ""
+        | let s = str.d(nanosecond, ~width: 9, ~pad: Char"0", ~align: #'right)
+          "." ++ (match format
+                  | #'milliseconds: s.substring(0, 3)
+                  | #'microseconds: s.substring(0, 6)
+                  | #'nanoseconds: s
+                  | ~else:
+                      recur loop (i = s.length()):
+                        if s[i-1] == Char"0" && s[i-2] == Char"0" && s[i-3] == Char"0"
+                        | loop(i - 3)
+                        | s.substring(0, i)))
+
+fun time_zone_string(time_zone_offset, sep :~ String):
+  let offset = math.abs(time_zone_offset)
+  let h = offset div 3600
+  let m = (offset mod 3600) div 60
+  (if time_zone_offset < 0 | "-" | "+")
+    ++ str_2d(h)
+    ++ sep ++ str_2d(m)
+
+enum Format:
+  rfc2822
+  rfc3339
+  iso8601
+  american
+  european
+  julian
+
+enum TimeFormat:
+  minutes
+  seconds
+  milliseconds
+  microseconds
+  nanoseconds
+  auto_subminutes
+  auto_subseconds
+
+enum TimeZoneFormat:
+  offset
+
+def default_format = #'rfc3339
+
+class ZonedDateTime(~year: year :: Int,
+                    ~month: month :: Int.in(1 ..= 12) = 1,
+                    ~day: day :: Int.in(1 ..= date.days_in_month(year, month)) = 1,
+                    ~hour: hour :: Int.in(0 ..= 23) = 0,
+                    ~minute: minute :: Int.in(0 ..= 59) = 0,
+                    ~second: second :: Int.in(0 ..= 60) = 0,
+                    ~nanosecond: nanosecond :: Int.in(0 ..= 999_999_999) = 0,
+                    ~time_zone_offset: time_zone_offset :: Int = 0,
+                    ~time_zone_name: time_zone_name :: String = "UTC",
+                    ~is_dst: is_dst :: Boolean = #false,
+                    private _week_day = date.week_day(year, month, day),
+                    private _year_day = date.year_day(year, month, day),
+                    private mutable _seconds = #false,
+                    private _handle = rkt.#{date*}(second, minute, hour, day, month, year,
+                                                   _week_day, _year_day,
+                                                   is_dst, time_zone_offset,
+                                                   nanosecond, time_zone_name)):
+  internal _ZonedDateTime
+
+  serializable:
+    ~serialize: fun (): Array(_handle)
+    ~deserialize: fun (handle): from_handle(handle)
+
+  property handle: _handle
+
+  private implements Printable
+  private override method describe(mode, recur):
+    if mode == #'text
+    | to_string()
+    | recur(this, ~as: #'super)
+
+  private implements Comparable
+  private override method compare_to(other :~ ZonedDateTime):
+    to_seconds() rhombus_compare_to other.to_seconds()
+
+  private implements Equatable
+  private override equals(other :~ _ZonedDateTime, recur):
+    recur(_handle, other._handle)
+  private override hash_code(recur):
+    recur(_handle)
+
+  property week_day :~ Int: _week_day
+  property year_day :~ Int: _year_day
+
+  method to_string(~format: format :: date.Format = default_format,
+                   ~time_format: show_time :: maybe(date.TimeFormat) = #'seconds,
+                   ~time_zone_format: show_time_zone :: maybe(date.TimeZoneFormat) = #'offset) :~ String:
+    match format
+    | #'iso8601 || #'rfc3339:
+        if show_time
+        | date_string(year, month, day, ~iso: format == #'iso8601)
+            ++ (if format == #'rfc3339 | " " | "T")
+            ++ time_string(hour, minute, second, nanosecond, show_time)
+            ++ (if show_time_zone
+                | (if time_zone_offset == 0
+                   | "Z"
+                   | time_zone_string(time_zone_offset, ":"))
+                | "")
+        | date_string(year, month, day, ~iso: #true)
+    | ~else:
+        parameterize { rkt_date.#{date-display-format}: match format
+                                                        |  #'european:
+                                                             #'irish
+                                                        | ~else:
+                                                            format }:
+          rhm_to_string(rkt_date.#{date->string}(_handle, show_time))
+
+  method to_seconds() :~ Real:
+    if _seconds
+    | _seconds
+    | let s = find_seconds(~second: second,
+                           ~minute: minute,
+                           ~hour: hour,
+                           ~day: day,
+                           ~month: month,
+                           ~year: year,
+                           ~local: #false)
+      let s = s + time_zone_offset
+      let s: if nanosecond .= 0
+             | s
+             | s + nanosecond / 1e9
+      _seconds := s
+      s
+
+  export:
+    now
+    from_seconds
+    find_seconds
+    from_handle
+
+  fun now(~local = #true) :~ ZonedDateTime:
+    from_seconds(system.milliseconds() / 1000.0,
+                 ~local: local)
+
+  fun from_seconds(secs :: Real,
+                   ~local: local = #true) :~ ZonedDateTime:
+    _from_handle(rkt.#{seconds->date}(secs, local), secs)
+
+  fun from_handle(d) :~ ZonedDateTime:
+    ~who: who
+    unless rkt.#{date?}(d)
+    | error(~who: who, "not a valid date handle", error.val(d))
+    _from_handle(d, #false)
+
+  fun _from_handle(d, secs):
+    _ZonedDateTime(~nanosecond: if rkt.#{date*?}(d)
+                                | rkt.#{date*-nanosecond}(d)
+                                | 0,
+                   ~second: rkt.#{date-second}(d),
+                   ~minute: rkt.#{date-minute}(d),
+                   ~hour: rkt.#{date-hour}(d),
+                   ~day: rkt.#{date-day}(d),
+                   ~month: rkt.#{date-month}(d),
+                   ~year: rkt.#{date-year}(d),
+                   rkt.#{date-week-day}(d),
+                   rkt.#{date-year-day}(d),
+                   ~is_dst: rkt.#{date-dst?}(d),
+                   ~time_zone_offset: rkt.#{date-time-zone-offset}(d),
+                   ~time_zone_name: if rkt.#{date*?}(d)
+                                    | rkt.#{date*-time-zone-name}(d)
+                                    | if rkt.#{date-time-zone-offset}(d) == 0
+                                      | "UTC"
+                                      | "",
+                   secs,
+                   d)
+
+  fun find_seconds(~second: second :: Int.in(0, 60) = 0,
+                   ~minute: minute :: Int.in(0, 59) = 0,
+                   ~hour: hour :: Int.in(0, 23) = 0,
+                   ~day: day :: Int.in(1, 31),
+                   ~month: month :: Int.in(1, 12),
+                   ~year: year :: Int,
+                   ~local: local = #true) :~ Int:
+    rkt_date.#{find-seconds}(second, minute, hour, day, month, year, local)
+
+class DateTime(~year: year :: Int,
+               ~month: month :: Int.in(1 ..= 12) = 1,
+               ~day: day :: Int.in(1 ..= date.days_in_month(year, month)) = 1,
+               ~hour: hour :: Int.in(0 ..= 23) = 0,
+               ~minute: minute :: Int.in(0 ..= 59) = 0,
+               ~second: second :: Int.in(0 ..= 59) = 0,
+               ~nanosecond: nanosecond :: Int.in(0 ..= 999_999_999) = 0):
+  serializable
+
+  private implements Printable
+  private override method describe(mode, recur):
+    if mode == #'text
+    | to_zoned().to_string()
+    | recur(this, ~as: #'super)
+
+  private implements Comparable
+  private override method compare_to(other :~ DateTime):
+    if year == other.year
+    | if month == other.month
+      | if day == other.day
+        | if hour == other.hour
+          | if minute == other.minute
+            | if second == other.second
+              | nanosecond rhombus_compare_to other.nanosecond
+              | second - other.second
+            | minute - other.minute
+          | hour - other.hour
+        | hour - other.hour
+      | month - other.month
+    | year - other.year
+
+  property week_day :~ Int: date.week_day(year, month, day)
+  property year_day :~ Int: date.year_day(year, month, day)
+
+  method to_seconds() :~ Real:
+    let s = ZonedDateTime.find_seconds(~second: second,
+                                       ~minute: minute,
+                                       ~hour: hour,
+                                       ~day: day,
+                                       ~month: month,
+                                       ~year: year,
+                                       ~local: #false)
+    if nanosecond .= 0
+    | s
+    | s + nanosecond / 1e9
+
+  method to_zoned() :~ ZonedDateTime:
+    ZonedDateTime.from_seconds(to_seconds(), ~local: #false)
+
+  method to_string(~format: format :: date.Format = default_format,
+                   ~time_format: show_time :: maybe(date.TimeFormat) = #'seconds) :~ String:
+    match format
+    | #'rfc3339 || #'iso8601:
+        if show_time
+        | date_string(year, month, day)
+            ++ (if format == #'iso8601 | "T" | " ")
+            ++ time_string(hour, minute, second, nanosecond, show_time)
+        | date_string(year, month, day)
+    | ~else:
+        _ZonedDateTime(~year: year,
+                       ~month: month,
+                       ~day: day,
+                       ~hour: hour,
+                       ~minute: minute,
+                       ~second: second,
+                       ~nanosecond: nanosecond)
+          .to_string(~format: format,
+                     ~time_format: show_time,
+                     ~time_zone_format: #false)
+
+  export:
+    now
+    from_seconds
+
+  fun now(~local = #true) :~ DateTime:
+    from_seconds(system.milliseconds() / 1000.0,
+                 ~local: local)
+
+  fun from_seconds(secs :: Real,
+                   ~local = #true) :~ DateTime:
+    let d = rkt.#{seconds->date}(secs, local)
+    DateTime(~nanosecond: if rkt.#{date-second}(d) == 60
+                          | 999_999_999
+                          | rkt.#{date*-nanosecond}(d),
+             ~second: if rkt.#{date-second}(d) == 60
+                      | 59
+                      | rkt.#{date-second}(d),
+             ~minute: rkt.#{date-minute}(d),
+             ~hour: rkt.#{date-hour}(d),
+             ~day: rkt.#{date-day}(d),
+             ~month: rkt.#{date-month}(d),
+             ~year: rkt.#{date-year}(d))
+
+
+class Date(~year: year :: Int,
+           ~month: month :: Int.in(1 ..= 12) = 1,
+           ~day: day :: Int.in(1 ..= date.days_in_month(year, month)) = 1):
+  serializable
+  private implements Printable
+  private override method describe(mode, recur):
+    if mode == #'text
+    | to_string()
+    | recur(this, ~as: #'super)
+
+  private implements Comparable
+  private override method compare_to(other :~ Date):
+    if year == other.year
+    | if month == other.month
+      | day - other.day
+      | month - other.month
+    | year - other.year
+
+  property week_day :~ Int: date.week_day(year, month, day)
+  property year_day :~ Int: date.year_day(year, month, day)
+
+  method to_datetime(~time: time :: date.Time = Time()) :~ DateTime:
+    DateTime(~day: day, ~month: month, ~year: year,
+             ~nanosecond: time.nanosecond,
+             ~second: time.second,
+             ~minute: time.minute,
+             ~hour: time.hour)
+
+  method to_seconds() :~ Real:
+    to_datetime().to_seconds()
+
+  method to_string(~format: format :: date.Format = default_format) :~ String:
+    match format
+    | #'rfc3339 || #'iso8601:
+        date_string(year, month, day)
+    | ~else:
+        to_datetime().to_string(~format: format, ~time_format: #false)
+
+  export:
+    now
+    from_seconds
+
+  fun now(~local = #true) :~ Date:
+    from_seconds(system.seconds(),
+                 ~local: local)
+
+  fun from_seconds(secs :: Real,
+                   ~local = #true) :~ Date:
+    let d = rkt.#{seconds->date}(secs, local)
+    Date(~day: rkt.#{date-day}(d),
+         ~month: rkt.#{date-month}(d),
+         ~year: rkt.#{date-year}(d))
+
+class Time(~hour: hour :: Int.in(0 ..= 23) = 0,
+           ~minute: minute :: Int.in(0 ..= 59) = 0,
+           ~second: second :: Int.in(0 ..= 59) = 0,
+           ~nanosecond: nanosecond :: Int.in(0 ..= 999_999_999) = 0):
+  serializable
+
+  private implements Printable
+  private override method describe(mode, recur):
+    if mode == #'text
+    | to_string()
+    | recur(this, ~as: #'super)
+
+  private implements Comparable
+  private override method compare_to(other :~ Time):
+    if hour == other.hour
+    | if minute == other.minute
+      | if second == other.second
+        | nanosecond rhombus_compare_to other.nanosecond
+        | second - other.second
+      | minute - other.minute
+    | hour - other.hour
+
+  method to_string(~time_format: show_time :: date.TimeFormat = #'seconds) :~ String:
+    time_string(hour, minute, second, nanosecond, show_time)
+
+  export:
+    now
+    from_seconds
+
+  fun now(~local = #true) :~ Time:
+    from_seconds(system.milliseconds() / 1000.0,
+                 ~local: local)
+
+  fun from_seconds(secs :: Real,
+                   ~local = #true) :~ Time:
+    let d = rkt.#{seconds->date}(secs, local)
+    if rkt.#{date-second}(d) == 60
+    | Time(~nanosecond: 999_999_999,
+           ~second: 59,
+           ~minute: rkt.#{date-minute}(d),
+           ~hour: rkt.#{date-hour}(d))
+    | Time(~nanosecond: rkt.#{date*-nanosecond}(d),
+           ~second: rkt.#{date-second}(d),
+           ~minute: rkt.#{date-minute}(d),
+           ~hour: rkt.#{date-hour}(d))

--- a/rhombus-lib/rhombus/private/date.rhm
+++ b/rhombus-lib/rhombus/private/date.rhm
@@ -1,0 +1,47 @@
+#lang rhombus/static
+
+export:
+  is_leap_year
+  days_in_year
+  days_in_month
+  year_day
+  week_day
+
+// Based `gregor` and `datetime-lib` by Jon Zeppieri
+
+def days_per_month = Array(0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+def cumulative_month_days = Array(0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334)
+def cumulative_month_days_leap = Array(0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335)
+
+fun is_leap_year(y :: Int):
+  y rem 4 == 0
+    && (!(y rem 100 == 0)
+          || y rem 400 == 0)
+
+fun days_in_year(y :: Int) :~ Int:
+  if is_leap_year(y) | 366 | 365
+
+fun days_in_month(y :: Int, m :: Int.in(1 ..= 12)) :~ Int:
+  days_per_month[m] + (if m == 2 && is_leap_year(y) | 1 | 0)
+
+fun year_day(year :: Int,
+             month :: Int.in(1 ..= 12),
+             day :: Int.in(1 ..= days_in_month(year, month))) :~ Int:
+  day - 1 + (if is_leap_year(year)
+             | cumulative_month_days_leap[month-1]
+             | cumulative_month_days[month-1])
+
+def month_dow_map = Array(0, 3, 2, 5, 0, 3, 5, 1, 4, 6, 2, 4)
+
+fun week_day(year :: Int,
+             month :: Int.in(1 ..= 12),
+             day :: Int.in(1 ..= days_in_month(year, month))) :~ Int:
+  // https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week#Implementation-dependent_methods
+  let y1 = if month < 3 | year-1 | year
+  let d1: y1
+            + y1 div 4
+            - y1 div 100
+            + y1 div 400
+            + month_dow_map[month-1]
+            + day
+  d1 mod 7

--- a/rhombus/rhombus/scribblings/reference/date.scrbl
+++ b/rhombus/rhombus/scribblings/reference/date.scrbl
@@ -1,0 +1,633 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open:
+      except: def
+    "nonterminal.rhm" open
+    meta_label:
+      rhombus/date)
+
+@(def date_eval: make_rhombus_eval())
+@examples(
+  ~hidden: #true
+  ~eval: date_eval
+  import rhombus/date
+)
+
+@title(~style: #'toc, ~tag: "date"){Date and Time}
+
+@docmodule(rhombus/date)
+
+The @rhombusmodname(rhombus/date) library provides basic facilities for
+working with dates and times. A @rhombus(date.Time, ~class) represents
+just a time (relative to an unspecified date and time zone),
+@rhombus(date.Date, ~class) represents just a day (relative to an
+unspecified time zone), a @rhombus(date.DateTime, ~class) has both a
+day and time, and a @rhombus(date.ZonedDateTime, ~class) represents an
+absolute point in time as a date and time in a specific time zone.
+
+@local_table_of_contents()
+
+@// ============================================================
+
+@section(~tag: "date-time"){Time}
+
+@doc(
+  class date.Time(
+    ~hour: hour :: Int.in(0 ..= 23) = 0,
+    ~minute: minute :: Int.in(0 ..= 59) = 0,
+    ~second: second :: Int.in(0 ..= 59) = 0,
+    ~nanosecond: nanosecond :: Int.in(0, 999_999_999) = 0
+  )
+){
+
+ Represents a time relative to an unspecified date and in an unspecified
+ time zone.
+
+ The @rhombus(date.Time, ~annot) class privately implements
+ @rhombus(Comparable, ~class), so @rhombus(date.Time, ~annot) instances
+ can be compared with operators like @rhombus(<) and @rhombus(>).
+ A @rhombus(date.Time, ~annot) instance is @tech{serializable}.
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    def tm = date.Time(~hour: 5, ~minute: 45)
+    tm
+    tm.to_string()
+    tm < date.Time(~hour: 6, ~minute: 10)
+)
+
+}
+
+@doc(
+  fun date.Time.now(~local: local :: Any = #true) :: date.Time
+){
+
+ Uses the system clock via @rhombus(system.milliseconds) to get the
+ current time and using the operating system's facilities to get a time
+ of day relative to either the current time zone (when @rhombus(local) is
+ true) or UTC (when @rhombus(local) is false).
+
+}
+
+
+@doc(
+  fun date.Time.from_seconds(
+    secs :: Real,
+    ~local: local :: Any = #true
+  ) :: date.Time
+){
+
+ Uses operating system facilities to convert a number of seconds since
+ @tech{the epoch} to a time of day relative to either the current time
+ zone (when @rhombus(local) is true) or UTC (when @rhombus(local) is
+ false).
+
+ If the operating system reports a time within a leap second, then the
+ reported time is the end of the preceding second.
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    date.Time.from_seconds(0, ~local: #false)
+)
+
+}
+
+
+@doc(
+  method (tm :: date.Time).to_string(
+    ~time_format: time_format :: date.TimeFormat = #'seconds
+  ) :: String
+){
+
+ Converts @rhombus(tm) to a string format depending on
+ @rhombus(time_format). See @rhombus(date.TimeFormat, ~annot)
+ for more information.
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    def tm1 = date.Time(~hour: 5, ~minute: 45, ~second: 1, ~nanosecond: 70000)
+    tm1.to_string()
+    tm1.to_string(~time_format: #'nanoseconds)
+    tm1.to_string(~time_format: #'auto_subseconds)
+)
+
+}
+
+@// ============================================================
+
+@section(~tag: "date-date"){Date}
+
+@doc(
+  class date.Date(
+    ~year: year :: Int,
+    ~month: month :: Int.in(1 ..= 12) = 1,
+    ~day: day :: Int.in(1 ..= date.days_in_month(year, month)) = 1
+  )
+){
+
+ Represents a date relative to an unspecified time zone.
+
+ The @rhombus(date.Date, ~annot) class privately implements
+ @rhombus(Comparable, ~class), so @rhombus(date.Date, ~annot) instances
+ can be compared with operators like @rhombus(<) and @rhombus(>).
+ A @rhombus(date.Date, ~annot) instance is @tech{serializable}.
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    def dt = date.Date(~year: 1968, ~month: 1, ~day: 24)
+    dt
+    dt.to_string()
+    dt < date.Date(~year: 1969, ~month: 7, ~day: 20)
+    ~error:
+      date.Date(~year: 1999, ~month: 2, ~day: 29)
+)
+
+}
+
+
+@doc(
+  property (dt :: date.Date).week_day :: Int.in(0 ..= 6)
+  property (dt :: date.Date).year_day :: Int.in(0 ..= 366)
+){
+
+ Reports a day of the week or day of the year represented by
+ @rhombus(dt).
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    date.Date(~year: 1968, ~month: 1, ~day: 24).week_day
+)
+
+}
+
+
+@doc(
+  fun date.Date.now(~local: local :: Any = #true) :: date.Date
+){
+
+ Uses the system clock via @rhombus(system.milliseconds) to get the
+ current time and using the operating system's facilities to get a date
+ relative to either the current time zone (when @rhombus(local) is true)
+ or UTC (when @rhombus(local) is false).
+
+}
+
+
+@doc(
+  fun date.Date.from_seconds(
+    secs :: Real,
+    ~local: local :: Any = #true
+  ) :: date.Date
+){
+
+ Uses operating system facilities to convert a number of seconds since
+ @tech{the epoch} to a date relative to either the current time
+ zone (when @rhombus(local) is true) or UTC (when @rhombus(local) is
+ false).
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    date.Date.from_seconds(0, ~local: #false)
+)
+
+}
+
+
+@doc(
+  method (dt :: date.Date).to_string(
+    ~format: format :: date.Format = #'rfc3339
+  ) :: String
+){
+
+ Converts @rhombus(dt) to a string using the format selected by
+ @rhombus(format).
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    def dt1 = date.Date(~year: 1968, ~month: 1, ~day: 24)
+    dt1.to_string()
+    dt1.to_string(~format: #'american)
+)
+
+}
+
+
+@doc(
+  method (dt :: date.Date).to_datetime(
+    ~time: tm :: date.Time = date.Time()
+  ) :: date.DateTime
+){
+
+ Converts a @rhombus(date.Date) to a @rhombus(date.DateTime) using
+ @rhombus(tm) for the time portion of the new @rhombus(date.DateTime),
+ and using UTC as the time zone.
+
+}
+
+@doc(
+  method (dt :: date.Date).to_seconds() :: Real
+){
+
+ Equivalent to @rhombus(dt.to_datetime().to_seconds()).
+
+}
+
+@// ============================================================
+
+@section(~tag: "date-datetime"){Date and Time Combined}
+
+@doc(
+  class date.DateTime(
+    ~year: year :: Int,
+    ~month: month :: Int.in(1 ..= 12) = 1,
+    ~day: day :: Int.in(1 .. date.days_in_month(year, month)) = 1,
+    ~hour: hour :: Int.in(0 ..= 23) = 0,
+    ~minute: minute :: Int.in(0 ..= 59) = 0,
+    ~second: second :: Int.in(0 ..= 59) = 0,
+    ~nanosecond: nanosecond :: Int.in(0, 999_999_000) = 0
+  )
+){
+
+ Combines the fields of @rhombus(date.Date) and @rhombus(date.Time) to
+ represent a specific date and time relative to an unspecified time zone.
+
+ The @rhombus(date.DateTime, ~annot) class privately implements
+ @rhombus(Comparable, ~class), so @rhombus(date.DateTime, ~annot) instances
+ can be compared with operators like @rhombus(<) and @rhombus(>).
+ A @rhombus(date.DateTime, ~annot) instance is @tech{serializable}.
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    def dt = date.DateTime(~year: 2025, ~month: 11, ~day: 14,
+                           ~hour: 18, ~minute: 14)
+    dt
+    dt.to_string()
+    dt > date.DateTime.from_seconds(0)
+)
+
+}
+
+
+@doc(
+  property (dt :: date.DateTime).week_day :: Int.in(0 ..= 6)
+  property (dt :: date.DateTime).year_day :: Int.in(0 ..= 366)
+){
+
+ Reports a day of the week or day of the year represented by
+ @rhombus(dt).
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    date.DateTime(~year: 2025, ~month: 11, ~day: 14).week_day
+)
+
+}
+
+
+@doc(
+  fun date.DateTime.now(~local: local :: Any = #true) :: date.DateTime
+){
+
+ Like @rhombus(date.Date.now), but preserving the current time within
+ the current day.
+
+}
+
+
+@doc(
+  fun date.DateTime.from_seconds(
+    secs :: Real,
+    ~local: local :: Any = #true
+  ) :: date.TimeDate
+){
+
+ Like @rhombus(date.Date.now), but preserving the time of @rhombus(secs)
+ within the day of @rhombus(secs).
+
+ If the operating system reports a time within a leap second, then the
+ reported time is the end of the preceding second.
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    date.DateTime.from_seconds(0, ~local: #false)
+)
+
+}
+
+
+@doc(
+  method (dt :: date.DateTime).to_string(
+    ~format: format :: date.Format = #'rfc3339,
+    ~time_format: time_format :: maybe(date.TimeFormat) = #'seconds,
+  ) :: String
+){
+
+ Converts @rhombus(dt) to a string using the format selected by
+ @rhombus(format). If @rhombus(time_format) is not @rhombus(#false), then
+ the string includes the time portion of @rhombus(dt). The use of
+ @rhombus(time_format) may be limited by @rhombus(format). If a
+ @rhombus(format) requires a time zone, then UTC is used.
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    def dt1 = date.DateTime(~year: 1968, ~month: 1, ~day: 24, ~second: 10)
+    dt1.to_string()
+    dt1.to_string(~format: #'rfc2822)
+)
+
+}
+
+
+@doc(
+  method (dt :: date.DateTime).to_zoned() :: date.ZonedDateTime
+){
+
+ Converts a @rhombus(date.DateTime) to a @rhombus(date.ZonedDateTime)
+ using using UTC as the time zone. This conversion can fail if the date
+ falls outside the (large) range of dates that the operating system can
+ locate.
+
+}
+
+@doc(
+  method (dt :: date.DateTime).to_seconds() :: Real
+){
+
+ Equivalent to @rhombus(dt.to_zoned().to_seconds()).
+
+}
+
+@// ============================================================
+
+@section(~tag: "date-zoneddatetime"){Date and Time in a Time Zone}
+
+@doc(
+  class date.ZonedDateTime(
+    ~year: year :: Int,
+    ~month: month :: Int.in(1 ..= 12) = 1,
+    ~day: day :: Int.in(1 ..= date.days_in_month(year, month)) = 1,
+    ~hour: hour :: Int.in(0 ..= 23) = 0,
+    ~minute: minute :: Int.in(0 ..= 59) = 0,
+    ~second: second :: Int.in(0 ..= 60) = 0,
+    ~nanosecond: nanosecond :: Int.in(0 ..= 999_999_999) = 0,
+    ~is_dst: is_dst :: Boolean = #false,
+    ~time_zone_offset: time_zone_offset :: Int = 0,
+    ~time_zone_name: time_zone_name :: String = "UTC"
+  )
+){
+
+ Represents an absolute date and time within a specific time zone. The
+ @rhombus(time_zone_offset) argument is in seconds. There is no checking
+ that @rhombus(time_zone_offset), @rhombus(is_dst), and and
+ @rhombus(time_zone_name) are consistent, but they will be filled in
+ correctly when a function like @rhombus(date.ZonedDateTime.now)
+ @rhombus(date.ZonedDateTime.from_seconds) is used to create a
+ @rhombus(date.ZonedDateTime, ~class).
+
+ Unlike @rhombus(date.DateTime, ~class),
+ @rhombus(date.ZonedDateTime, ~annot) accommodates a leap second. There
+ is no checking when a @rhombus(date.ZonedDateTime, ~annot) is created
+ that the leap second is appropriate to the date.
+
+ The @rhombus(date.ZonedDateTime, ~annot) class privately implements
+ @rhombus(Comparable, ~class), so @rhombus(date.ZonedDateTime, ~annot)
+ instances can be compared with operators like @rhombus(<) and
+ @rhombus(>). Comparison involves conversion via
+ @rhombus(date.ZonedDateTime.to_seconds).
+ A @rhombus(date.ZonedDateTime, ~annot) instance is @tech{serializable}.
+
+}
+
+
+@doc(
+  property (dt :: date.ZonedDateTime).week_day :: Int.in(0 ..= 6)
+  property (dt :: date.ZonedDateTime).year_day :: Int.in(0 ..= 366)
+){
+
+ Reports a day of the week or day of the year represented by
+ @rhombus(dt).
+
+}
+
+
+@doc(
+  fun date.ZonedDateTime.now(~local: local :: Any = #true) :: date.DateTime
+){
+
+ Like @rhombus(date.DateTime.now), but preserving the time zone selected
+ by @rhombus(local) and (if true) the current time zone, and with a leap
+ second (if any) preserved.
+
+}
+
+
+@doc(
+  fun date.ZonedDateTime.from_seconds(
+    secs :: Real,
+    ~local: local :: Any = #true
+  ) :: date.TimeDate
+){
+
+ Like @rhombus(date.DateTime.from_seconds), but preserving the time zone
+ selected by @rhombus(local) and (if true) the current time zone.
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    date.ZonedDateTime.from_seconds(0, ~local: #false)
+)
+
+}
+
+
+@doc(
+  method (dt :: date.ZonedDateTime).to_string(
+    ~format: format :: date.Format = #'rfc3339,
+    ~time_format: time_format :: maybe(date.TimeFormat) = #'seconds,
+    ~time_zone_format: tz_format :: maybe(date.TimeZoneFormat) = #'offset
+  ) :: String
+){
+
+ Converts @rhombus(dt) to a string in a similar way as
+ @rhombus(date.DateTime.to_string), but with an extra option
+ @rhombus(tz_format) to determine whether a time zone is shown if
+ it is optional for @rhombus(format).
+
+@examples(
+  ~eval: date_eval
+  ~repl:
+    def dt1 = date.ZonedDateTime(~year: 1968, ~month: 1, ~day: 24, ~second: 10,
+                                 ~time_zone_offset: 7 * 60 * 60,
+                                 ~time_zone_name: "MDT")
+    dt1.to_string()
+    dt1.to_string(~format: #'rfc2822)
+)
+
+}
+
+
+@doc(
+  method (dt :: date.ZonedDateTime).to_seconds() :: Real
+){
+
+ Returns the number of seconds since @tech{the epoch} until
+ @rhombus(dt).
+
+}
+
+@// ============================================================
+
+@section(~tag: "date-format"){Date Formats and Utilities}
+
+@doc(
+  enum date.Format:
+    rfc2822
+    rfc3339
+    iso8601
+    american
+    european
+    julian
+){
+
+ A format supported by @rhombus(date.Date.to_string),
+ @rhombus(date.DateTime.to_string), and
+ @rhombus(date.ZonedDateTime.to_string):
+
+@itemlist(
+
+  @item{@rhombus(#'rfc2822): follows
+   @hyperlink("https://datatracker.ietf.org/doc/html/rfc2822"){RFC 2822}.}
+
+  @item{@rhombus(#'rfc3339): follows
+   @hyperlink("https://datatracker.ietf.org/doc/html/rfc3339"){RFC 3339},
+   specifically using a space character between a date and time, and
+   showing a time zone offset (if requested) as @litchar{Z},
+   @tt{@litchar{+}HH@litchar{:}MM} or @tt{@litchar{+}HH@litchar{:}MM}.}
+
+  @item{@rhombus(#'iso8601): follows ISO 8601, showing a time zone offset
+   (if requested) as @litchar{Z}, @tt{@litchar{+}HH@litchar{:}MM}, or
+   @tt{@litchar{+}HH@litchar{:}MM}.}
+
+  @item{@rhombus(#'american): shows a date in an English, human-readable
+   form that spells out a month and day of the week, putting the month
+   before the day.}
+
+  @item{@rhombus(#'european): shows a date in an English, human-readable
+   form that spells out a month and day of the week, putting the date
+   before the month.}
+
+  @item{@rhombus(#'julian): shows the date in Julian form.}
+
+)
+
+}
+
+
+@doc(
+  enum date.TimeFormat:
+    minutes
+    seconds
+    milliseconds
+    microseconds
+    nanoseconds
+    auto_subminutes
+    auto_subseconds
+){
+
+ A time format that selects the smallest time granularity to be shown,
+ sometimes used as @rhombus(maybe(date.TimeZoneFormat), ~annot) so that
+ @rhombus(#false) means that a time is not shown.
+
+@itemlist(
+
+ @item{@rhombus(#'minutes): Produces @tt{HH@litchar{:}MM}}
+
+ @item{@rhombus(#'seconds): Produces @tt{HH@litchar{:}MM@litchar{:}SS}}
+
+ @item{@rhombus(#'milliseconds): Produces @tt{HH@litchar{:}MM@litchar{:}SS@litchar{.}SSS}}
+
+ @item{@rhombus(#'microseconds): Produces @tt{HH@litchar{:}MM@litchar{:}SS@litchar{.}SSSSSS}}
+
+ @item{@rhombus(#'nanoseconds): Produces @tt{HH@litchar{:}MM@litchar{:}SS@litchar{.}SSSSSSSSS}}
+
+ @item{@rhombus(#'auto_subminutes): The same as @rhombus(#'minutes) if
+  seconds and nanoseconds are zero, the same as @rhombus(#'auto_subseconds) otherwise.}
+
+ @item{@rhombus(#'auto_subseconds): The same as @rhombus(#'seconds) if
+  nanoseconds are zero, and otherwise the same as
+  @rhombus(#'milliseconds), @rhombus(#'microseconds), or
+  @rhombus(#'nanoseconds) depending on the number of trailing zeros
+  available to be omitted.}
+
+)
+
+}
+
+
+@doc(
+  enum date.TimeZoneFormat:
+    offset
+){
+
+ A time-zone format. Although only one format is currently supported,
+ this annotation is used as @rhombus(maybe(date.TimeZoneFormat), ~annot)
+ so that @rhombus(#false) means that a time zone is not shown.
+
+}
+
+
+@doc(
+  fun date.is_leap_year(year :: Int) :: Boolean
+  fun date.days_in_year(year :: Int) :~ Int.in(365 ..= 366)
+){
+
+ Reports whether a year is a leap year or whether it has 365 or 366
+ days.
+
+}
+
+@doc(
+  fun date.days_in_month(year :: Int,
+                         month :: Int.in(1 ..= 12)) :: Int.in(28 ..= 31)
+){
+
+ Returns the number of days in a given month during a specific year.
+
+}
+
+@doc(
+  fun date.year_day(
+    year :: Int,
+    month :: Int.in(1 ..= 12),
+    day :: Int.in(1 ..= date.days_in_month(year, month))
+  ) :: Int.in(0 ..= 365)
+){
+
+ Reports the index of a given day for a specific month within a specific
+ year.
+
+}
+
+@doc(
+  fun date.week_day(
+    year :: Int,
+    month :: Int.in(1 ..= 12),
+    day :: Int.in(1 ..= date.days_in_month(year, month))
+  ) :: Int.in(0 ..= 6)
+){
+
+ Reports the index of a day of the week for a given day of a specific
+ month within a specific year.
+
+}

--- a/rhombus/rhombus/scribblings/reference/os.scrbl
+++ b/rhombus/rhombus/scribblings/reference/os.scrbl
@@ -12,4 +12,5 @@
 @include_section("subprocess.scrbl")
 @include_section("network.scrbl")
 @include_section("system.scrbl")
+@include_section("date.scrbl")
 @include_section("cmdline.scrbl")

--- a/rhombus/rhombus/scribblings/reference/system.scrbl
+++ b/rhombus/rhombus/scribblings/reference/system.scrbl
@@ -106,7 +106,7 @@
 ){
 
  The @rhombus(system.seconds) reports the current time in seconds since
- the epoch---which is consistent with the
+ @deftech{the epoch}, January 1, 1970 UTC, which is consistent with the
  @rhombus(filesystem.modify_seconds) function's result, for example. The
  @rhombus(system.milliseconds) function reports the same time with more
  precision, expressed in milliseconds (including fractional milliseconds)

--- a/rhombus/rhombus/tests/date.rhm
+++ b/rhombus/rhombus/tests/date.rhm
@@ -1,0 +1,198 @@
+#lang rhombus/static
+import:
+  rhombus/date open
+  rhombus/rx open
+  rhombus/serialize open
+
+def now = system.milliseconds() / 1000.0
+
+def time_rx = rx'digit{2} ":" digit{2} ":" digit{2}'
+def time_ns_rx = rx'$time_rx "."? digit*'
+
+check:
+  Time().nanosecond ~is 0
+  Time().second ~is 0
+  Time().minute ~is 0
+  Time().hour ~is 0
+  Time(~nanosecond: 0.5) ~throws error.annot_msg()
+  Time(~nanosecond: "x") ~throws error.annot_msg()
+  Time(~nanosecond: 1_000_000_000) ~throws error.annot_msg()
+  Time(~second: 0.5) ~throws error.annot_msg()
+  Time(~second: 60) ~throws error.annot_msg()
+  Time(~minute: 0.5) ~throws error.annot_msg()
+  Time(~hour: 0.5) ~throws error.annot_msg()
+  Time.from_seconds(now) ~is Time.from_seconds(now)
+  Time.now() >= Time.from_seconds(now) ~is #true
+  Time.now() < Time.from_seconds(now) ~is #false
+  Time.now().to_string() ~matches time_rx
+  Time.now().to_string(~time_format: #'nanoseconds) ~matches time_ns_rx
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4).to_string() ~is "01:02:03"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4).to_string(~time_format: #'seconds) ~is "01:02:03"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4).to_string(~time_format: #'minutes) ~is "01:02"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 0).to_string(~time_format: #'auto_subminutes) ~is "01:02:03"
+  Time(~hour: 1, ~minute: 2, ~second: 0, ~nanosecond: 0).to_string(~time_format: #'auto_subminutes) ~is "01:02"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4).to_string(~time_format: #'auto_subminutes) ~is "01:02:03.000000004"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4).to_string(~time_format: #'nanoseconds) ~is "01:02:03.000000004"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4).to_string(~time_format: #'auto_subseconds) ~is "01:02:03.000000004"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 400).to_string(~time_format: #'nanoseconds) ~is "01:02:03.000000400"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 400).to_string(~time_format: #'auto_subseconds) ~is "01:02:03.000000400"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4_000).to_string(~time_format: #'nanoseconds) ~is "01:02:03.000004000"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4_000).to_string(~time_format: #'auto_subseconds) ~is "01:02:03.000004"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 400_000).to_string(~time_format: #'nanoseconds) ~is "01:02:03.000400000"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 400_000).to_string(~time_format: #'auto_subseconds) ~is "01:02:03.000400"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4_000_000).to_string(~time_format: #'nanoseconds) ~is "01:02:03.004000000"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 4_000_000).to_string(~time_format: #'auto_subseconds) ~is "01:02:03.004"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 400_000_000).to_string(~time_format: #'nanoseconds) ~is "01:02:03.400000000"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 400_000_000).to_string(~time_format: #'auto_subseconds) ~is "01:02:03.400"
+  Time(~hour: 1, ~minute: 2, ~second: 3, ~nanosecond: 400_000_000).to_string(~time_format: #'auto_subminutes) ~is "01:02:03.400"
+  deserialize(serialize(Time.from_seconds(now))) ~is Time.from_seconds(now)
+
+def d = Date(~year: 2000, ~month: 5, ~day: 23)
+
+check:
+  d.year ~is 2000
+  d.month ~is 5
+  d.day ~is 23
+  Date(~year: 2025).year ~is 2025
+  Date(~year: 2025).month ~is 1
+  Date(~year: 2025).day ~is 1
+  Date(~year: 0, ~month: 1, ~day: 1).year ~is 0
+  Date(~year: -100, ~month: 1, ~day: 1).year ~is -100
+  Date(~year: 0.5, ~month: 1, ~day: 1) ~throws error.annot_msg()
+  Date(~year: 0, ~month: 1, ~day: 0.5) ~throws error.annot_msg()
+  Date(~year: 0, ~month: 0.5, ~day: 1) ~throws error.annot_msg()
+  Date(~year: 2024, ~month: 2, ~day: 29) ~is_a Date
+  Date(~year: 2024, ~month: 2, ~day: 30) ~throws error.annot_msg()
+  Date(~year: 2025, ~month: 2, ~day: 29) ~throws error.annot_msg()
+  d.week_day ~is 2
+  d.year_day ~is 143
+  d < Date(~year: 2003, ~month: 5, ~day: 22) ~is #true
+  Date.now() >= Date.from_seconds(now) ~is #true
+  Date.now() < Date.from_seconds(now) ~is #false
+  Date.from_seconds(now).to_seconds() < now ~is #true
+  (Date.now() with (year = Date.now().year + 1)).to_seconds() > now ~is #true
+  d.to_datetime().year ~is 2000
+  d.to_datetime().month ~is 5
+  d.to_datetime().day ~is 23
+  d.to_datetime().second ~is 0
+  d.to_datetime(~time: Time(~second: 8)).second ~is 8
+  d.to_string() ~is "2000-05-23"
+  d.to_string(~format: #'rfc3339) ~is "2000-05-23"
+  d.to_string(~format: #'iso8601) ~is "2000-05-23"
+  d.to_string(~format: #'american) ~is "Tuesday, May 23rd, 2000"
+  d.to_string(~format: #'european) ~is "Tuesday, 23rd May 2000"
+  d.to_string(~format: #'rfc2822) ~is "Tue, 23 May 2000"
+  d.to_string(~format: #'julian) ~is "JD 2 451 688"
+  d.to_string(~format: #'incorrect) ~throws error.annot_msg("argument")
+  deserialize(serialize(d)) ~is d
+  d with (day = 100) ~throws error.annot_msg()
+
+def dt = DateTime(~year: 2003, ~month: 5, ~day: 22,
+                  ~hour: 9, ~minute: 20)
+
+check:
+  DateTime(~year: 2025).year ~is 2025
+  DateTime(~year: 2025).month ~is 1
+  DateTime(~year: 2025).day ~is 1
+  DateTime(~year: 0.5, ~month: 1, ~day: 1) ~throws error.annot_msg()
+  DateTime(~year: 0, ~month: 1, ~day: 0.5) ~throws error.annot_msg()
+  DateTime(~year: 0, ~month: 0.5, ~day: 1) ~throws error.annot_msg()
+  DateTime(~year: 2024, ~month: 2, ~day: 29) ~is_a DateTime
+  DateTime(~year: 2024, ~month: 2, ~day: 30) ~throws error.annot_msg()
+  DateTime(~year: 2025, ~month: 2, ~day: 29) ~throws error.annot_msg()
+  DateTime(~year: 2025, ~month: 2, ~day: 28, ~hour: 0.5) ~throws error.annot_msg()
+  DateTime(~year: 2025, ~month: 2, ~day: 28, ~minute: 0.5) ~throws error.annot_msg()
+  DateTime(~year: 2025, ~month: 2, ~day: 28, ~second: 0.5) ~throws error.annot_msg()
+  DateTime(~year: 2025, ~month: 2, ~day: 28, ~second: 60) ~throws error.annot_msg()
+  DateTime(~year: 2025, ~month: 2, ~day: 28, ~nanosecond: -5) ~throws error.annot_msg()
+  dt with (day = 100) ~throws error.annot_msg()
+  dt.year ~is 2003
+  dt.month ~is 5
+  dt.day ~is 22
+  dt.hour ~is 9
+  dt.minute ~is 20
+  dt.second ~is 0
+  dt.nanosecond ~is 0
+  dt.week_day ~is 4
+  dt.year_day ~is 141
+  DateTime.now() > dt ~is #true
+  DateTime.now() >= DateTime.from_seconds(now) ~is #true
+  DateTime.from_seconds(now, ~local: #false).to_seconds() ~is now
+  dt.to_zoned().time_zone_offset ~is 0
+  dt.to_zoned().year ~is 2003
+  dt.to_zoned().minute ~is 20
+  dt.to_string() ~is "2003-05-22 09:20:00"
+  dt.to_string(~time_format: #'auto_subseconds) ~is "2003-05-22 09:20:00"
+  dt.to_string(~time_format: #'seconds) ~is "2003-05-22 09:20:00"
+  dt.to_string(~time_format: #'auto_subminutes) ~is "2003-05-22 09:20"
+  dt.to_string(~time_format: #'minutes) ~is "2003-05-22 09:20"
+  (dt with (nanosecond = 1_000_000)).to_string(~time_format: #'auto_subseconds) ~is "2003-05-22 09:20:00.001"
+  dt.to_string(~format: #'iso8601) ~is "2003-05-22T09:20:00"
+  dt.to_string(~format: #'iso8601, ~time_format: #'minutes) ~is "2003-05-22T09:20"
+  dt.to_string(~format: #'american) ~is "Thursday, May 22nd, 2003 9:20:00am"
+  dt.to_string(~format: #'european) ~is "Thursday, 22nd May 2003, 9:20am"
+  dt.to_string(~format: #'rfc2822) ~is "Thu, 22 May 2003 09:20:00 +0000"
+  dt.to_string(~format: #'julian) ~is "JD 2 452 782, 09:20:00"
+  deserialize(serialize(dt)) ~is dt
+
+def zdt = ZonedDateTime(~year: 1995, ~month: 8, ~day: 18,
+                        ~hour: 1, ~minute: 2, ~second: 3,
+                        ~time_zone_offset: 6*60*60,
+                        ~time_zone_name: "CDT")
+
+check:
+  ZonedDateTime(~year: 2025).year ~is 2025
+  ZonedDateTime(~year: 2025).month ~is 1
+  ZonedDateTime(~year: 2025).day ~is 1
+  ZonedDateTime(~year: 0.5, ~month: 1, ~day: 1) ~throws error.annot_msg()
+  ZonedDateTime(~year: 0, ~month: 1, ~day: 0.5) ~throws error.annot_msg()
+  ZonedDateTime(~year: 0, ~month: 0.5, ~day: 1) ~throws error.annot_msg()
+  ZonedDateTime(~year: 2024, ~month: 2, ~day: 29) ~is_a ZonedDateTime
+  ZonedDateTime(~year: 2024, ~month: 2, ~day: 30) ~throws error.annot_msg()
+  ZonedDateTime(~year: 2025, ~month: 2, ~day: 29) ~throws error.annot_msg()
+  ZonedDateTime(~year: 2025, ~month: 2, ~day: 28, ~hour: 0.5) ~throws error.annot_msg()
+  ZonedDateTime(~year: 2025, ~month: 2, ~day: 28, ~minute: 0.5) ~throws error.annot_msg()
+  ZonedDateTime(~year: 2025, ~month: 2, ~day: 28, ~second: 0.5) ~throws error.annot_msg()
+  ZonedDateTime(~year: 2025, ~month: 2, ~day: 28, ~second: 60) ~is_a ZonedDateTime
+  ZonedDateTime(~year: 2025, ~month: 2, ~day: 28, ~nanosecond: -5) ~throws error.annot_msg()
+  zdt with (day = 100) ~throws error.annot_msg()
+  zdt.year ~is 1995
+  zdt.month ~is 8
+  zdt.day ~is 18
+  zdt.hour ~is 1
+  zdt.minute ~is 2
+  zdt.second ~is 3
+  zdt.nanosecond ~is 0
+  zdt.year_day ~is 229
+  zdt.week_day ~is 5
+  zdt.time_zone_offset ~is 6*60*60
+  zdt.time_zone_name ~is "CDT"
+  zdt.to_string() ~is "1995-08-18 01:02:03+06:00"
+  zdt.to_string(~format: #'iso8601) ~is "1995-08-18T01:02:03+06:00"
+  zdt.to_string(~format: #'iso8601, ~time_zone_format: #false) ~is "1995-08-18T01:02:03"
+  zdt.to_string(~format: #'iso8601, ~time_format: #'minutes) ~is "1995-08-18T01:02+06:00"
+  zdt.to_string(~time_zone_format: #false) ~is "1995-08-18 01:02:03"
+  zdt.to_string(~time_format: #'minutes, ~time_zone_format: #false) ~is "1995-08-18 01:02"
+  (zdt with (time_zone_offset = 0)).to_string() ~is "1995-08-18 01:02:03Z"
+  (zdt with (time_zone_offset = -3660)).to_string() ~is "1995-08-18 01:02:03-01:01"
+  ZonedDateTime.now() > zdt ~is #true
+  ZonedDateTime.from_seconds(now) > zdt ~is #true
+  ZonedDateTime.from_seconds(now, ~local: #false).to_seconds() ~is now
+  ZonedDateTime.from_seconds(now) ~is ZonedDateTime.from_seconds(now)
+  deserialize(serialize(zdt)) ~is zdt
+
+check:
+  is_leap_year(2000) ~is #true
+  is_leap_year(2001) ~is #false
+  is_leap_year(2100) ~is #false
+  days_in_year(2000) ~is 366
+  days_in_year(2001) ~is 365
+  days_in_year(2100) ~is 365
+  days_in_month(2000, 1) ~is 31
+  days_in_month(2000, 2) ~is 29
+  days_in_month(2001, 2) ~is 28
+  days_in_month(2000, 12) ~is 31
+  week_day(2025, 11, 16) ~is 0
+  year_day(2025, 1, 1) ~is 0
+  year_day(2025, 11, 16) ~is 319
+  year_day(2025, 12, 31) ~is 364


### PR DESCRIPTION
This attempt to add time and date functions in a `rhombus/date` library is based on the `gregor` library for Racket and Java's `date.LocalTime`, etc., classes. It doesn't try to do everything that those do, but instead provides basic functionality that is available from `racket/base` and `racket/date`, but in a form that hopefully does not preclude improvements and compatible generalization by new libraries (unlike the way Gregor has to avoid the Racket `date` structure type).

I think I get why Java puts `Local` in the names of classes, but I have opted not to do that, but the name `ZonedDateTime` does come from Java.

API sumary:

```
export:
  Time
  Date
  DateTime
  ZonedDateTime
  Format  

class Time(~hour: hour :: Int.in(0, 23) = 0,
           ~minute: minute :: Int.in(0, 59) = 0,
           ~second: second :: Int.in(0, 60) = 0,
           ~nanosecond: nanosecond :: Int.in(0, 999_999_999) = 0):
  private implements Comparable

  fun now(~local = #true) :: Time

  fun from_seconds(secs :: Real,
                   ~local = #true) :: Time             

  method to_string(~show_nanosecond = #false) :: String

class Date(~year: year :: Int,
           ~month: month :: Int.in(1, 12 ~inclusive),
           ~day: day :: Int.in(1, 31 ~inclusive)):
  private implements Comparable

  fun now(~local = #true) :: Date

  fun from_seconds(secs :: Real,
                   ~local = #true) :: Date

  method to_datetime(~time: time :: date.Time = Time()) :: DateTime
  
  method to_seconds() :: Real

  method to_string(~format: format :: date.Format = default_format) :: String

class DateTime(~year: year :: Int,
               ~month: month :: Int.in(1, 12),
               ~day: day :: Int.in(1, 31),
               ~hour: hour :: Int.in(0, 23) = 0,
               ~minute: minute :: Int.in(0, 59) = 0,
               ~second: second :: Int.in(0, 60) = 0,
               ~nanosecond: nanosecond :: Int.in(0, 999_999_999) = 0):
  private implements Comparable

  fun now(~local = #true) :: DateTime

  fun from_seconds(secs :: Real,
                   ~local = #true) :: DateTime

  method to_seconds() :: Real

  method to_zoned() :: ZonedDateTime

  method to_string(~format: format :: date.Format = default_format,
                   ~show_time = #true,
                   ~show_nanosecond = #false) :: String

class ZonedDateTime(~year: year :: Int,
                    ~month: month :: Int.in(1, 12),
                    ~day: day :: Int.in(1, 31),
                    ~hour: hour :: Int.in(0, 23) = 0,
                    ~minute: minute :: Int.in(0, 59) = 0,
                    ~second: second :: Int.in(0, 60) = 0,
                    ~nanosecond: nanosecond :: Int.in(0, 999_999_999) = 0,
                    ~week_day: week_day :: Int.in(0, 6) = 0,
                    ~year_day: year_day :: Int.in(0, 365) = 0,
                    ~is_dst: is_dst :: Boolean = #false,
                    ~time_zone_offset: time_zone_offset :: Int = 0,
                    ~time_zone_name: time_zone_name :: String = "UTC"):
  private implements Comparable

  fun now() :: ZonedDateTime

  fun from_seconds(secs :: Real,
                   ~local: local = #true)

  fun find_seconds(~second: second :: Int.in(0, 60) = 0,
                   ~minute: minute :: Int.in(0, 59) = 0,
                   ~hour: hour :: Int.in(0, 23) = 0,
                   ~day: day :: Int.in(1, 31),
                   ~month: month :: Int.in(1, 12),
                   ~year: year :: Int,
                   ~local: local = #true) :: Int

  method to_string(~format: format :: date.Format = default_format,
                   ~show_time = #true,
                   ~show_nanosecond = #false,
                   ~show_time_zone = #true) :: String

  method to_seconds() :: Real

enum Format:
  rfc2822
  rfc3339
  iso8601
  american
  european
  julian

```
