### PR TITLE
revise rules for defining identifier/operator as a macro

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/macro-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/macro-macro.rkt
@@ -301,16 +301,13 @@
 
   (define-splicing-syntax-class :operator-or-identifier-or-$
     #:attributes (name extends)
-    #:description "macro identifier or operator"
+    #:description "macro identifier or operator, possibly parenthesized"
     #:datum-literals (op group)
-    (pattern (~seq ::name)
-             #:when (not (free-identifier=? (in-binding-space #'name) (bind-quote $)
-                                            (add1 (syntax-local-phase-level)) (syntax-local-phase-level)))
-             #:with extends #'#f)
-    (pattern (~seq (_::parens (group seq::dotted-operator-or-identifier-sequence)))
+    (pattern (~seq seq::dotted-operator-or-identifier-sequence)
+             #:with (~not (_::$+1)) #'seq
              #:with ::dotted-operator-or-identifier #'seq)
-    (pattern (~seq _::$+1 (_::parens (group (_::quotes (group (op (~and name (~datum $))))))))
-             #:with extends #'#f))
+    (pattern (~seq (_::parens (group seq::dotted-operator-or-identifier-sequence)))
+             #:with ::dotted-operator-or-identifier #'seq))
 
   (define-syntax-class :identifier-for-parsed
     #:attributes (id)

--- a/rhombus-lib/rhombus/private/amalgam/rx.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/rx.rhm
@@ -221,20 +221,20 @@ rx.macro
 
 // Escape operators + end of line operator
 rx.macro
-| '$('$')$(id :: Identifier): $body':
+| '($) $(id :: Identifier): $body':
     ~stronger_than: ~other
     let '$(p :: rx_meta.Parsed); ...' = body
     let ['[$pat, [$p_var, ...]]', ...] = [rx_meta.unpack(p), ...]
     rx_meta.pack('[capture(sequence($pat, ...)), [$id, $p_var, ..., ...]]')
-| '$('$') $(name :: IdentifierName)':
+| '($) $(name :: IdentifierName)':
     if name is_a Identifier
     | rx_meta.pack('[backref_or_splice($name), [[~maybe_splice, $name]]]')
     | rx_meta.pack('[splice($name), [[~maybe_splice, ~other]]]')
-| '$('$') $(index :: Int)':
+| '($) $(index :: Int)':
     rx_meta.pack('[backref($index), []]')
-| '$('$') $(term :: Term)':
+| '($) $(term :: Term)':
     rx_meta.pack('[splice($term), [[~maybe_splice, ~other]]]')
-| '$('$') $(index :: Int)':
+| '($) $(index :: Int)':
     ~all_stx: stx
     unless index.unwrap() is_a PosInt
     | syntax_meta.error("invalid match index", stx, index)

--- a/rhombus/rhombus/scribblings/meta/defn-macro.scrbl
+++ b/rhombus/rhombus/scribblings/meta/defn-macro.scrbl
@@ -47,9 +47,8 @@
     '$defined_name $pattern ...'
 
   grammar defined_name:
-    $id
-    $op
-    #,(dollar)('#,(dollar)')
+    $id_name
+    $op_name
     ($id_name)
     ($op_name)
 
@@ -64,8 +63,10 @@
     ~effect_id $id
 ){
 
- Defines @rhombus(defined_name) as a macro
- in the @rhombus(expr, ~space) @tech{space}. The macro can be used
+ Defines the @rhombus(id_name) or @rhombus(op_name) within
+ @rhombus(defined_name) as a macro
+ in the @rhombus(expr, ~space) @tech{space}, where @rhombus(defined_name)
+ is constrained in the same way as for @rhombus(macro, ~defn). The macro can be used
  in a definition context, where the compile-time
  @rhombus(body) block returns the expansion result. The macro pattern is
  matched to an entire group in a definition context.

--- a/rhombus/rhombus/scribblings/reference/macro.scrbl
+++ b/rhombus/rhombus/scribblings/reference/macro.scrbl
@@ -42,9 +42,8 @@
     '$ $left_parsed_id $defined_name $ $right_parsed_id'
     '$ $left_parsed_id $defined_name $pattern ...'
   grammar defined_name:
-    $id
-    $op
-    #,(dollar)('#,(dollar)')
+    $id_name
+    $op_name
     ($id_name)
     ($op_name)
     ()
@@ -79,14 +78,20 @@
     ~none
 ){
 
- As a definition form, @rhombus(macro) defines the @rhombus(defined_name)
- (which is an operator or identifier) within @rhombus(macro_pattern) as a
+ As a definition form, @rhombus(macro) defines the @rhombus(id_name) or
+ @rhombus(op_name) within @rhombus(defined_name) (within @rhombus(macro_pattern)) as a
  pattern-based macro whose expansion is described by a
- @rhombus(template). When @rhombus(defined_name) is a plain
- @rhombus(op), it cannot be @rhombus($), but the form
- @rhombus($('$')) can be used to define @rhombus($). A
+ @rhombus(template). A @rhombus(defined_name) can have parentheses
+ around the identifier or operator to define to distinguish it from other
+ potential roles. Specifically, when @rhombus(defined_name) is a plain
+ @rhombus(op_name), it cannot be @rhombus($, ~bind), but the form
+ @rhombus(($), ~datum) can be used to define @rhombus($, ~datum). To avoid a @rhombus(.)
+ operator being treated as part of a @rhombus(defined_name), either
+ wrap the defined @rhombus(id_name) or @rhombus(op_name) within parentheses
+ use the pattern @rhombus($('.')). A
  @rhombus(defined_name) cannot be @rhombus(()) for a @rhombus(macro)
- definition. The @rhombus(defined_name) is bound in the
+ definition; the form is used for @rhombus(macro) expressions (as described
+ further below). The @rhombus(defined_name) is bound in the
  @rhombus(expr, ~space) @tech(~doc: meta_doc){space}.
 
  As an expression or @tech{entry point}, @rhombus(macro) is a shorthand

--- a/rhombus/rhombus/tests/defn-macro.rhm
+++ b/rhombus/rhombus/tests/defn-macro.rhm
@@ -168,3 +168,17 @@ check:
   guard_let_pos x = 7
   "done!"
   ~is "done!"
+
+block:
+  defn.macro '(f).g': '"ok"'
+  check f.g ~is "ok"
+
+check:
+  ~eval
+  import rhombus/meta open
+  defn.macro 'f.g': '"ok"'
+  ~throws "f: not defined as a namespace"
+
+block:
+  defn.macro '($)g': '"ok"'
+  check $g ~is "ok"

--- a/rhombus/rhombus/tests/expr-macro.rhm
+++ b/rhombus/rhombus/tests/expr-macro.rhm
@@ -474,3 +474,19 @@ check:
     values(rhs, '$rhs.tail ...')
   ns.id 42
   ~is 42
+
+block:
+  expr.macro '($)g': '"ok"'
+  check $g ++ "z" ~is "okz"
+
+block:
+  expr.macro '$a ($)g': '$a ++ "ok"'
+  check "a" $g ++ "z" ~is "aokz"
+
+block:
+  expr.macro '$a (.) g': '$a ++ "ok"'
+  check "a" . g ++ "z" ~is "aokz"
+
+block:
+  expr.macro '$a . g': '$a ++ "ok"'
+  check "a" . g ++ "z" ~is "aokz"

--- a/rhombus/rhombus/tests/pattern-template-escape.rhm
+++ b/rhombus/rhombus/tests/pattern-template-escape.rhm
@@ -51,14 +51,14 @@ check:
   ~is "dotss"
 
 check:
-  // special syntax to define `$` as a prefix operator
-  expr.macro '$('$') $x': '1 + $x'
+  // parentheses to define `$` as a prefix operator
+  expr.macro '($) $x': '1 + $x'
   $10
   ~is 11
 
 check:
-  // special syntax to `$` as an infix operator
-  expr.macro '$x $('$') $y': '[$x, $y]'
+  // parentheses to `$` as an infix operator
+  expr.macro '$x ($) $y': '[$x, $y]'
   1 $ 2
   ~is [1, 2]
 
@@ -97,7 +97,7 @@ check:
   // phase-1 bindings of `$` makes `macro` bind `$`
   meta:
     operator ($ b): b
-    bind.macro '$('$')': 'no'
+    bind.macro '($)': 'no'
   macro '$x + $y': '[$x, $y]'
   (1+2)
   ~is 3

--- a/rhombus/rhombus/tests/rx-space.rhm
+++ b/rhombus/rhombus/tests/rx-space.rhm
@@ -130,7 +130,7 @@ regexp.macro
     regexp_meta.pack("^" ++ regexp_meta.unpack(right))
 
 regexp.macro
-| '$left $('$')':
+| '$left ($)':
     ~weaker_than: #%juxtapose #%call
     ~same_as: ^
     regexp_meta.pack(regexp_meta.unpack(left) +& "$")


### PR DESCRIPTION
Suggested by @distractedlambda, a revision to the "defined_name" rules in `expr.macro` and similar.

Currently, `expr.macro 'x.y'` defines `x` as expecting a literal `.y` afterward, while `expr.macro '(x.y)'` is needed to define `x.y` (extending an existing namespace `y`). This has confused me a few times, and the `expr.macro` form for `doc` was nont consistent with this rule. The main change here is to reverse the treatment of `.`, so you'd have to write `expr.macro '(x).y'` if you want to define `x` that expects a literal `.y` afterward. If you mistakenly write `x . y` when you mean `(x) . y`, then you're much more likely to get a helpful error message.

Also, instead of a special rule for `$('$')`, rely on the fact that `($)` works to define `$`.
