### PR TITLE
`None` -> `Never`

### DIFF
--- a/rhombus-lib/rhombus/private/amalgam/annotation-string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation-string.rkt
@@ -8,7 +8,7 @@
          annotation-string-convert-pair)
 
 (define annotation-any-string "Any")
-(define annotation-none-string "None")
+(define annotation-never-string "Never")
 
 (define (annotation-string-from-pattern p)
   (string-append "matching(" p ")"))
@@ -24,9 +24,9 @@
 (define (annotation-string-and a b)
   (cond
     [(or (equal? a annotation-any-string)
-         (equal? b annotation-none-string))
+         (equal? b annotation-never-string))
      b]
-    [(or (equal? a annotation-none-string)
+    [(or (equal? a annotation-never-string)
          (equal? b annotation-any-string))
      a]
     [else
@@ -35,9 +35,9 @@
 (define (annotation-string-or a b)
   (cond
     [(or (equal? a annotation-any-string)
-         (equal? b annotation-none-string))
+         (equal? b annotation-never-string))
      a]
-    [(or (equal? a annotation-none-string)
+    [(or (equal? a annotation-never-string)
          (equal? b annotation-any-string))
      b]
     [else

--- a/rhombus-lib/rhombus/private/amalgam/annotation.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/annotation.rkt
@@ -21,6 +21,7 @@
                      "annotation-failure.rkt"
                      (for-syntax racket/base))
          "provide.rkt"
+         "deprecated.rkt"
          "enforest.rkt"
          "annotation-operator.rkt"
          "expression.rkt"
@@ -59,6 +60,7 @@
                      is_a)
          (for-space rhombus/annot
 
+                    Never
                     None
                     Boolean
                     PosInt
@@ -1093,7 +1095,8 @@
 (void (set-primitive-contract! 'flonum? "Flonum"))
 (void (set-primitive-contract! 'fixnum? "Fixnum"))
 (define-annotation-syntax Any (identifier-annotation always-satisfied ()))
-(define-annotation-syntax None (identifier-annotation (lambda (x) #f) ((#%none #t))))
+(define-annotation-syntax Never (identifier-annotation (lambda (x) #f) ((#%never #t))))
+(define-deprecated None None (rhombus/annot) "01-May-2026" Never)
 (define-annotation-syntax Boolean (identifier-annotation boolean? ()))
 (define-annotation-syntax Int (identifier-annotation exact-integer? #,(get-int-static-infos)))
 (define-annotation-syntax PosInt (identifier-annotation exact-positive-integer? #,(get-int-static-infos)))
@@ -1429,7 +1432,7 @@
                           (or (equal-always? lit v)
                               ...)))
                     (if (null? (syntax->list #'(lit ...)))
-                        #'((#%none #true))
+                        #'((#%never #true))
                         #'())))
                   #'tail))]))))
 

--- a/rhombus-lib/rhombus/private/amalgam/control.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/control.rkt
@@ -203,7 +203,7 @@
    (lambda (form1 op-stx)
      (wrap-static-info
       #`(raise #,(discard-static-infos form1))
-      #'#%none
+      #'#%never
       #'#true))))
 
 (void (set-primitive-who! 'call-with-composable-continuation 'Continuation.capture))
@@ -342,7 +342,7 @@
                #:tag [prompt-tag (default-continuation-prompt-tag)]
                . vals)
   #:primitive (abort-current-continuation)
-  #:static-infos ((#%call-result ((#%none #t))))
+  #:static-infos ((#%call-result ((#%never #t))))
   (apply abort-current-continuation prompt-tag vals))
 
 (define Continuation.PromptTag.default

--- a/rhombus-lib/rhombus/private/amalgam/error.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/error.rhm
@@ -58,7 +58,7 @@ fun error(~srcloc: srcloc :: maybe(Srcloc) = #false,
           // or `error.text`; each `clause` starts its own line with
           // a 2-space prefix:
           clause :: error.Clause,
-          ...) :~ None:
+          ...) :~ Never:
   let msg = message(~srcloc: srcloc,
                     ~who: who,
                     ~realm: realm,

--- a/rhombus-lib/rhombus/private/amalgam/static-info-macro.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/static-info-macro.rkt
@@ -98,7 +98,7 @@
      maybe_key
      values_key
      indirect_key
-     none_key)))
+     never_key)))
 
 (define-for-syntax (make-static-info-macro-macro in-space convert-id)
   (definition-transformer
@@ -383,7 +383,7 @@
 
   (define/arity (statinfo_meta.or . statinfos)
     #:static-infos ((#%call-result #,(get-syntax-static-infos)))
-    (static-infos-merge who statinfos static-infos-or #'((#%none #t))))
+    (static-infos-merge who statinfos static-infos-or #'((#%never #t))))
 
   (define/arity (statinfo_meta.and . statinfos)
     #:static-infos ((#%call-result #,(get-syntax-static-infos)))
@@ -413,4 +413,4 @@
 (define-key fixnum_key #%fixnum)
 (define-key values_key #%values)
 (define-key indirect_key #%indirect-static-info)
-(define-key none_key #%none)
+(define-key never_key #%never)

--- a/rhombus-lib/rhombus/private/amalgam/static-info.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/static-info.rkt
@@ -57,7 +57,7 @@
          #%indirect-static-info
          #%values
          #%maybe
-         #%none)
+         #%never)
 
 (begin-for-syntax
   (property static-info (get-stxs))
@@ -211,7 +211,7 @@
                      (lambda (a b)
                        (merge a b static-infos-and)))))
 
-(define-syntax #%none
+(define-syntax #%never
   (static-info-key (lambda (a b) a)
                    (lambda (a b) a)))
 
@@ -345,13 +345,13 @@
                    (syntax-parse a
                      [(a-key . _) (datum->syntax #f (list #'a-key new-val))])))
             #'())))
-       (define (none? as) (and as (static-info-lookup as (quote-syntax #%none))))
-       ;; if one has `None` and the other doesn't, ignore the one with `None`
+       (define (never? as) (and as (static-info-lookup as (quote-syntax #%never))))
+       ;; if one has `Never` and the other doesn't, ignore the one with `Never`
        (cond
-         [(none? as) (if (none? bs)
+         [(never? as) (if (never? bs)
                          (merge)
                          bs)]
-         [(none? bs) as]
+         [(never? bs) as]
          [else (merge)]))]))
 
 ;; note that `&&` at the annotation level feels like "union" on statinfo tables

--- a/rhombus-lib/rhombus/private/amalgam/syntax-meta.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/syntax-meta.rkt
@@ -12,7 +12,7 @@
                      "call-result-key.rkt"
                      "name-root.rkt"
                      (submod "annotation.rkt" for-class)
-                     (only-in "static-info.rkt" #%none)
+                     (only-in "static-info.rkt" #%never)
                      (for-syntax racket/base)
                      (submod "syntax-object.rkt" for-quasiquote)
                      "srcloc.rkt"
@@ -140,7 +140,7 @@
                                    form/msg
                                    [form unsafe-undefined]
                                    [detail unsafe-undefined])
-    #:static-infos ((#%call-result ((#%none #t))))
+    #:static-infos ((#%call-result ((#%never #t))))
     (define who-in
       (cond
         [(or (not m-who) (symbol? m-who)) m-who]

--- a/rhombus-lib/rhombus/wrapper.rhm
+++ b/rhombus-lib/rhombus/wrapper.rhm
@@ -6,7 +6,7 @@ export:
 
 fun error_not_handle(~who: who :: maybe(error.Who) = #false,
                      ~what: what :: maybe(String) = #false,
-                     handle) :~ None:
+                     handle) :~ Never:
   ~name: wrapper.error
   error(~who: who,
         ~exn: Exn.Fail.Annot,

--- a/rhombus/rhombus/scribblings/meta/static-info.scrbl
+++ b/rhombus/rhombus/scribblings/meta/static-info.scrbl
@@ -285,7 +285,7 @@
  @rhombus(statinfo_stx) arguments have the key, the values associated
  with those keys will be ``and''ed. That combination is true even if
  one of the @rhombus(statinfo_stx) arguments has the static information of
- @rhombus(None, ~annot) as represented by @rhombus(statinfo_meta.none_key).
+ @rhombus(Never, ~annot) as represented by @rhombus(statinfo_meta.never_key).
 
  An ``or'' combination corresponds to the @rhombus(||, ~annot) annotation
  operator. From the perspective of static-information keys and values,
@@ -293,9 +293,9 @@
  @rhombus(statinfo_stx) arguments is included in the result, and the
  value in each @rhombus(statinfo_stx) is ``or''ed for the result.
  However, if a @rhombus(statinfo_stx) argument has the static information of
- @rhombus(None, ~annot), that @rhombus(statinfo_stx) is effectively discarded.
+ @rhombus(Never, ~annot), that @rhombus(statinfo_stx) is effectively discarded.
  If no @rhombus(statinfo_stx) arguments are provided to @rhombus(statinfo_meta.or),
- the result is the same static information as for @rhombus(None, ~annot).
+ the result is the same static information as for @rhombus(Never, ~annot).
 
 }
 
@@ -356,7 +356,7 @@
   def statinfo_meta.fixnum_key :: Identifier
   def statinfo_meta.values_key :: Identifier
   def statinfo_meta.indirect_key :: Identifier
-  def statinfo_meta.none_key :: Identifier
+  def statinfo_meta.never_key :: Identifier
 ){
 
  Values that can be used to associate static information with an
@@ -461,9 +461,9 @@
         static information is lazily spliced in place of this key
         and identifier.}
 
-  @item{@rhombus(statinfo_meta.none_key): Any value, but normally
+  @item{@rhombus(statinfo_meta.never_key): Any value, but normally
         @rhombus(#true), where the presence of this key indicates
-        the static information of @rhombus(None, ~annot): a claim
+        the static information of @rhombus(Never, ~annot): a claim
         that no value is possible at run time.}
 
 )

--- a/rhombus/rhombus/scribblings/meta/stxobj-meta.scrbl
+++ b/rhombus/rhombus/scribblings/meta/stxobj-meta.scrbl
@@ -11,16 +11,16 @@
   ~meta
   fun syntax_meta.error(~who: who :: maybe(error.Who) = #false,
                         in_stx :: Syntax)
-    :: None
+    :: Never
   fun syntax_meta.error(~who: who :: maybe(error.Who) = #false,
                         message :: ReadableString,
                         in_stx :: Syntax)
-    :: None
+    :: Never
   fun syntax_meta.error(~who: who :: maybe(error.Who) = #false,
                         message :: ReadableString,
                         in_stx :: Syntax,
                         at_stx :: Syntax || List.of(Syntax))
-    :: None
+    :: Never
 ){
 
  Throws a syntax-error message concerning @rhombus(in_stx). If

--- a/rhombus/rhombus/scribblings/reference/annotation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/annotation.scrbl
@@ -87,7 +87,7 @@
   annot.macro 'Any'
   annot.macro 'Any.of($expr, ...)'
   annot.macro 'Any.to_boolean'
-  annot.macro 'None'
+  annot.macro 'Never'
 ){
 
  The @rhombus(Any, ~annot) annotation matches any value, so it
@@ -97,19 +97,19 @@
  @rhombus(Any.to_boolean, ~annot) annotation matches any value and
  converts non-@rhombus(#false) value to @rhombus(#true).
 
- The @rhombus(None, ~annot) annotation matches no values, or in other
+ The @rhombus(Never, ~annot) annotation matches no values, or in other
  words, is equivalent to @rhombus(Any.of(), ~annot). It is useful for
  asserting that something never returns, such as a function that always
  throws an exception. The annotation
- @rhombus(None || #,(@rhombus(ann, ~var)), ~annot) is equivalent to
+ @rhombus(Never || #,(@rhombus(ann, ~var)), ~annot) is equivalent to
  @rhombus(ann, ~var), since any value that satisfies the annotation must
- satisfy @rhombus(ann, ~var). In principle, @rhombus(None, ~annot) would
+ satisfy @rhombus(ann, ~var). In principle, @rhombus(Never, ~annot) would
  imply any other annotation and provide all static information; instead,
- as a pratical compromise, @rhombus(None, ~annot) provides no oher static
+ as a pratical compromise, @rhombus(Never, ~annot) provides no other static
  information. As a further practical choice along those lines, the annotation
- @rhombus(None && #,(@rhombus(ann, ~var)), ~annot) implies all the static
+ @rhombus(Never && #,(@rhombus(ann, ~var)), ~annot) implies all the static
  information of @rhombus(ann, ~var), while still behaving like
- @rhombus(None, ~annot) for further combinations via @rhombus(||, ~annot).
+ @rhombus(Never, ~annot) for further combinations via @rhombus(||, ~annot).
 
  See @secref(~doc: guide_doc, "annotation-satisfying") for information
  about the time that @rhombus(expr) is evaluated.
@@ -120,7 +120,7 @@
   "hola" is_a Any.of("hello", "goodbye")
   "hello" :: Any.to_boolean
   #false :: Any.to_boolean
-  "will not match" is_a None
+  "will not match" is_a Never
   "will not match" is_a Any.of()
 )
 

--- a/rhombus/rhombus/scribblings/reference/boolean.scrbl
+++ b/rhombus/rhombus/scribblings/reference/boolean.scrbl
@@ -103,7 +103,7 @@ and @rhombus(#false). For most contexts, such as the test position in
  implied by the annotation is the @rhombus(statinfo_meta.or) of information for
  @rhombus(left_annot) and @rhombus(right_annot), which means that information for a key
  must appear in both for the key to be part of the implied annotation (except
- that @rhombus(None, ~annot) is treated specially).
+ that @rhombus(Never, ~annot) is treated specially).
 
  The annotations are checked in other. Either or both of
  @rhombus(left_annot) and @rhombus(right_annot) can be a @tech(~doc: model_doc){converter

--- a/rhombus/rhombus/scribblings/reference/char.scrbl
+++ b/rhombus/rhombus/scribblings/reference/char.scrbl
@@ -113,7 +113,7 @@ character.
  @item{titlecase: Unicode general category @UCat{Lt}}
 
  @item{numeric: Unicode ``Numeric_Type'' property other than
-  @litchar{None}}
+  @litchar{Never}}
 
  @item{symbolic: Unicode general category @UCat{Sm}, @UCat{Sc},
   @UCat{Sk}, or @UCat{So}}

--- a/rhombus/rhombus/scribblings/reference/continuation.scrbl
+++ b/rhombus/rhombus/scribblings/reference/continuation.scrbl
@@ -118,7 +118,7 @@ or by using it with @rhombus(Continuation.in).
     ~tag: tag :: Continuation.PromptTag:
             Continuation.PromptTag.default,
     val :: Any, ...
-  ) :: None
+  ) :: Never
 ){
 
  Escapes to the nearest prompt in the current continuation that has the

--- a/rhombus/rhombus/scribblings/reference/error.scrbl
+++ b/rhombus/rhombus/scribblings/reference/error.scrbl
@@ -18,7 +18,7 @@
     ~details: details :: List.of(ReadableString) = [],
     clause :: error.Clause,
     ...
-  ) :: None
+  ) :: Never
 ){
 
  Throws the result of @rhombus(exn) as an exception, constructing the

--- a/rhombus/rhombus/scribblings/reference/exn.scrbl
+++ b/rhombus/rhombus/scribblings/reference/exn.scrbl
@@ -151,7 +151,7 @@
  @rhombus(Exn, ~class).
 
  Since it does not return a value, a @rhombus(throw) expression has the
- static information of @rhombus(None, ~annot).
+ static information of @rhombus(Never, ~annot).
 
 }
 

--- a/rhombus/rhombus/scribblings/reference/number.scrbl
+++ b/rhombus/rhombus/scribblings/reference/number.scrbl
@@ -112,7 +112,7 @@ literals rely on a escape to S-expression syntax.
 
  Matches @tech{exact} @tech{integers}: all of them, positive integers, negative
  integers, nonnegative integers, or integers in a given range.
- None that a range can omit a lower bound or upper bound, such as
+ Note that a range can omit a lower bound or upper bound, such as
  when @rhombus(..) is used as a prefix or postfix operator. The
  @rhombus(Nat, ~annot) annotation is the preferred alias for
  @rhombus(NonnegInt, ~annot).

--- a/rhombus/rhombus/scribblings/rhombus-racket/wrapper.scrbl
+++ b/rhombus/rhombus/scribblings/rhombus-racket/wrapper.scrbl
@@ -49,7 +49,7 @@ result annotation @rhombus(:~ Fish).
     ~who: who :: maybe(error.Who) = #false,
     ~what: what :: maybe(String) = #false,
     handle
-  ) :: None
+  ) :: Never
 ){
 
  Throws an exception indicating that @rhombus(handle) is not an

--- a/rhombus/rhombus/tests/annotation.rhm
+++ b/rhombus/rhombus/tests/annotation.rhm
@@ -128,15 +128,15 @@ check:
   #true :: Any ~is #true
   #true :: Any.of(#true, #false) ~is #true
   #true :: Any.to_boolean ~is #true
-  #true :: None ~throws "does not satisfy"
+  #true :: Never ~throws "does not satisfy"
   #false :: Any ~is #false
   #false :: Any.of(#true, #false) ~is #false
   #false :: Any.to_boolean ~is #false
-  #false :: None ~throws "does not satisfy"
+  #false :: Never ~throws "does not satisfy"
   "x" :: Any ~is "x"
   "x" :: Any.of(#true, #false) ~throws "does not satisfy"
   "x" :: Any.to_boolean ~is #true
-  "x" :: None ~throws "does not satisfy"
+  "x" :: Never ~throws "does not satisfy"
 
 block:
   namespace ns:
@@ -366,18 +366,18 @@ check:
 
 block:
   use_static
-  check ([] || (0 :: None)).length() ~is 0
-  check ((0 :: None) || []).length() ~throws error.annot_msg()
+  check ([] || (0 :: Never)).length() ~is 0
+  check ((0 :: Never) || []).length() ~throws error.annot_msg()
   check ((dynamic([]) :: maybe(List))!! || error("oops")).length() ~is 0
   check ((dynamic([]) :: maybe(List))!! || throw #'bye).length() ~is 0
-  check (fun (x :: (List || None)): x.length()) ~completes
-  check (fun (x :: (List && None)): x.length()) ~completes // analogous to `List && String`
-  check 10 is_a (Int && None) ~is #false
+  check (fun (x :: (List || Never)): x.length()) ~completes
+  check (fun (x :: (List && Never)): x.length()) ~completes // analogous to `List && String`
+  check 10 is_a (Int && Never) ~is #false
 
 check:
   ~eval
   use_static
-  fun (x :: None): x.length()
+  fun (x :: Never): x.length()
   ~throws "no such field or method"
 
 // check precedence of boolean operators

--- a/rhombus/rhombus/tests/arrow-annotation.rhm
+++ b/rhombus/rhombus/tests/arrow-annotation.rhm
@@ -753,7 +753,7 @@ block:
   def f0 = (fun () :: String: "x")
   def f = (fun (x) :: ((~any) -> String):
              (fun () :: String: "x"))
-  def fx: (fun () :: None: error("no"))
+  def fx: (fun () :: Never: error("no"))
 
   def h = adjust(f0)
 

--- a/rhombus/rhombus/tests/class.rhm
+++ b/rhombus/rhombus/tests/class.rhm
@@ -1471,20 +1471,20 @@ block:
     fun whoami():
       ~who: who
       who
-    fun try_input(_ :: None):
+    fun try_input(_ :: Never):
       error("should not get here")
-    fun try_output() :: None:
+    fun try_output() :: Never:
       "oops"
   check:
     A.whoami() ~is #'#{A.whoami}
     A.try_input("oops") ~throws values(
       "A.try_input: " ++ error.annot_msg("argument"),
-      error.annot("None").msg,
+      error.annot("Never").msg,
       error.val("oops", ~label: "argument").msg,
     )
     A.try_output() ~throws values(
       "A.try_output: " ++ error.annot_msg("result"),
-      error.annot("None").msg,
+      error.annot("Never").msg,
       error.val("oops", ~label: "result").msg,
     )
 

--- a/rhombus/rhombus/tests/interface.rhm
+++ b/rhombus/rhombus/tests/interface.rhm
@@ -735,20 +735,20 @@ block:
     fun whoami():
       ~who: who
       who
-    fun try_input(_ :: None):
+    fun try_input(_ :: Never):
       error("should not get here")
-    fun try_output() :: None:
+    fun try_output() :: Never:
       "oops"
   check:
     A.whoami() ~is #'#{A.whoami}
     A.try_input("oops") ~throws values(
       "A.try_input: " ++ error.annot_msg("argument"),
-      error.annot("None").msg,
+      error.annot("Never").msg,
       error.val("oops", ~label: "argument").msg,
     )
     A.try_output() ~throws values(
       "A.try_output: " ++ error.annot_msg("result"),
-      error.annot("None").msg,
+      error.annot("Never").msg,
       error.val("oops", ~label: "result").msg,
     )
 

--- a/rhombus/rhombus/tests/statinfo-macro.rhm
+++ b/rhombus/rhombus/tests/statinfo-macro.rhm
@@ -85,7 +85,7 @@ block:
     meta -1: rhombus/meta open
   check:
     statinfo_meta.and() ~matches '()'
-    statinfo_meta.or() ~matches '(($(statinfo_meta.none_key), #true))'
+    statinfo_meta.or() ~matches '(($(statinfo_meta.never_key), #true))'
 
 block:
   use_static

--- a/rhombus/rhombus/tests/veneer.rhm
+++ b/rhombus/rhombus/tests/veneer.rhm
@@ -362,20 +362,20 @@ block:
     fun whoami():
       ~who: who
       who
-    fun try_input(_ :: None):
+    fun try_input(_ :: Never):
       error("should not get here")
-    fun try_output() :: None:
+    fun try_output() :: Never:
       "oops"
   check:
     A.whoami() ~is #'#{A.whoami}
     A.try_input("oops") ~throws values(
       "A.try_input: " ++ error.annot_msg("argument"),
-      error.annot("None").msg,
+      error.annot("Never").msg,
       error.val("oops", ~label: "argument").msg,
     )
     A.try_output() ~throws values(
       "A.try_output: " ++ error.annot_msg("result"),
-      error.annot("None").msg,
+      error.annot("Never").msg,
       error.val("oops", ~label: "result").msg,
     )
 


### PR DESCRIPTION
Also `statinfo_meta.none_key` -> `statinfo_meta.never_key`. For now, `None` remains available as a deprecated alias of `Never`, but I didn't bother with `statinfo_meta.none_key`.
