### PR TITLE
add streams

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -333,7 +333,7 @@
        (define unsorted-gs (syntax->list #'(g ...)))
        (define gs (sort-with-respect-to-keywords kws unsorted-gs new-stx
                                                  #:make-missing (lambda (kw) #'(group Any))))
-       (unless (eqv? (length gs) sub-n)
+       (unless (or (eq? sub-n 'any) (eqv? (length gs) sub-n))
          (raise-syntax-error #f
                              "wrong number of subannotations in parentheses"
                              (respan new-stx)))

--- a/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/builtin-dot.rkt
@@ -2,6 +2,8 @@
 (require racket/mutability
          racket/treelist
          racket/mutable-treelist
+         (only-in racket/private/for
+                  stream?)
          "pipe-port.rkt"
          "syntax-wrap.rkt"
          (submod "dot.rkt" for-builtin)
@@ -19,7 +21,8 @@
          (submod "path-object.rkt" for-builtin)
          (submod "srcloc-object.rkt" for-builtin)
          (submod "port.rkt" for-builtin)
-         (submod "exn-object.rkt" for-builtin))
+         (submod "exn-object.rkt" for-builtin)
+         (submod "stream.rkt" for-builtin))
 
 (define (merge ht ht2)
   (if ht
@@ -67,6 +70,7 @@
                         (and (file-stream-port? v) file-stream-port-method-table)))]
     [(box? v) box-method-table]
     [(mutable-treelist? v) mutable-treelist-method-table]
+    [(stream? v) stream-method-table]
     [else #f]))
 
 (define (builtin->mutator-ref v)

--- a/rhombus-lib/rhombus/private/amalgam/core.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core.rkt
@@ -167,7 +167,8 @@
         "printable.rkt"
         "callable.rkt"
         "path-object.rkt"
-        "srcloc-object.rkt")
+        "srcloc-object.rkt"
+        "stream.rkt")
 
 (module reader racket/base
   (require (submod rhombus/private/core reader))

--- a/rhombus-lib/rhombus/private/amalgam/indexable.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/indexable.rkt
@@ -9,6 +9,8 @@
          racket/mutability
          racket/treelist
          racket/mutable-treelist
+         (only-in racket/private/for
+                  stream?)
          "provide.rkt"
          "repetition.rkt"
          (submod "annotation.rkt" for-class)
@@ -25,7 +27,8 @@
          "parens.rkt"
          (submod "map-maybe.rkt" for-print)
          (only-in (submod "function-parse.rkt" for-build)
-                  find-call-result-at))
+                  find-call-result-at)
+         (submod "stream.rkt" for-index))
 
 (provide (for-spaces (rhombus/class
                       rhombus/annot)
@@ -62,6 +65,7 @@
       (bytes? v)
       (mutable-treelist? v)
       (map-maybe? v)
+      (stream? v)
       (Indexable? v)))
 
 (define-class-desc-syntax Indexable
@@ -238,6 +242,7 @@
     [(string? indexable) (string-ref indexable index)]
     [(bytes? indexable) (bytes-ref indexable index)]
     [(mutable-treelist? indexable) (mutable-treelist-ref indexable index)]
+    [(stream? indexable) (Stream.get indexable index)]
     [else
      (define ref (indexable-ref indexable #f))
      (unless ref

--- a/rhombus-lib/rhombus/private/amalgam/list.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/list.rkt
@@ -127,6 +127,7 @@
            (add-result-statinfo lhs-si (get-treelist-static-infos)))])
   #:methods
   (length
+   is_empty
    get
    set
    add
@@ -178,6 +179,7 @@
            (add-result-statinfo lhs-si (get-list-static-infos)))])
   #:methods
   (length
+   is_empty
    get
    reverse
    append
@@ -500,6 +502,17 @@
   #:primitive (length)
   #:static-infos ((#%call-result #,(get-int-static-infos)))
   (length l))
+
+(define/method (List.is_empty l)
+  #:primitive (treelist-empty?)
+  (treelist-empty? l))
+
+(define/method (PairList.is_empty l)
+  #:static-infos ((#%call-result #,(get-int-static-infos)))
+  (cond
+    [(null? l) #t]
+    [(list? l) #f]
+    [else (raise-annotation-failure who l "PairList")]))
 
 (define/method (MutableList.length l)
   #:primitive (mutable-treelist-length)

--- a/rhombus-lib/rhombus/private/amalgam/print.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/print.rkt
@@ -6,6 +6,9 @@
          racket/mutability
          racket/treelist
          racket/mutable-treelist
+         (only-in racket/private/for
+                  stream?
+                  stream-empty?)
          shrubbery/write
          "../version-case.rkt"
          "provide.rkt"
@@ -485,6 +488,13 @@
     [(map-maybe? v)
      (pretty-concat (print (map-maybe-ht v))
                     (pretty-text ".maybe"))]
+    [(stream? v)
+     (if (stream-empty? v)
+         (pretty-text "Stream.empty")
+         (pretty-listlike
+          (pretty-text "Stream.cons(")
+          (list (pretty-text "..."))
+          (pretty-text ")")))]
     [(sequence? v)
      (pretty-listlike
       (pretty-text "Sequence.make(")

--- a/rhombus-lib/rhombus/private/amalgam/sequence.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/sequence.rhm
@@ -21,6 +21,7 @@ namespace Sequence:
     instantiable
     instantiate
     generate
+    to_stream
     expect_of
   annot.macro 'expect_of($(ann :: Group), ...)':
     ~all_stx: stx
@@ -85,3 +86,6 @@ fun instantiate(~initial_position: init_pos,
 fun generate(seq :: Sequence) :~ values(Function.of_arity(0), Function.of_arity(0)):
   ~name: Sequence.instantiate
   base.#{sequence-generate}(seq)
+
+fun to_stream(seq :: Sequence) :~ Stream.expect_of(Any.like_element(seq)):
+  base.#{sequence->stream}(seq)

--- a/rhombus-lib/rhombus/private/amalgam/stream.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/stream.rkt
@@ -1,0 +1,254 @@
+#lang racket/base
+(require (for-syntax racket/base
+                     syntax/parse/pre
+                     "annot-context.rkt")
+         (only-in racket/private/for
+                  stream?
+                  stream-first
+                  stream-rest
+                  stream-empty?
+                  empty-stream
+                  in-stream)
+         (only-in racket/private/stream-cons
+                  stream-cons)
+         "provide.rkt"
+         "class-primitive.rkt"
+         "dot-parse.rkt"
+         "call-result-key.rkt"
+         "index-result-key.rkt"
+         "index-key.rkt"
+         "sequence-constructor-key.rkt"
+         "sequence-element-key.rkt"
+         "values-key.rkt"
+         "define-arity.rkt"
+         "realm.rkt"
+         "rhombus-primitive.rkt"
+         "static-info.rkt"
+         "expression.rkt"
+         (submod "annotation.rkt" for-class)
+         "binding.rkt"
+         "composite.rkt"
+         "literal.rkt"
+         "parse.rkt"
+         "parens.rkt"
+         (only-in "underscore.rkt"
+                  [_ rhombus-_]))
+
+(provide (for-spaces (rhombus/namespace
+                      #f
+                      rhombus/bind
+                      rhombus/annot)
+                     Stream))
+
+(module+ for-builtin
+  (provide stream-method-table))
+
+(module+ for-static-info
+  (provide (for-syntax get-stream-static-infos)))
+
+(module+ for-index
+  (provide Stream.get))
+
+(define-primitive-class Stream stream
+  #:lift-declaration
+  #:instance-static-info ((#%sequence-constructor Stream.to_sequence/optimize)
+                          (#%index-get Stream.get))
+  #:existing
+  #:transparent
+  #:fields
+  ()
+  #:namespace-fields
+  ([expect_of Stream.expect_of]
+   [empty Stream.empty]
+   [cons Stream.cons])
+  #:properties
+  ([first Stream.first extract-result-statinfo]
+   [rest Stream.rest extract-rest-statinfo])
+  #:methods
+  (is_empty
+   get))
+
+(define-for-syntax (extract-result-statinfo lhs-si)
+  (or (static-info-lookup lhs-si #'#%sequence-element)
+      (extract-index-uniform-result
+       (static-info-lookup lhs-si #'#%index-result))
+      #'()))
+
+(define-for-syntax (extract-rest-statinfo arg-si
+                                          #:static-infos [statinfos (get-stream-static-infos)])
+  (define r-si (extract-result-statinfo arg-si))
+  (if (not (static-infos-empty? r-si))
+      #`((#%sequence-element #,r-si)
+         #,@statinfos)
+      statinfos))
+
+(define-syntax (stream-of-static-infos data static-infoss)
+  #`((#%sequence-element #,(if (= (length static-infoss) 1)
+                               (car static-infoss)
+                               #`((#%values #,static-infoss))))))
+
+(define-syntax (stream-build-convert arg-id build-convert-stxs kws data)
+  arg-id)
+
+(define-annotation-constructor (StreamAgain Stream.expect_of)
+  ()
+  #'stream? #,(get-stream-static-infos)
+  'any ;; allow any number of annotations in `expect_of`
+  #f
+  (lambda (predicate-stxs) #`(lambda (arg) #t))
+  #'stream-of-static-infos #f
+  #'stream-build-convert #'())
+
+(define Stream.empty
+  empty-stream)
+
+(define-static-info-syntax Stream.empty
+  #,@(get-stream-static-infos))
+
+(define-syntax (select-elem data deps)
+  (define mode (syntax-e data))
+  (define args (annotation-dependencies-args deps))
+  (define lst-i 0)
+  (define arg-si (or (and (< lst-i (length args))
+                          (list-ref args lst-i))
+                     #'()))
+  (case mode
+    [(first) (extract-result-statinfo arg-si)]
+    [(rest) (extract-rest-statinfo arg-si)]
+    [(seq) (extract-rest-statinfo arg-si #:static-infos #'())]))
+
+(define/method (Stream.first s)
+  #:primitive (stream-first)
+  #:static-infos ((#%call-result ((#%dependent-result (select-elem first)))))
+  (stream-first s))
+
+(define/method (Stream.rest s)
+  #:primitive (stream-rest)
+  #:static-infos ((#%call-result ((#%dependent-result (select-elem rest)))))
+  (stream-rest s))
+
+(define/method (Stream.get st i)
+  #:static-infos ((#%call-result ((#%dependent-result (select-elem first)))))
+  (unless (stream? st) (raise-annotation-failure who st "Stream"))
+  (unless (exact-nonnegative-integer? i)
+    (raise-annotation-failure who i "Nat"))
+  (let loop ([n i] [s st])
+    (cond
+     [(stream-empty? s)
+      (raise-arguments-error* who
+                              rhombus-realm
+                              "stream ended before index"
+                              "index" i
+                              ;; Why `"stream" st` is omitted: see `racket/stream`
+                              #;"stream" #;st)]
+     [(zero? n)
+      (stream-first s)]
+     [else
+      (loop (sub1 n) (stream-rest s))])))
+
+(define/method (Stream.is_empty s)
+  #:primitive (stream-empty?)
+  (stream-empty? s))
+
+(define (nonempty-stream? v)
+  (and (stream? v)
+       (not (stream-empty? v))))
+
+(begin-for-syntax
+  (define-syntax-class (:maybe-eager-expression stx)
+    #:attributes (parsed [eager 1])
+    #:datum-literals (group)
+    (pattern (group (~and #:eager kw))
+             #:do [(raise-syntax-error #f
+                                       "missing expression after keyword"
+                                       stx
+                                       #'kw)]
+             #:attr parsed #'#f
+             #:attr [eager 1] null)
+    (pattern (group #:eager . tail)
+             #:with ::expression #'(group . tail)
+             #:attr [eager 1] (list #'#:eager))
+    (pattern ::expression
+             #:attr [eager 1] null)))
+
+(define-syntax Stream.cons
+  (expression-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(_ (_::parens (~var a (:maybe-eager-expression stx)) (~var d (:maybe-eager-expression stx))) . tail)
+        (define e (wrap-static-info*
+                   #'(stream-cons a.eager ... a.parsed d.eager ... d.parsed)
+                   (get-stream-static-infos)))
+        (define si (static-infos-or (extract-static-infos #'a.parsed)
+                                    (extract-result-statinfo
+                                     (extract-static-infos #'d.parsed))))
+        (values (if (static-infos-empty? si)
+                    e
+                    (wrap-static-info e #'#%sequence-element si))
+                #'tail)]))))
+
+(define-binding-syntax Stream.cons
+  (binding-transformer
+   (lambda (tail)
+     (define (underscore? g)
+       (syntax-parse g
+         #:datum-literals (group)
+         [(_ us:identifier)
+          (free-identifier=? (in-binding-space #'rhombus-_) (in-binding-space #'us))]
+         [_ #f]))
+     (composite-binding-transformer tail
+                                    "Stream && !satisfying(Stream.is_empty)"
+                                    #'nonempty-stream?
+                                    #:static-infos (get-stream-static-infos)
+                                    #:stream-element-info? #t
+                                    (syntax-parse tail
+                                      [(_ (_::parens g1 g2) . _)
+                                       (list (if (underscore? #'g1) #'void #'stream-first)
+                                             (if (underscore? #'g2) #'void #'stream-rest))]
+                                      [_
+                                       (list #'stream-first #'stream-rest)])
+                                    (list #'() (get-stream-static-infos))))))
+
+(define-binding-syntax Stream.empty
+  (binding-transformer
+   (lambda (stx)
+     (syntax-parse stx
+       [(form-id . tail)
+        (values (binding-form #'stream-empty-infoer #'()) #'tail)]))))
+
+(define-syntax (stream-empty-infoer stx)
+  (syntax-parse stx
+    [(_ up-static-infos _)
+     (binding-info "Stream.empty"
+                   #'empty
+                   (static-infos-and (get-stream-static-infos) #'up-static-infos)
+                   #'()
+                   #'empty-oncer
+                   #'stream-empty-matcher
+                   #'()
+                   #'literal-commit-nothing
+                   #'literal-bind-nothing
+                   #'datum)]))
+
+(define-syntax (stream-empty-matcher stx)
+  (syntax-parse stx
+    [(_ arg-id datum IF success fail)
+     #'(IF (and (stream? arg-id) (stream-empty? arg-id))
+           success
+           fail)]))
+
+(define-sequence-syntax Stream.to_sequence/optimize
+  (lambda () #'Stream.to_sequence)
+  (lambda (stx)
+    (syntax-parse stx
+      [[(id) (_ stm-expr)]
+       #`[(id) (in-stream #,(discard-static-infos #'stm-expr))]]
+      [_ #f])))
+
+(define/method (Stream.to_sequence stm)
+  #:primitive (in-stream)
+  #:static-infos ((#%call-result ((#%dependent-result (select-elem seq)))))
+  (in-stream stm))
+
+(void (set-primitive-contract! '(and/c stream? (not/c stream-empty?)) "Stream && !satisfying(Stream.is_empty)"))
+(void (set-primitive-who! 'stream-cons 'Stream.cons))

--- a/rhombus/rhombus/scribblings/guide/datatype.scrbl
+++ b/rhombus/rhombus/scribblings/guide/datatype.scrbl
@@ -15,5 +15,6 @@ collections through repetition and iteration forms.
 @include_section("repetition.scrbl")
 @include_section("for.scrbl")
 @include_section("range.scrbl")
+@include_section("stream.scrbl")
 @include_section("more-arguments.scrbl")
 @include_section("function-shorthand.scrbl")

--- a/rhombus/rhombus/scribblings/guide/stream.scrbl
+++ b/rhombus/rhombus/scribblings/guide/stream.scrbl
@@ -1,0 +1,64 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open)
+
+@(def stream_eval = make_rhombus_eval())
+
+@title(~tag: "stream"){Streams}
+
+A @tech(~doc: ref_doc){stream} is like a sequence, but it is stateless
+and supports functional ``first'' and ``rest'' operations like a linked
+list. Lists and sequence ranges can be used as streams. Any sequence can
+be turned into a stream using @rhombus(Sequence.to_stream), which
+instantiates the sequence an caches results so that the same first value
+can be provided from a stream as many times as it is requested. An
+element can be accessed from a stream using @brackets, which is
+equivalent to accessing the @rhombus(Stream.rest) property as many times
+as the index in @brackets, and then using @rhombus(Stream.first) to get
+the element.
+
+The @rhombus(Stream.cons) expression form is similar to
+@rhombus(List.cons), but it constructs a lazy stream: the expressions
+for the first and rest of the stream are evaluated on demand. A classic
+example for lazy streams is creating an infinite stream of numbers.
+Although ranges can also represent streams of numbers, they cannot
+represent, say, a stream of prime numbers.
+
+@examples(
+  ~eval: stream_eval
+  ~defn:
+    fun naturals_from(i :: Int) :: Stream:
+      Stream.cons(i, naturals_from(i+1))
+  ~defn:
+    :
+      def naturals = naturals_from(0) // equivalent to `(0 ..)`
+  ~repl:
+    naturals.first
+    naturals.rest.first
+    naturals[0]
+    naturals[11]
+  ~defn:
+    fun remove_multiples(s :: Stream, n :: Int) :: Stream:
+      match s
+      | Stream.cons(fst, rst):
+          if fst mod n == 0
+          | remove_multiples(rst, n)
+          | Stream.cons(fst, remove_multiples(rst, n))
+  ~defn:
+    def odds = remove_multiples(naturals, 2)
+  ~repl:
+    odds[0]
+    odds[11]
+  ~defn:
+    fun primes_from(s :: Stream) :: Stream:
+      match s
+      | Stream.cons(fst, rst):
+          Stream.cons(fst, primes_from(remove_multiples(rst, fst)))
+  ~defn:
+    def primes = primes_from(naturals.rest.rest)
+  ~repl:
+    primes[0]
+    primes[11]
+)
+
+@(close_eval(stream_eval))

--- a/rhombus/rhombus/scribblings/reference/collection.scrbl
+++ b/rhombus/rhombus/scribblings/reference/collection.scrbl
@@ -15,3 +15,4 @@
 @include_section("repetition.scrbl")
 @include_section("for.scrbl")
 @include_section("range.scrbl")
+@include_section("stream.scrbl")

--- a/rhombus/rhombus/scribblings/reference/list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/list.scrbl
@@ -32,7 +32,7 @@ A list is @tech{indexable} using @brackets to access a list
 element by position via
 @rhombus(#%index). A list also works with the @rhombus(++) operator
 to append lists. A list supports @tech{membership tests} using
-the @rhombus(in) operator. A list can be used as @tech{sequence}, in which case
+the @rhombus(in) operator. A list can be used as @tech{stream} or @tech{sequence}, in which case
 it supplies its elements in order.
 
 Two lists are equal by @rhombus(==) if they have the same length and

--- a/rhombus/rhombus/scribblings/reference/pair.scrbl
+++ b/rhombus/rhombus/scribblings/reference/pair.scrbl
@@ -21,7 +21,7 @@ A pair list is @tech{indexable} using @brackets to access a list
 element by position---in @math{O(N)} time---via @rhombus(#%index). A
 pair list also works with the @rhombus(++) operator to append pair
 lists. A pair list supports @tech{membership tests} using the
-@rhombus(in) operator. A pair list can be used as @tech{sequence}, in
+@rhombus(in) operator. A pair list can be used as @tech{stream} or @tech{sequence}, in
 which case it supplies its elements in order.
 
 The empty pair-list value is unique and @rhombus(===) to itself. Two

--- a/rhombus/rhombus/scribblings/reference/range.scrbl
+++ b/rhombus/rhombus/scribblings/reference/range.scrbl
@@ -7,7 +7,7 @@
 
 A @deftech{range}@intro_note("range", "ranges") represents a contiguous
 set of integers between two points. When the starting point is
-not @rhombus(#neginf), the range can be used as a @tech{sequence}; in addition,
+not @rhombus(#neginf), the range can be used as a @tech{stream} or @tech{sequence}; in addition,
 when the ending point is not @rhombus(#inf), the range is
 @tech{listable}. Generally, the starting point must be less than or
 equal to the ending point, so that the lower bound is ``less than or
@@ -27,7 +27,7 @@ operator, which is the same as @rhombus(Range.contains).
  The @rhombus(Range, ~annot) annotation matches any range.
 
  The @rhombus(SequenceRange, ~annot) annotation matches a range that
- can be used as a @tech{sequence}. Such a range has a
+ can be used as a @tech{stream} or @tech{sequence}. Such a range has a
  non-@rhombus(#neginf) starting point.
 
  The @rhombus(ListRange, ~annot) annotation matches a range that is
@@ -306,15 +306,11 @@ operator, which is the same as @rhombus(Range.contains).
   method (rge :: Range).is_empty() :: Boolean
 ){
 
- Returns @rhombus(#true) if @rhombus(rge) is an @deftech{empty range},
- @rhombus(#false) otherwise. An empty range is empty
- ``by definition,'' meaning that its lower bound is ``equal to'' its
- upper bound, and therefore it cannot have anything at all in the
- range that it represents. By contrast, a range may have no integers
- even if its lower bound is strictly ``less than'' its upper bound
- (but it may well have real numbers, in principle); in such case, use
- @rhombus(rge.canonicalize().is_empty()) to check for its
- ``emptiness.''
+ Returns @rhombus(#true) if @rhombus(rge) has no integers.
+
+ A range can count as empty even if real numbers exist between its
+ bounds, as in @rhombus(3 <.. 4), where the exclusive bounds @rhombus(3)
+ and @rhombus(4) rule out all integers.
 
 @examples(
   (3..4).is_empty()
@@ -322,7 +318,6 @@ operator, which is the same as @rhombus(Range.contains).
   (3..3).is_empty()
   (3 <..= 3).is_empty()
   (3 <.. 4).is_empty()
-  (3 <.. 4).canonicalize().is_empty()
 )
 
 }
@@ -562,6 +557,30 @@ operator, which is the same as @rhombus(Range.contains).
 
 
 @doc(
+  property (rge :: SequenceRange).first :: Int
+  property (rge :: SequenceRange).rest :: SequenceRange
+){
+
+ For a non-empty range, produces the first integer in @rhombus(rge) or a
+ range that is like @rhombus(rge) without its first element.
+
+ The @rhombus(SequenceRange.rest) property produces a range that is
+ inclusive for its start and end points the same as @rhombus(rge), except
+ that a range constructed by @rhombus(..=) or
+ @rhombus(Range.from_to_inclusive) cannot be empty, so the result uses
+ @rhombus(..).
+
+@examples(
+  (10 ..).first
+  (10 ..).rest
+  (0 <..= 10).rest
+  (1 ..= 1).rest
+)
+
+}
+
+
+@doc(
   annot.macro 'DescendingRange'
   annot.macro 'DescendingListRange':
     ~method_fallback DescendingRange
@@ -586,6 +605,8 @@ operator, which is the same as @rhombus(Range.contains).
  @rhombus(DescendingRange, ~annot) object that is also
  @tech{listable}. These are precisely the possible results of
  @rhombus(ListRange.descending).
+
+ A descending range can be used as a @tech{stream} or @tech{sequence}.
 
 }
 
@@ -750,6 +771,33 @@ operator, which is the same as @rhombus(Range.contains).
     i
   for List (i in (10 >..= 0).step_by(-3)):
     i
+)
+
+}
+
+
+@doc(
+  property (rge :: DescendingRange).first :: Int
+  property (rge :: DescendingRange).rest :: DescendingRange
+  method (rge :: DescendingRange).is_empty() :: Boolean
+){
+
+ Produces the first integer in a non-empty @rhombus(rge), produces a
+ descending range that is like a non-empty @rhombus(rge) without its
+ first element, or checks whether @rhombus(rge) is empty.
+
+ The @rhombus(DescendingRange.rest) property produces a descending range
+ that is inclusive for its start and end points the same as
+ @rhombus(rge), except that a range constructed by @rhombus(>=..=) or
+ @rhombus(DescendingRange.from_to_inclusive) cannot be empty, so the
+ result uses @rhombus(>..=).
+
+@examples(
+  (10 >.. 0).first
+  (10 >.. 0).rest
+  (10 >.. 0).is_empty()
+  (1 >=..= 1).rest
+  (1 >=..= 1).rest.is_empty()
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/sequence.scrbl
+++ b/rhombus/rhombus/scribblings/reference/sequence.scrbl
@@ -13,7 +13,7 @@ can be defined by calling @rhombus(Sequence.make),
 @rhombus(Sequence.instantiable), or implementing
 @rhombus(Sequenceable, ~class).
 
-A sequence is more general than a list or stream in that it can have
+A sequence is more general than a list or @tech{stream} in that it can have
 internal state, and the state can even be specific to a particular
 @deftech{instantiation} of the sequence for a new iteration.
 
@@ -77,6 +77,22 @@ internal state, and the state can even be specific to a particular
   has_more()
   ~error:
     next()
+)
+
+}
+
+@doc(
+  fun Sequence.to_stream(seq :: Sequence)
+    :: Stream.expect_of(Any.like_element(seq))
+){
+
+ Converts a @tech{sequence} to a @tech{stream} by lazily demanding and
+ caching elements of the sequence.
+
+@examples(
+  def stm = Sequence.to_stream(0 ..)
+  stm.rest.rest.rest.first
+  stm.rest.rest.rest.first
 )
 
 }

--- a/rhombus/rhombus/scribblings/reference/stream.scrbl
+++ b/rhombus/rhombus/scribblings/reference/stream.scrbl
@@ -1,0 +1,139 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open)
+
+@title{Streams}
+
+A @deftech{stream} is a stateless @tech{sequence} that supports
+@rhombus(Stream.first) and @rhombus(Stream.rest) operations. Accessing
+@rhombus(Stream.first) multiple times for the same stream will produce
+the same result, and calling @rhombus(Stream.rest) multiple times for the
+same stream will produce the same new stream that omits the first
+element. @tech{Lists}, @tech{pair lists}, and sequenceable @tech{ranges}
+are streams, as well as lazy streams constructed using
+@rhombus(Stream.cons).
+
+A stream is @tech{indexable} using @brackets to access a stream
+element by position via @rhombus(#%index).
+
+@doc(
+  annot.macro 'Stream'
+  annot.macro 'Stream.expect_of($ann, ...)'
+){
+
+ Matches any @tech{stream}.
+
+ A @rhombus(Stream.expect_of(ann, ...), ~annot) annotation is the same as
+ @rhombus(Stream, ~annot), but elements drawn from the stream via
+ @rhombus(Stream.first) have the static information of  the @rhombus(ann)s
+ (where multiple @rhombus(ann)s correspond to multiple values for each
+ element, such as the key and value from a @tech{map}). The
+ extracted elements are not checked or converted, however, and each
+ @rhombus(ann) is used only for its static information.
+
+ Static information associated by @rhombus(Stream, ~annot) or
+ @rhombus(Stream.expect_of, ~annot) makes an expression acceptable as a
+ sequence to @rhombus(for) in static mode.
+
+}
+
+@doc(
+  property (stm :: Stream).first :: Any.like_element(stm)
+  property (stm :: Stream).rest
+    :: Stream.expect_of(Any.like_element(stm))
+  method (stm :: Stream).is_empty :: Boolean
+){
+
+ The @rhombus(Stream.first) and @rhombus(Stream.rest) properties report
+ the first element of @rhombus(stm) or a new stream that has the rest of
+ the elements of @rhombus(stm), respectively.
+
+ The @rhombus(Stream.first) and @rhombus(Stream.rest) properties require
+ non-empty streams. The @rhombus(Stream.is_empty) method reports whether
+ @rhombus(stm) is empty.
+
+@examples(
+  Stream.first([1, 2, 3])
+  Stream.rest([1, 2, 3])
+  Stream.is_empty([1, 2, 3])
+  ~error:
+    Stream.first([])
+  ~error:
+    Stream.rest([])
+)
+
+}
+
+@doc(
+  method (stm :: Stream).get(n :: Nat) :: Any.like_element(stm)
+){
+
+ Equivalent to @rhombus(stm[n]) (with the default implicit
+ @rhombus(#%index) form). Returns the @rhombus(n)th element of
+ @rhombus(stm) (starting from @rhombus(0)).
+
+}
+
+
+@doc(
+  def Stream.empty :: Stream
+  annot.macro 'Stream.empty'
+){
+
+ Returns or matches an empty stream. The emptry stream is not unique, so
+ check for an empty stream by matching to @rhombus(Stream.empty, ~annot)
+ or calling @rhombus(Stream.is_empty).
+
+}
+
+
+@doc(
+  ~nonterminal:
+    first_expr: block expr
+    rest_expr: block expr
+    first_bind: def bind ~defn
+    rest_bind: def bind ~defn
+  expr.macro 'Stream.cons($maybe_eager $first_expr, $maybe_eager $rest_expr)'
+  bind.macro 'Stream.cons($first_bind, $rest_bind)'
+  grammar maybe_eager
+  | ~eager
+  | #,(epsilon)
+){
+
+ The @rhombus(Stream.cons) expression form creates a stream whose first
+ element is determined by evaluating @rhombus(first_expr) on demand, and
+ whose remainder is determined by evaluating @rhombus(rest_expr) on
+ demand. After @rhombus(first_expr) or @rhombus(rest_expr) is evaluated,
+ its value is retained (and the corresponding expression is forgotten)
+ for use by future demands. The result of @rhombus(rest_expr) must
+ satisfy @rhombus(Stream, ~annot), but it is checked only at the point
+ where the stream's remainder is demanded. The result of @rhombus(first_expr)
+ can be multiple values, in which case the corresponding element of the
+ stream consists of multiple values.
+
+ If @rhombus(first_expr) ir @rhombus(rest_expr) is prefixed with
+ @rhombus(~eager), then the expression is evaluated at the time the
+ stream is constructed, instead of delaying until the result is demanded.
+
+ The @rhombus(Stream.cons, ~bind) binding form matches a non-empty
+ stream, and it binds @rhombus(first_bind) and @rhombus(rest_bind) to the
+ first and rest of the matched stream---but not demanding the first or
+ rest if @rhombus(first_bind) or @rhombus(rest_bind) is literally
+ @rhombus(_, ~bind), respectively.
+
+@examples(
+  ~defn:
+    fun stream_skip(s :: Stream) :: Stream:
+      match s
+      | Stream.cons(fst, Stream.cons(_, rst)): Stream.cons(fst, stream_skip(rst))
+      | Stream.cons(fst, _): Stream.cons(fst, Stream.empty)
+      | Stream.empty: Stream.empty
+    def evens = stream_skip(0 ..)
+  ~repl:
+    evens.first
+    evens.rest.first
+    evens[100]
+)
+
+}

--- a/rhombus/rhombus/tests/descending-range.rhm
+++ b/rhombus/rhombus/tests/descending-range.rhm
@@ -13,6 +13,9 @@ block:
     DescendingRange.to_sequence(rge) ~method
     DescendingRange.step_by(rge, step) ~method
     DescendingListRange.to_list(rge) ~method
+    DescendingRange.is_empty(rge) ~method
+    DescendingRange.first(rge)
+    DescendingRange.rest(rge)
 
 // basic sanity checks
 check:
@@ -978,3 +981,44 @@ block:
   generate_checks ..=
   generate_checks <..
   generate_checks <..=
+
+def empty_msg = "DescendingRange && !satisying(DescendingRange.is_empty)"
+
+check:
+  (10 >.. 0).first ~is 9
+  (2 >.. 0).first ~is 1
+  (10 >..= 0).first ~is 9
+  (1 >..= 0).first ~is 0
+  (10 >=.. 0).first ~is 10
+  (1 >=.. 0).first ~is 1
+  (10 >=..= 0).first ~is 10
+  (0 >=..= 0).first ~is 0
+  (1 >.. 0).first ~throws empty_msg
+  (0 >..= 0).first ~throws empty_msg
+  (0 >=.. 0).first ~throws empty_msg
+
+check:
+  (10 >.. 0).rest ~is 9 >.. 0
+  (2 >.. 0).rest ~is 1 >.. 0
+  (10 >..= 0).rest ~is 9 >..= 0
+  (1 >..= 0).rest ~is 0 >..= 0
+  (10 >=.. 0).rest ~is 9 >=.. 0
+  (1 >=.. 0).rest ~is 0 >=.. 0
+  (10 >=..= 0).rest ~is 9 >=..= 0
+  (0 >=..= 0).rest ~is -1 >..= -1 // must switch to `>..=`
+  (1 >.. 0).rest ~throws empty_msg
+  (0 >..= 0).rest ~throws empty_msg
+  (0 >=.. 0).rest ~throws empty_msg
+
+check:
+  (10 >.. 0).is_empty() ~is #false
+  (2 >.. 0).is_empty() ~is #false
+  (10 >..= 0).is_empty() ~is #false
+  (1 >..= 0).is_empty() ~is #false
+  (10 >=.. 0).is_empty() ~is #false
+  (1 >=.. 0).is_empty() ~is #false
+  (10 >=..= 0).is_empty() ~is #false
+  (0 >=..= 0).is_empty() ~is #false
+  (1 >.. 0).is_empty() ~is #true
+  (0 >..= 0).is_empty() ~is #true
+  (0 >=.. 0).is_empty() ~is #true

--- a/rhombus/rhombus/tests/range.rhm
+++ b/rhombus/rhombus/tests/range.rhm
@@ -27,6 +27,8 @@ block:
     Range.intersect(rge, ...) ~method
     SequenceRange.to_sequence(rge) ~method
     SequenceRange.step_by(rge, step) ~method
+    SequenceRange.first(rge)
+    SequenceRange.rest(rge)
     // `ListRange.descending` is in "descending-range.rhm"
     ListRange.to_list(rge) ~method
 
@@ -1214,14 +1216,6 @@ block:
        check:
          lhs.is_empty() $is #true
          lhs.canonicalize().is_empty() $is #true'
-  expr.macro '$lhs canonicalized_is_empty':
-    ~op_stx self
-    let is = '~is'.relocate(self)
-    'block:
-       def lhs = $lhs
-       check:
-         lhs.is_empty() $is #false
-         lhs.canonicalize().is_empty() $is #true'
   expr.macro '$lhs is_not_empty':
     ~op_stx self
     let is = '~is'.relocate(self)
@@ -1233,7 +1227,7 @@ block:
   (0..0) is_empty
   (0..=0) is_not_empty
   (0..) is_not_empty
-  (0 <.. 1) canonicalized_is_empty
+  (0 <.. 1) is_empty
   (0 <..= 0) is_empty
   (0 <..) is_not_empty
   (..0) is_not_empty
@@ -1871,3 +1865,43 @@ check:
     error.annot("Range").msg,
     error.val("oops").msg,
   )
+
+def empty_msg = "SequenceRange && !satisying(Range.is_empty)"
+
+check:
+  (0 ..).first ~is 0
+  (0 <..).first ~is 1
+  (0 .. 10).first ~is 0
+  (9 .. 10).first ~is 9
+  (0 <.. 10).first ~is 1
+  (8 <.. 10).first ~is 9
+  (0 ..= 10).first ~is 0
+  (10 ..= 10).first ~is 10
+  (0 <..= 10).first ~is 1
+  (9 <..= 10).first ~is 10
+  (0 .. 0).first ~throws empty_msg
+  (9 <.. 10).first ~throws empty_msg
+  (10 <..= 10).first ~throws empty_msg
+
+check:
+  (0 ..).rest ~is 1 ..
+  (0 <..).rest ~is 1 <..
+  (0 .. 10).rest ~is 1 .. 10
+  (9 .. 10).rest ~is 10 .. 10
+  (0 <.. 10).rest ~is 1 <.. 10
+  (8 <.. 10).rest ~is 9 <.. 10
+  (0 ..= 10).rest ~is 1 ..= 10
+  (10 ..= 10).rest ~is 11 .. 11 // must switch to `..`
+  (0 <..= 10).rest ~is 1 <..= 10
+  (9 <..= 10).rest ~is 10 <..= 10
+  (0 .. 0).rest ~throws empty_msg
+  (9 <.. 10).rest ~throws empty_msg
+  (10 <..= 10).rest ~throws empty_msg
+
+// although `is_empty` is already tests above,
+// some extra checks in the context of `.first`
+// and `.rest` to check that things are consistent
+check:
+  (10 .. 10).is_empty() ~is #true
+  (9 <.. 10).is_empty() ~is #true
+  (10 <..= 10).is_empty() ~is #true

--- a/rhombus/rhombus/tests/stream.rhm
+++ b/rhombus/rhombus/tests/stream.rhm
@@ -1,0 +1,261 @@
+#lang rhombus/static
+
+block:
+  import "static_arity.rhm"
+  static_arity.check:
+    Stream.is_empty(strm) ~method
+    Stream.first(strm)
+    Stream.rest(strm)
+
+check:
+  [] ~is_a Stream
+  [1, 2, 3] ~is_a Stream
+  PairList[] ~is_a Stream
+  PairList[1, 2, 3] ~is_a Stream
+  0 .. ~is_a Stream
+  0 <.. ~is_a Stream
+  0 .. 10 ~is_a Stream
+  0 <.. 10 ~is_a Stream
+  0 ..= 10 ~is_a Stream
+  0 <..= 10 ~is_a Stream
+  10 >.. 0 ~is_a Stream
+  10 >..= 0 ~is_a Stream
+  [1, 2, 3].to_sequence() is_a Stream ~is #false
+  Stream.cons(1, []) ~is_a Stream
+  Stream.empty ~is_a Stream
+
+check:
+  Stream.is_empty([]) ~is #true
+  Stream.is_empty([1, 2, 3]) ~is #false
+  Stream.is_empty(PairList[]) ~is #true
+  Stream.is_empty(PairList[1, 2, 3]) ~is #false
+  Stream.is_empty(0 ..) ~is #false
+  Stream.is_empty(0 <..) ~is #false
+  Stream.is_empty(0 .. 10) ~is #false
+  Stream.is_empty(0 <.. 10) ~is #false
+  Stream.is_empty(0 ..= 10) ~is #false
+  Stream.is_empty(0 <..= 10) ~is #false
+  Stream.is_empty(0 .. 0) ~is #true
+  Stream.is_empty(10 >.. 0) ~is #false
+  Stream.is_empty(10 >..= 0) ~is #false
+  Stream.is_empty(1 >.. 0) ~is #true
+  Stream.cons(1, []).is_empty() ~is #false
+  Stream.empty.is_empty() ~is #true
+
+def empty_msg = error.annot("Stream && !satisfying(Stream.is_empty)").msg
+
+check:
+  Stream.first([]) ~throws empty_msg
+  Stream.first([1, 2, 3]) ~is 1
+  Stream.first(PairList[]) ~throws empty_msg
+  Stream.first(PairList[1, 2, 3]) ~is 1
+  Stream.first(0 ..) ~is 0
+  Stream.first(0 <..) ~is 1
+  Stream.first(0 .. 10) ~is 0
+  Stream.first(0 <.. 10) ~is 1
+  Stream.first(0 ..= 10) ~is 0
+  Stream.first(0 <..= 10) ~is 1
+  Stream.first(0 .. 0) ~throws empty_msg
+  Stream.first(10 >.. 0) ~is 9
+  Stream.first(10 >..= 0) ~is 9
+  Stream.first(10 >=.. 0) ~is 10
+  Stream.first(10 >=..= 0) ~is 10
+  Stream.first(1 >.. 0) ~throws empty_msg
+  Stream.cons(1, []).first ~is 1
+  Stream.empty.first ~throws empty_msg
+
+check:
+  Stream.rest([]) ~throws empty_msg
+  Stream.rest([1, 2, 3]) ~is [2, 3]
+  Stream.rest(PairList[]) ~throws empty_msg
+  Stream.rest(PairList[1, 2, 3]) ~is PairList[2, 3]
+  Stream.rest(0 ..) ~is 1 ..
+  Stream.rest(0 <..) ~is 1 <..
+  Stream.rest(0 .. 10) ~is 1 .. 10
+  Stream.rest(0 <.. 10) ~is 1 <.. 10
+  Stream.rest(0 ..= 10) ~is 1 ..= 10
+  Stream.rest(0 <..= 10) ~is 1 <..= 10
+  Stream.rest(0 .. 0) ~throws empty_msg
+  Stream.rest(10 >.. 0) ~is 9 >.. 0
+  Stream.rest(10 >..= 0) ~is 9 >..= 0
+  Stream.rest(10 >=.. 0) ~is 9 >=.. 0
+  Stream.rest(10 >=..= 0) ~is 9 >=..= 0
+  Stream.rest(1 >.. 0) ~throws empty_msg
+  Stream.cons(1, []).rest ~matches Stream.empty
+  Stream.empty.rest ~throws empty_msg
+
+fun naturals_from(i) :~ Stream:
+  Stream.cons(i, naturals_from(i+1))
+
+def naturals = naturals_from(0)
+
+check:
+  naturals.first ~is 0
+  naturals.rest.first ~is 1
+  naturals.first ~is 0
+  naturals.rest.rest.rest.rest.first ~is 4
+  naturals.rest.rest.rest.rest.first ~is 4
+  naturals.rest.rest.rest.rest.is_empty() ~is #false
+
+fun stream_add1(s :: Stream) :~ Stream:
+  match s
+  | Stream.cons(f, r): Stream.cons(f+1, stream_add1(r))
+
+def wholes = stream_add1(naturals)
+
+check:
+  wholes.first ~is 1
+  wholes.rest.first ~is 2
+  wholes.first ~is 1
+  wholes.rest.rest.rest.rest.first ~is 5
+  wholes.rest.rest.rest.rest.first ~is 5
+  wholes.rest.rest.rest.rest.is_empty() ~is #false
+
+block:
+  let mutable x = #false
+  let s = Stream.cons(block:
+                        x := #true
+                        7,
+                      block:
+                        x := #false
+                        [8])
+  check x ~is #false
+  check (match s | Stream.cons(_, _): #'yes) ~is #'yes
+  check x ~is #false
+  check s.first ~is 7
+  check x ~is #true
+  block:
+    use_dynamic
+    check dynamic(s).first ~is 7
+  check (match s | Stream.cons(f, _): f) ~is 7
+  check x ~is #true
+  check s[0] ~is 7
+  block:
+    use_dynamic
+    check dynamic(s)[0] ~is 7
+  check x ~is #true
+  check s.rest.first ~is 8
+  check x ~is #false
+  block:
+    use_dynamic
+    check dynamic(s).rest.first ~is 8
+  check s.first ~is 7
+  check x ~is #false
+  check (match s | Stream.cons(_, s): s.first) ~is 8
+  check x ~is #false
+  block:
+    use_dynamic
+    check dynamic(s).is_empty() ~is #false
+    check dynamic(s).rest.rest.is_empty() ~is #true
+
+block:
+  let mutable x = #false
+  let s = Stream.cons(~eager block:
+                        x := #true
+                        7,
+                      block:
+                        x := #false
+                        [8])
+  check x ~is #true
+  check s.rest.first ~is 8
+  check x ~is #false
+
+block:
+  let mutable x = #'no
+  let s = Stream.cons(block:
+                        x := #true
+                        7,
+                      ~eager block:
+                        x := #false
+                        [8])
+  check x ~is #false
+  check s.rest.first ~is 8
+  check x ~is #false
+  check s.first ~is 7
+  check x ~is #true
+
+block:
+  let mutable x = #'no
+  let s = Stream.cons(~eager block:
+                        x := #true
+                        7,
+                      ~eager block:
+                        x := #false
+                        [8])
+  check x ~is #false
+  check s.rest.first ~is 8
+  check x ~is #false
+  check s.first ~is 7
+  check x ~is #false
+
+check:
+  ~eval
+  Stream.cons(~eager, [])
+  ~throws "missing expression after keyword"
+
+block:
+  let lst = [[1], [2, 3]]
+  let seq = lst.to_sequence()
+  let s = Sequence.to_stream(seq)
+  check s.first.length() ~is 1
+  check s.rest.first.length() ~is 2
+  check Stream.first(s.rest).length() ~is 2
+  check Stream.rest(s).first.length() ~is 2
+  check lst.first.length() ~is 1
+  check lst.rest.first.length() ~is 2
+  check (match s | Stream.cons(f, _): f.length()) ~is 1
+  check (match lst | Stream.cons(f, _): f.length()) ~is 1
+  check (match s | Stream.cons(f, r): r.first.length()) ~is 2
+  check (match lst | Stream.cons(f, r): r.first.length()) ~is 2
+  check Stream.cons("a", ["b"]).first.length() ~is 1
+
+check:
+  ~eval
+  use_static
+  check Stream.cons("a", [5]).first.length() ~is 1
+  ~throws values("no such field or method",
+                 "based on static information")
+
+check:
+  ~eval
+  use_static
+  check Stream.cons(5, ["b"]).first.length() ~is 1
+  ~throws values("no such field or method",
+                 "based on static information")
+
+block:
+  fun f(s :: Stream.expect_of(String)):
+    [s.first.length(), s.is_empty()]
+  check f(["apple"]) ~is [5, #false]
+  check f([]) ~throws empty_msg
+
+block:
+  fun f(s :: Stream):
+    for List (x in s):
+      [x]
+  let lst = [1, 2]
+  let seq = lst.to_sequence()
+  let s = Sequence.to_stream(seq)
+  check f(s) ~is [[1], [2]]
+
+block:
+  use_dynamic
+  fun f(s):
+    for List (x in s):
+      [x]
+  check f(Stream.cons(1, Stream.cons(2, Stream.empty))) ~is [[1], [2]]
+
+block:
+  check Sequence.to_stream({ 1: "a" }).first ~is values(1, "a")
+  check Sequence.to_stream({ 1: "a" }).rest ~matches Stream.empty
+  check Stream.cons(values(1, 2), []).first ~is values(1, 2)
+  check Stream.cons(values(1, 2), []).rest ~matches Stream.empty
+  check Stream.cons(values(1, 2), Stream.cons(values(3, 4), [])).rest.first ~is values(3, 4)
+  block:
+    let (x, y) = Stream.cons(values([1], "a"), [] :: Stream.expect_of(List, String)).first
+    check x.length() ~is 1
+    check y.length() ~is 1
+  block:
+    let (x, y) = Sequence.to_stream({ [1]: "a" }).first
+    check x.length() ~is 1
+    check y.length() ~is 1


### PR DESCRIPTION
I've been reluctant to add streams to Rhombus, because it's not clear that the extra code is worthwhile, I wasn't sure it would create trouble or redundancies with other datatypes, and it's difficult to arrive at a smooth integration with streams implemented only outside `rhombus`. Now that the rest of the language has shaped up, though, it seems a shame to leave out an abstraction that is distinct and whose design has been worked out in detail in Racket.

This commit adds "stream" as a subset of "sequence", matching Racket's notion of "stream". It includes `Stream.cons` as a lazy constructor, it allows things like lists and pair lists to serve as streams, and it adapts ranges to work as streams (analogous to `in-range` as a stream at the Racket level). In the interest of otherwise including only essential functionality, it leaves out the functions that are implemented in `racket/stream`, so there's no `Stream.map` or `Stream.filter` method; there is a `Stream.get` (which can be used via `[]`), which duplicates the short implementation in `racket/stream`.

New methods `SequenceRange.first`, `SequenceRange.rest`, `DescendingSequenceRange.first`, `DescendingSequenceRange.rest`, `DescendingSequenceRange.is_empty`, `List.is_empty`, and `PairList.is_empty` sync the corresponding datatypes with `Stream`.