### PR TITLE
remove `pragma`

### DIFF
--- a/rhombus/rhombus/scribblings/model/static-overview.scrbl
+++ b/rhombus/rhombus/scribblings/model/static-overview.scrbl
@@ -1,6 +1,8 @@
 #lang rhombus/scribble/manual
 @(import:
-    "common.rhm" open)
+    "common.rhm" open
+    meta_label:
+      rhombus/unsafe.use_unsafe)
 
 @title(~style: #'toc, ~tag: "static-info"){Type Model}
 
@@ -13,8 +15,8 @@ object's class. The main distinction between this capability and a
 statically typed language, at least in the usual sense, is that Rhombus
 offers only limited guarantees that static predictions about values will
 be correct. Rhombus is a safe language,@margin_note{Although Rhombus is
- safe by default, unsafe facilities or the use of
- @rhombus(pragma ~unsafe, ~decl) can opt into unsafe mode.} because
+ safe by default, unsafe facilities or the use of an
+ @rhombus(use_unsafe) declaration can opt into unsafe mode.} because
 run-time checks will enforce predictions where the compiler cannot prove
 that they will hold, but limited guarantees mean that the checks can
 fail.

--- a/rhombus/rhombus/scribblings/reference/module.scrbl
+++ b/rhombus/rhombus/scribblings/reference/module.scrbl
@@ -101,35 +101,6 @@ different than the enclosing (sub)module.
 }
 
 @doc(
-  ~nonterminal:
-    module_path: import ~defn
-
-  decl.macro 'pragma $decl'
-  decl.macro 'pragma:
-                $decl ...
-                ...'
-
-  grammar decl
-  | ~unsafe
-  | ~empty_evaluator
-){
-
- Controls properties of a module's compilation:
-
-@itemlist(
-
- @item{@as_indexed{@rhombus(~unsafe)} compiles the module in unsafe mode,
-  where annotation failures trigger unspecified behavior.}
-
- @item{@as_indexed{@rhombus(~empty_evaluator)} disables the use of the
-  module's content for interactive evaluation, which can avoid overhead
-  for the module.}
-
-)
-
-}
-
-@doc(
   decl.macro '#%module_block:
                 $body
                 ...'


### PR DESCRIPTION
The `pragma` form was originally added to support `pragma ~unsafe`, but I had forgotten about it a year later when adding `use_unsafe` (as imported via `rhombus/unsafe`). The `use_unsafe` convention seems better, so remove `pragma`.