### PR TITLE
Update Quick Start documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ line with
 raco pkg install rhombus
 ```
 
-See also the [documentation Quick Start](https://docs.racket-lang.org/rhombus@rhombus/Quick_Start.html).
+See also the [documentation Quick Start](https://docs.racket-lang.org/rhombus-guide/Quick_Start.html).
 
 # Other Resources
 


### PR DESCRIPTION
The link to the Quick Start documentation was broken (https://docs.racket-lang.org/rhombus@rhombus/Quick_Start.html).

I replaced with the correct link (https://docs.racket-lang.org/rhombus-guide/Quick_Start.html).