### PR TITLE
`values` reducer: support general pattern bindings

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/for.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/for.rkt
@@ -93,23 +93,26 @@
               red-parsed
               (relocate+reraw
                (respan stx)
-               #`(f.wrapper
-                  f.data
-                  (for/fold f.binds
-                            (#:splice (for-clause-step #,stx
-                                                       #,static?
-                                                       [(f.body-wrapper f.data)
-                                                        #,@(if (syntax-e #'f.pre-clause-former)
-                                                               (list #'(f.pre-clause-former f.data))
-                                                               '())]
-                                                       . #,body))
-                    #,@(if (syntax-e #'f.break-whener)
-                           #`(#:break (f.break-whener f.data))
-                           null)
-                    #,@(if (syntax-e #'f.final-whener)
-                           #`(#:final (f.final-whener f.data))
-                           null)
-                    (f.finisher f.data)))))
+               #`(let ()
+                   f.pre-defn
+                   ...
+                   (f.wrapper
+                    f.data
+                    (for/fold f.binds
+                              (#:splice (for-clause-step #,stx
+                                                         #,static?
+                                                         [(f.body-wrapper f.data)
+                                                          #,@(if (syntax-e #'f.pre-clause-former)
+                                                                 (list #'(f.pre-clause-former f.data))
+                                                                 '())]
+                                                         . #,body))
+                      #,@(if (syntax-e #'f.break-whener)
+                             #`(#:break (f.break-whener f.data))
+                             null)
+                      #,@(if (syntax-e #'f.final-whener)
+                             #`(#:final (f.final-whener f.data))
+                             null)
+                      (f.finisher f.data))))))
              #'f.static-infos)])])
       #'()))))
 

