### PR TITLE
add `List.slice`, `String.slice`, etc.

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/array.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/array.rkt
@@ -31,6 +31,7 @@
          "class-primitive.rkt"
          "rhombus-primitive.rkt"
          "../version-case.rkt"
+         "slice.rkt"
          (submod "list.rkt" for-compound-repetition))
 
 (provide (for-spaces (rhombus/namespace
@@ -73,6 +74,7 @@
    copy
    copy_from
    snapshot
+   slice
    drop
    drop_last
    take
@@ -336,6 +338,12 @@
   #:primitive (vector-drop-right)
   #:static-infos ((#%call-result #,(get-array-static-infos)))
   (vector-drop-right v n))
+
+(define/method (Array.slice v start [end (and (vector? v) (vector-length v))])
+  #:static-infos ((#%call-result #,(get-array-static-infos)))
+  (check-array who v)
+  (define-values (s e) (slice-bounds who "array" v (vector-length v) start end))
+  (vector-copy v s e))
 
 (define/method (Array.set_in_copy v i val)
   #:primitive (vector-set/copy)

--- a/rhombus-lib/rhombus/private/amalgam/bytes.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bytes.rkt
@@ -19,7 +19,8 @@
          "number.rkt"
          "static-info.rkt"
          (submod "range.rkt" for-substring)
-         (submod "char.rkt" for-static-info))
+         (submod "char.rkt" for-static-info)
+         "slice.rkt")
 
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
@@ -62,6 +63,7 @@
    set
    append
    subbytes
+   slice
    copy
    copy_from
    fill
@@ -125,6 +127,12 @@
   (case-lambda
     [(bstr r) (subbytes/range who bstr r)]
     [(bstr start end) (subbytes bstr start end)]))
+
+(define/method (Bytes.slice bstr start [end (and (bytes? bstr) (bytes-length bstr))])
+  #:static-infos ((#%call-result #,(get-bytes-static-infos)))
+  (check-bytes who bstr)
+  (define-values (s e) (slice-bounds who "byte string" bstr (bytes-length bstr) start end))
+  (subbytes bstr s e))
 
 (define-syntax (define-string stx)
   (syntax-parse stx

--- a/rhombus-lib/rhombus/private/amalgam/list.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/list.rkt
@@ -45,6 +45,7 @@
          "list-last.rkt"
          "maybe-list-tail.rkt"
          (submod "range.rkt" for-substring)
+         "slice.rkt"
          "treelist-statinfo.rkt"
          "tuple-annot.rkt")
 
@@ -140,6 +141,7 @@
    drop
    drop_last
    sublist
+   slice
    contains
    index
    find
@@ -230,6 +232,7 @@
    drop
    drop_last
    sublist
+   slice
    contains
    index
    find
@@ -1249,6 +1252,12 @@
     [(lst r) (treelist-sublist/range who lst r)]
     [(lst start end) (treelist-sublist lst start end)]))
 
+(define/method (List.slice lst start [end (and (treelist? lst) (treelist-length lst))])
+  #:static-infos ((#%call-result ((#%dependent-result (merge-elem (0 #f treelist))))))
+  (check-treelist who lst)
+  (define-values (s e) (slice-bounds who "list" lst (treelist-length lst) start end))
+  (treelist-sublist lst s e))
+
 (define (raise-list-count who what l len n)
   (raise-arguments-error* who rhombus-realm
                           (string-append "list is shorter than the number of elements to "
@@ -1319,6 +1328,7 @@
   (check-mutable-treelist who lst)
   (define-values (start end)
     (range-canonical-start+end who "mutable list" r lst 0 (mutable-treelist-length lst)))
+  ;; this could fail if the mutable list changes size before we take the sublist
   (mutable-treelist-sublist! lst start end))
 
 (define/method MutableList.sublist
@@ -1326,6 +1336,12 @@
   (case-lambda
     [(lst r) (mutable-treelist-sublist!/range who lst r)]
     [(lst start end) (mutable-treelist-sublist! lst start end)]))
+
+(define/method (MutableList.slice lst start [end (and (mutable-treelist? lst) (mutable-treelist-length lst))])
+  (check-mutable-treelist who lst)
+  (define-values (s e) (slice-bounds who "mutable list" lst (mutable-treelist-length lst) start end))
+  ;; this could fail if the mutable list changes size before we take the sublist
+  (mutable-treelist-sublist! lst s e))
 
 (define/method (List.remove l v)
   #:static-infos ((#%call-result ((#%dependent-result (merge-elem (0 #f treelist))))))

--- a/rhombus-lib/rhombus/private/amalgam/slice.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/slice.rkt
@@ -1,0 +1,22 @@
+#lang racket/base
+(require racket/fixnum
+         "realm.rkt"
+         "annotation-failure.rkt")
+
+(provide slice-bounds)
+
+(define (slice-bounds who what v len start end)
+  (unless (exact-integer? start) (raise-annotation-failure who start "Int"))
+  (unless (exact-integer? end) (raise-annotation-failure who end "Int"))
+  (define s (if (< start 0) (+ start len) start))
+  (define e (if (< end 0) (+ end len) end))
+  (if (and (fixnum? s) (fixnum? e)
+           (fx<= 0 s len)
+           (fx<= s e len))
+      (values s e)
+      (raise-arguments-error* who rhombus-realm
+                              "invalid slice bounds"
+                              "given start" start
+                              "given end" end
+                              (string-append what " length") len
+                              what v)))

--- a/rhombus-lib/rhombus/private/amalgam/string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/string.rkt
@@ -36,7 +36,8 @@
          "static-info.rkt"
          "rx-object.rkt"
          "order-primitive.rkt"
-         (submod "range.rkt" for-substring))
+         (submod "range.rkt" for-substring)
+         "slice.rkt")
 
 (provide (for-spaces (#f
                       rhombus/repet)
@@ -100,6 +101,7 @@
    [ends_with String.ends_with]
    [append String.append]
    [substring String.substring]
+   [slice String.slice]
    [trim String.trim]
    [split String.split]
    [replace String.replace]
@@ -146,6 +148,7 @@
    [starts_with String.starts_with]
    [ends_with String.ends_with]
    [substring String.substring]
+   [slice String.slice]
    [trim String.trim]
    [split String.split]
    [join String.join]
@@ -553,6 +556,12 @@
   (case-lambda
     [(str r) (string->immutable-string (substring/range who str r))]
     [(str start end) (string->immutable-string (substring str start end))]))
+
+(define/method (String.slice str start [end (and (string? str) (string-length str))])
+  #:static-infos ((#%call-result #,(get-string-static-infos)))
+  (check-readable-string who str)
+  (define-values (s e) (slice-bounds who "string" str (string-length str) start end))
+  (string->immutable-string (substring str s e)))
 
 (define/method String.append
   #:primitive (string-append-immutable)

--- a/rhombus/rhombus/scribblings/reference/array.scrbl
+++ b/rhombus/rhombus/scribblings/reference/array.scrbl
@@ -303,6 +303,29 @@ pairwise equal by @rhombus(==).
 }
 
 @doc(
+  method (arr :: Array).slice(start :: Int,
+                              end :: Int = lst.length())
+    :: MutableArray
+){
+
+ Similar to @rhombus(Array.copy), but when @rhombus(start) or
+ @rhombus(end) is negative, it is replaced by
+ @rhombus(arr.length()+start) or @rhombus(arr.length()+end),
+ respectively.
+
+@examples(
+  def a = Array("a", "b", "c", "d", "e")
+  a.slice(1, 3)
+  a.slice(1)
+  a.slice(1, -2)
+  a.slice(-3, 4)
+)
+
+}
+
+
+
+@doc(
   method Array.copy_from(dest_arr :: MutableArray,
                          dest_start :: Nat,
                          src_arr :: Array,

--- a/rhombus/rhombus/scribblings/reference/bytes.scrbl
+++ b/rhombus/rhombus/scribblings/reference/bytes.scrbl
@@ -142,6 +142,26 @@ like @rhombus(<) and @rhombus(>) work on byte strings.
 }
 
 @doc(
+  method (bstr :: Bytes).slice(start :: Int,
+                               end :: Int = bstr.length())
+    :: Bytes
+){
+
+ Similar to @rhombus(Bytes.subbytes) with integer arguments, but when
+ @rhombus(start) or @rhombus(end) is negative, it is replaced by
+ @rhombus(bstr.length()+start) or @rhombus(bstr.length()+end),
+ respectively.
+
+@examples(
+  #"hello".slice(1, 3)
+  #"hello".slice(1)
+  #"hello".slice(1, -2)
+  #"hello".slice(-3, 4)
+)
+
+}
+
+@doc(
   method (bstr :: Bytes).copy() :: MutableBytes
 ){
 

--- a/rhombus/rhombus/scribblings/reference/list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/list.scrbl
@@ -589,6 +589,25 @@ their elements are pairwise equal by @rhombus(==).
 
 }
 
+@doc(
+  method (lst :: List).slice(start :: Int,
+                             end :: Int = lst.length())
+    :: List.of(Any.like_element(lst))
+){
+
+ Similar to @rhombus(List.sublist) with integer arguments, but when
+ @rhombus(start) or @rhombus(end) is negative, it is replaced by
+ @rhombus(lst.length()+start) or @rhombus(lst.length()+end),
+ respectively.
+
+@examples(
+  [1, 2, 3, 4, 5].slice(1, 3)
+  [1, 2, 3, 4, 5].slice(1)
+  [1, 2, 3, 4, 5].slice(1, -2)
+  [1, 2, 3, 4, 5].slice(-3, 4)
+)
+
+}
 
 @doc(
   method (lst :: List).contains(v :: Any,

--- a/rhombus/rhombus/scribblings/reference/mutable-list.scrbl
+++ b/rhombus/rhombus/scribblings/reference/mutable-list.scrbl
@@ -400,6 +400,34 @@ immutable list.
 
 
 @doc(
+  method (lst :: MutableList).slice(start :: Int,
+                                    end :: Int = lst.length())
+    :: Void
+){
+
+ Similar to @rhombus(MutableList.sublist) with integer arguments, but
+ when @rhombus(start) or @rhombus(end) is negative, it is replaced by
+ @rhombus(lst.length()+start) or @rhombus(lst.length()+end),
+ respectively.
+
+@examples(
+  ~repl:
+    def l = MutableList[1, 2, 3, 4, 5]
+    l.slice(1, 3)
+    l
+  ~repl:
+    def l = MutableList[1, 2, 3, 4, 5]
+    l.slice(1)
+    l
+  ~repl:
+    def l = MutableList[1, 2, 3, 4, 5]
+    l.slice(1, -2)
+    l
+)
+
+}
+
+@doc(
   method (mlst :: MutableList).contains(v :: Any,
                                         eqls :: Function.of_arity(2) = (_ == _))
     :: Boolean

--- a/rhombus/rhombus/scribblings/reference/string.scrbl
+++ b/rhombus/rhombus/scribblings/reference/string.scrbl
@@ -186,6 +186,26 @@ Strings are @tech{comparable}, which means that generic operations like
 
 }
 
+@doc(
+  method String.slice(str :: ReadableString,
+                      start :: Int,
+                      end :: Int = str.length())
+    :: String
+){
+
+ Similar to @rhombus(String.substring) with integer arguments, but when
+ @rhombus(start) or @rhombus(end) is negative, it is replaced by
+ @rhombus(str.length()+start) or @rhombus(str.length()+end),
+ respectively.
+
+@examples(
+  "hello".slice(1, 3)
+  "hello".slice(1)
+  "hello".slice(1, -2)
+  "hello".slice(-3, 4)
+)
+
+}
 
 @doc(
   method String.find(str :: ReadableString,

--- a/rhombus/rhombus/tests/array.rhm
+++ b/rhombus/rhombus/tests/array.rhm
@@ -14,6 +14,7 @@ block:
     Array.append(arr, ...) ~method
     Array.copy(arr, [start], [end]) ~method
     Array.copy_from(dest_arr, dest_start, src_arr, [src_start], [src_end]) ~method
+    Array.slice(arr, start, [end]) ~method
     Array.snapshot(arr) ~method
     Array.drop(arr, n) ~method
     Array.drop_last(arr, n) ~method
@@ -125,6 +126,11 @@ block:
        s) ~is_now Array(4, 5, 9, 10, 8)
     Array(1, 2, 3).snapshot() ~is Array(1, 2, 3).snapshot()
     Array(1, 2, 3).snapshot().copy() ~is_now Array(1, 2, 3)
+  check:
+    Array(1, 2, 3).slice(1) ~is_now Array(2, 3)
+    Array(4, 5, 6).slice(-2) ~is_now Array(5, 6)
+    Array(4, 5, 6).slice(1, -1) ~is_now Array(5)
+    Array(4, 5, 6).slice(2, -1) ~is_now Array()
 
 block:
   check:
@@ -157,6 +163,11 @@ block:
        let s = Array(4, 5, 6, 7, 8)
        dynamic(s).copy_from(2, Array(0, 9, 10, 11), 1, 3)
        s) ~is_now Array(4, 5, 9, 10, 8)
+  check:
+    dynamic(Array(1, 2, 3)).slice(1) ~is_now Array(2, 3)
+    dynamic(Array(4, 5, 6)).slice(-2) ~is_now Array(5, 6)
+    dynamic(Array(4, 5, 6)).slice(1, -1) ~is_now Array(5)
+    dynamic(Array(4, 5, 6)).slice(2, -1) ~is_now Array()
 
 block:
   def [x, ...] = [1, 2, 3]

--- a/rhombus/rhombus/tests/bytes.rhm
+++ b/rhombus/rhombus/tests/bytes.rhm
@@ -11,6 +11,7 @@ block:
     Bytes.set(bstr, i, b) ~method
     Bytes.append(bstr, ...) ~method
     Bytes.subbytes(bstr, start, [end]) ~method
+    Bytes.slice(bstr, start, [end]) ~method
     Bytes.copy(bstr) ~method
     Bytes.copy_from(dest_bstr, dest_start, src_bstr, [src_start], [src_end]) ~method
     Bytes.snapshot(bstr) ~method
@@ -50,6 +51,10 @@ block:
     #"hello".subbytes(1..) ~is_now #"ello"
     #"hello".subbytes(..3) ~is_now #"hel"
     #"hello".subbytes(..) ~is_now #"hello"
+    #"hello".slice(1) ~is_now #"ello"
+    #"hello".slice(-1) ~is_now #"o"
+    #"hello".slice(-3, -1) ~is_now #"ll"
+    #"hello".slice(1, 4) ~is_now #"ell"
     #"hello".copy() ~is_now #"hello"
     #"hello".copy() == #"hello" ~is #false
     (block:
@@ -101,6 +106,8 @@ check:
   dynamic(#"hello").subbytes(1..) ~is_now #"ello"
   dynamic(#"hello").subbytes(..3) ~is_now #"hel"
   dynamic(#"hello").subbytes(..) ~is_now #"hello"
+  dynamic(#"hello").slice(-2) ~is_now #"lo"
+  dynamic(#"hello").slice(-2, -1) ~is_now #"l"
   dynamic(#"hello").copy() ~is_now #"hello"
   (block:
      let s = #"hello".copy()
@@ -143,6 +150,8 @@ check:
   Bytes.subbytes(#"hello", 1..) ~is_now #"ello"
   Bytes.subbytes(#"hello", ..3) ~is_now #"hel"
   Bytes.subbytes(#"hello", ..) ~is_now #"hello"
+  Bytes.slice(#"hello", 1) ~is_now #"ello"
+  Bytes.slice(#"hello", 1, -1) ~is_now #"ell"
   Bytes.copy(#"hello") ~is_now #"hello"
   Bytes.utf8_string(#"h\303\211llo") ~is "hÉllo"
   Bytes.utf8_string(#"h\303\211llo", #false, 3) ~is "llo"

--- a/rhombus/rhombus/tests/list.rhm
+++ b/rhombus/rhombus/tests/list.rhm
@@ -32,6 +32,7 @@ block:
     List.take(lst, n) ~method
     List.take_last(lst, n) ~method
     List.sublist(lst, start, [end]) ~method
+    List.slice(lst, start, [end]) ~method
     List.sort(lst, [is_less]) ~method
     List.iota(n)
     List.copy(lst) ~method
@@ -446,6 +447,17 @@ check:
   List.sublist([1, 2, 3, 4, 5, 6], ..4) ~is [1, 2, 3, 4]
   [1, 2, 3, 4, 5, 6].sublist(..) ~is [1, 2, 3, 4, 5, 6]
   List.sublist([1, 2, 3, 4, 5, 6], ..) ~is [1, 2, 3, 4, 5, 6]
+  [1, 2, 3, 4, 5, 6].slice(2) ~is [3, 4, 5, 6]
+  List.slice([1, 2, 3, 4, 5, 6], 2) ~is [3, 4, 5, 6]
+  [1, 2, 3, 4, 5, 6].slice(2, 5) ~is [3, 4, 5]
+  List.slice([1, 2, 3, 4, 5, 6], 2, 5) ~is [3, 4, 5]
+  [1, 2, 3, 4, 5, 6].slice(2, -1) ~is [3, 4, 5]
+  List.slice([1, 2, 3, 4, 5, 6], 2, -1) ~is [3, 4, 5]
+  [1, 2, 3, 4, 5, 6].slice(-4, 5) ~is [3, 4, 5]
+  List.slice([1, 2, 3, 4, 5, 6], -4, 5) ~is [3, 4, 5]
+  [1, 2, 3, 4, 5, 6].slice(2, 1) ~throws "invalid slice bounds"
+  [1, 2, 3, 4, 5, 6].slice(-2, -5) ~throws "invalid slice bounds"
+  [1, 2, 3, 4, 5, 6].slice(-7, 6) ~throws "invalid slice bounds"
 
 check:
   [1, 2, 3].sort() ~is [1, 2, 3]
@@ -962,6 +974,7 @@ block:
   check los.drop_last(1)[0].length() ~is 1
   check los.take_last(1)[0].length() ~is 1
   check los.sublist(0..1)[0].length() ~is 1
+  check los.slice(0, 1)[0].length() ~is 1
   check los.reverse()[0].length() ~is 1
   check los.find((_ == "a")).length() ~is 1
   check los.remove("a")[0].length() ~is 1

--- a/rhombus/rhombus/tests/mutable-list.rhm
+++ b/rhombus/rhombus/tests/mutable-list.rhm
@@ -27,6 +27,7 @@ block:
     MutableList.take(lst, n) ~method
     MutableList.take_last(lst, n) ~method
     MutableList.sublist(lst, start, [end]) ~method
+    MutableList.slice(lst, start, [end]) ~method
     MutableList.sort(lst, [is_less]) ~method
     MutableList.copy(lst) ~method
     MutableList.to_list(lst) ~method
@@ -273,6 +274,9 @@ check:
   (block: let l = MutableList[1, 2, 3, 4, 5, 6]; l.sublist(2..); l) ~is_now MutableList[3, 4, 5, 6]
   (block: let l = MutableList[1, 2, 3, 4, 5, 6]; l.sublist(..4); l) ~is_now MutableList[1, 2, 3, 4]
   (block: let l = MutableList[1, 2, 3, 4, 5, 6]; l.sublist(..); l) ~is_now MutableList[1, 2, 3, 4, 5, 6]
+  (block: let l = MutableList[1, 2, 3, 4, 5, 6]; l.slice(2); l) ~is_now MutableList[3, 4, 5, 6]
+  (block: let l = MutableList[1, 2, 3, 4, 5, 6]; l.slice(2, 4); l) ~is_now MutableList[3, 4]
+  (block: let l = MutableList[1, 2, 3, 4, 5, 6]; l.slice(-2, 5); l) ~is_now MutableList[5]
 
 check:
   (block: let l = MutableList[1, 2, 3]; l.sort(); l) ~is_now MutableList[1, 2, 3]

--- a/rhombus/rhombus/tests/string.rhm
+++ b/rhombus/rhombus/tests/string.rhm
@@ -22,6 +22,7 @@ block:
     String.from_int(n)
     String.from_number(n)
     String.substring(str, start, [end]) ~method ReadableString
+    String.slice(str, start, [end]) ~method ReadableString
     String.append(str, ...) ~method ReadableString
     String.replace(str, from, to) ~method ReadableString
     String.trim(str, [sep]) ~method ReadableString
@@ -100,6 +101,9 @@ block:
     "hello".substring(1..) ~is "ello"
     "hello".substring(..3) ~is "hel"
     "hello".substring(..) ~is "hello"
+    "hello".slice(1, 3) ~is "el"
+    "hello".slice(1, -3) ~is "e"
+    "hello".slice(-1) ~is "o"
     "hÉllo".utf8_bytes() ~is #"h\303\211llo"
     "hÉllo".utf8_bytes(#false, 2) ~is #"llo"
     "hÉllo".latin1_bytes() ~is #"h\311llo"
@@ -182,6 +186,7 @@ check:
   dynamic("hello").substring(1..) ~is "ello"
   dynamic("hello").substring(..3) ~is "hel"
   dynamic("hello").substring(..) ~is "hello"
+  dynamic("hello").slice(2, -1) ~is "ll"
   dynamic("hÉllo").utf8_bytes() ~is #"h\303\211llo"
   dynamic("hÉllo").utf8_bytes(#false, 2) ~is #"llo"
   dynamic("hÉllo").latin1_bytes() ~is #"h\311llo"
@@ -256,6 +261,8 @@ check:
   String.substring("hello", 1..) ~is "ello"
   String.substring("hello", ..3) ~is "hel"
   String.substring("hello", ..) ~is "hello"
+  String.slice("hello", 2) ~is "llo"
+  String.slice("hello", 2, -2) ~is "l"
   String.utf8_bytes("hÉllo") ~is #"h\303\211llo"
   String.utf8_bytes("hÉllo", #false, 2) ~is #"llo"
   String.latin1_bytes("hÉllo") ~is #"h\311llo"


### PR DESCRIPTION
The others are `Bytes.slice`, `Array.slice`, and `MutableList.slice`.

These are similar to functions like `List.sublist` as called with integer arguments, but negative numbers are treated by `slice` methods as counting from the end. In other words, it's like a Python list slice, but in method-call form. Counting from the end can be helpfully more compact (compared to arithmetic on the result of calling `length`) in some cases.

An alternative could be to change `List.sublist` and similar. This commit adds `slice` methods instead for two reasons:

 * A single argument to `List.sublist` is treated as a range instead of a starting index. Allowing a range or number would be possible, but it implies a check on every call to dynamically select the mode, and that's in addition to the existing arity-based selection.

 * Treating negative numbers this way can be convenient, but it can also produce surprising results if a bug leads to a negative argument accidentally. Also, supporintg negative numbers implies a check that cannot be skipped in a (hypothetical, for now) unsafe mode. It seems cleaner to isolate negative-number treatment to a specific method, so callers can opt into it.

Another possibility is to add `take`, `take_last`, `drop`, and `drop_last` methods to more datatypes. Those cover common cases, but they're not as general as `slice`, and a use of `slice` reads well enough in comparison.