--- a/rhombus-lib/rhombus/private/amalgam/reducer.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/reducer.rkt
@@ -33,7 +33,8 @@
 
   (define-syntax-class :reducer-form
     #:description "reducer"
-    (pattern [wrapper:id
+    (pattern [(pre-defn ...)
+              wrapper:id
               (~and binds ([id:identifier init-expr] ...))
               (~and pre-clause-former (~or* #f _:id))
               body-wrapper:id
@@ -43,11 +44,13 @@
               static-infos
               data]))
 
-  (define (reducer wrapper binds
+  (define (reducer #:pre-defns [pre-defns '()]
+                   wrapper binds
                    pre-clause-former
                    body-wrapper break-whener final-whener finisher
                    static-infos data)
-    #`(#,wrapper
+    #`(#,pre-defns
+       #,wrapper
        #,binds
        #,pre-clause-former
        #,body-wrapper
@@ -57,10 +60,12 @@
        #,static-infos
        #,data))
 
-  (define (reducer/no-break wrapper binds
+  (define (reducer/no-break #:pre-defns [pre-defns '()]
+                            wrapper binds
                             body-wrapper static-infos data
                             #:pre-clause [pre-clause-former #f])
-    #`(bounce-to-wrapper
+    #`(#,pre-defns
+       bounce-to-wrapper
        #,binds
        #,(and pre-clause-former #'bounce-to-pre-clause-former)
        bounce-to-body-wrapper

--- a/rhombus/rhombus/scribblings/reference/values.scrbl
+++ b/rhombus/rhombus/scribblings/reference/values.scrbl
@@ -82,13 +82,8 @@
 }
 
 @doc(
-  reducer.macro 'values($id $maybe_annot $init, ...)'
-  reducer.macro 'fold($id $maybe_annot $init, ...)'
-
-  grammar maybe_annot:
-    #,(@rhombus(::, ~bind)) $annot
-    #,(@rhombus(:~, ~bind)) $annot
-    #,(epsilon)
+  reducer.macro 'values($bind $init, ...)'
+  reducer.macro 'fold($bind $init, ...)'
 
   grammar init:
     = $expr
@@ -96,14 +91,15 @@
 ){
 
  A @tech(~doc: guide_doc){reducer} used with @rhombus(for), expects as many results from a
- @rhombus(for) body as @rhombus(id)s. When @rhombus(id) is
- @rhombus(_, ~bind), a fresh identifier is used, otherwise
- @rhombus(id) is bound as follows. For the first iteration of
- the @rhombus(for) body, each @rhombus(id)'s value is the result
+ @rhombus(for) body as @rhombus(bind)s. For the first iteration of
+ the @rhombus(for) body, each @rhombus(bind) is matched to the result
  of the corresponding @rhombus(init). The results of a @rhombus(for) body
- for one iteration then serve as the values of the @rhombus(id)s
- for the next iteration. The values of the whole @rhombus(for) expression
- are the final values of the @rhombus(id)s.
+ for one iteration then serve as the values for the @rhombus(bind)s
+ of the next iteration. The values of the whole @rhombus(for) expression
+ are the final values that would be sent to @rhombus(bind)s for one more
+ interation, but @rhombus(bind)s are only partially applied to ensure that
+ values satisfy annotations (e.g., the results are not converted by converting
+ annotations).
 
  The @rhombus(fold, ~reducer) reducer form is an alias for
  @rhombus(values, ~reducer).
@@ -113,6 +109,11 @@
     sum + i
   for values(sum = 0, product = 1) (i in 1..=10):
     values(sum + i, product * i )
+  for values([sum, product] = [0, 1]) (i in 1..=10):
+    [sum + i, product * i]
+  for values(lst :: Listable.to_list = PairList[0, 0, 0]) (i in 1..=10):
+    lst :: List // assert that conversion happened in match
+    PairList[i, i, i]
 )
 
 }

--- a/rhombus/rhombus/tests/for.rhm
+++ b/rhombus/rhombus/tests/for.rhm
@@ -378,6 +378,95 @@ check:
   ~is [1, 0, 3]
 
 check:
+  for values([a, b] = [1, 2]) (i in 0..10):
+    [a + i, b + i]
+  ~is [46, 47]
+
+check:
+  for values(a :: Int.in(0, 9) = 0) (i in 0..10):
+    i
+  ~is 9
+
+check:
+  use_static
+  for values([a :: String, b] = ["1", 2]) (i in 0..10):
+    [to_string(a.length()), b + i]
+  ~is ["1", 47]
+
+check:
+  use_static
+  for values([a :~ String, b] = ["1", 2]) (i in 0..10):
+    [to_string(a.length()), b + i]
+  ~is ["1", 47]
+
+check:
+  use_static
+  (
+    for values([a, b] = [1, 2]) (i in 0..10):
+      [a + 1, b + i]
+  ).length()
+  ~is 2
+
+check:
+  use_static
+  def values(l, s):
+    for values([a, b] = [1, 2], s :~ String = "x") (i in 0..10):
+      values([a + 1, b + i], s)
+  [l.length(), s.length()]
+  ~is [2, 1]
+
+block:
+  check:
+    for values(a :: Int.in(0, 9) = 0) (i in 0..=11):
+      i
+    ~throws values("values:",
+                   error.annot_msg(),
+                   error.annot("Int.in(0, 9)").msg)
+  check:
+    for values(a :: Int.in(0, 9) = 0) (i in 0..=10):
+      i
+    ~throws values("values:",
+                   error.annot_msg(),
+                   error.annot("Int.in(0, 9)").msg)
+  check:
+    for values(a :: Int.in(0, 9) = -1) (i in 0..10):
+      i
+    ~throws values("values:",
+                   error.annot_msg(),
+                   error.annot("Int.in(0, 9)").msg)
+  check:
+    for fold(a :: Int.in(0, 9) = 0) (i in 0..=11):
+      i
+    ~throws values("fold:",
+                   error.annot_msg(),
+                   error.annot("Int.in(0, 9)").msg)
+  check:
+    for fold(a :: Int.in(0, 9) = 0) (i in 0..=10):
+      i
+    ~throws values("fold:",
+                   error.annot_msg(),
+                   error.annot("Int.in(0, 9)").msg)
+  check:
+    for fold(a :: Int.in(0, 9) = -1) (i in 0..10):
+      i
+    ~throws values("fold:",
+                   error.annot_msg(),
+                   error.annot("Int.in(0, 9)").msg)
+
+check:
+  for values(lst :: Listable.to_list = PairList[0, 0, 0]) (i in 1..=10):
+    lst :: List // assert that conversion happened in match
+    PairList[i, i, i]
+  ~is PairList[10, 10, 10]
+
+check:
+  for values(lst :: List = [0, 0, 0]) (i in 1..=1):
+    PairList[i, i, i]
+  ~throws values("values:",
+                 error.annot_msg(),
+                 error.annot("List").msg)
+
+check:
   for Set:
     each values(key, val) in {1: "a", 2: "b"}
     key +& " -> " +& val

--- a/rhombus/rhombus/tests/reducer-macro.rhm
+++ b/rhombus/rhombus/tests/reducer-macro.rhm
@@ -3,7 +3,7 @@
 block:
   import "static_arity.rhm"
   static_arity.check ~meta:
-    reducer_meta.pack(complete_id, binds,
+    reducer_meta.pack(defns, complete_id, binds,
                       pre_clause_id, step_id, break_id, final_id, step_result_id,
                       stat_info, data)
     reducer_meta.unpack(s)
@@ -19,7 +19,8 @@ block:
     let (_, si):
       let '$(a :: annot_meta.Parsed)' = 'List'
       annot_meta.unpack_predicate(a)
-    reducer_meta.pack('build_noop',
+    reducer_meta.pack('()',
+                      'build_noop',
                       '(l = List.empty)',
                       #false,
                       'build_add',
@@ -47,7 +48,7 @@ block:
 
 block:
   reducer.macro 'counted($(r :: reducer_meta.Parsed))':
-    let '($wrap, ($(bind && '$id $_'), ...),
+    let '($defns, $wrap, ($(bind && '$id $_'), ...),
           $pre, $step, $break, $final, $finish,
           $si, $data)':
       reducer_meta.unpack(r)
@@ -57,6 +58,7 @@ block:
       | statinfo_meta.unpack_group(sis)
       | [si]
     reducer_meta.pack(
+      defns,
       'build_return',
       '(count = 0, $bind, ...)',
       pre.unwrap() && 'build_pre',


### PR DESCRIPTION
Generalize `values` for `for` so that it can use pattern-matching bindings:

```
for values([sum, product] = [0, 1]) (i in 1..=10):
  [sum + i, product * i]
```

Note that even though two variables are bound by the pattern, the `for` result is still just a single list. That's hopefully as you'd expect.

There's a related subtlety with converting annotations. Conversions apply to the iteration body, but not the result:

```
for values(lst :: Listable.to_list = PairList[0, 0, 0]) (i in 1..=10):
  lst :: List // assert that conversion happened in match
  PairList[i, i, i]
// final result is a PairList, not a List
```

That behavior is because the final results are the values that would be fed into one more iteration, and not the pattern bindings or conversions created by binding to new values. Any predicates associated with an annotation are applied to the final values, however, so

```
for values(lst :: List = [0, 0, 0]) (i in 1..=1):
  PairList[i, i, i]
```

throws an exception that `PairList[1, 1, 1]` is not a `List`. Overall, this turns out to be an improvement over the old behevior, which incorrectly discarded conversions, even for the iteration body.

Aside from the correction for converting bindings, the new `values` is backward-compatible with existing uses. Avoiding code duplication in the expansion of `values` needs a small, backward-incompatible generation of the reducer protocol. The generalization allows a reducer to lift definitions outside the iteration. The `values` form lifts binding matchers so they can be used for the iteration body and for the overall results. The reducer generalization seems likely to be useful for future reducers, too.