### PR TITLE
add `while`

### DIFF
--- a/rhombus-ffi/rhombus/ffi/scribblings/overview.scrbl
+++ b/rhombus-ffi/rhombus/ffi/scribblings/overview.scrbl
@@ -54,6 +54,9 @@ exports of the library, it's simplest to use @rhombus(foreign.linker):
   import:
     ffi open
 
+  when stdin !is_a Port.FileStream.Terminal
+  | error("not in a terminal")
+
   foreign.linker curses:
     ~lib: Lib.load("libcurses")
 )

--- a/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/core-derived.rkt
@@ -14,6 +14,7 @@
         "class_together.rhm"
         "enum.rhm"
         "pipeline.rhm"
+        "while.rhm"
         "assuming.rhm"
         "compose.rhm"
         "str.rhm"

--- a/rhombus-lib/rhombus/private/amalgam/for-clause-primitive.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/for-clause-primitive.rkt
@@ -39,12 +39,16 @@
     (pattern (~and (~seq t ...)
                    (~seq (~optional _::values-id-bind) (_::parens bind-g ...) _::in expr ...+))
              #:do [(check-multiple-ins #'(t ...))]
-             #:with blk #`(block (#,group-tag expr ...)))
+             #:with blk (relocate+reraw
+                         #'(t ...)
+                         #`(block (#,group-tag expr ...))))
     (pattern (~and (~seq t ...)
                    (~seq bind ...+ _::in expr ...+))
              #:do [(check-multiple-ins #'(t ...))]
              #:with (bind-g ...) #`((#,group-tag bind ...))
-             #:with blk #`(block (#,group-tag expr ...)))
+             #:with blk (relocate+reraw
+                         #'(t ...)
+                         #`(block (#,group-tag expr ...))))
     (pattern (~seq bind ...+ (~and blk (_::block . _)))
              #:with (bind-g ...) #`((#,group-tag bind ...)))))
 

--- a/rhombus-lib/rhombus/private/amalgam/for.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/for.rkt
@@ -3,6 +3,7 @@
                      racket/for-clause
                      syntax/parse/pre
                      enforest/syntax-local
+                     shrubbery/print
                      "tag.rkt"
                      "srcloc.rkt"
                      "statically-str.rkt"
@@ -83,7 +84,8 @@
           #`(for (#:splice (for-clause-step #,stx
                                             #,static?
                                             [(void-result [])]
-                                            . #,body))
+                                            #,@body
+                                            (group (parsed #:rhombus/expr (void)))))
               (void)))]
         [else
          (syntax-parse red-parsed
@@ -298,7 +300,8 @@
                              [else
                               (syntax-parse orig-stx
                                 [(head . _)
-                                 #`(check-sequence-for-each 'head #,(unwrap-static-infos #'rhs))])])))]
+                                 #`(check-sequence-for-each '#,(string->symbol (shrubbery-syntax->string #'head))
+                                                            #,(unwrap-static-infos #'rhs))])])))]
          . rev-clauses)
         ()
         (begin

--- a/rhombus-lib/rhombus/private/amalgam/while.rhm
+++ b/rhombus-lib/rhombus/private/amalgam/while.rhm
@@ -1,0 +1,38 @@
+#lang rhombus/private/amalgam/core
+import:
+  "core-meta.rkt" open
+  "sequence_meta.rhm" open
+
+export:
+  while
+
+class Forever():
+  implements Sequenceable
+  override method to_sequence(): #void
+  sequence ': $self':
+    '(~outer_binds:«»,
+      ~recur_binds:«»,
+      ~head_guard:
+        #true,
+      ~inner_binds:«»,
+      ~recur_args:
+        ())'
+  
+expr.macro 'while $(tst :: expr_meta.Parsed):
+              $body
+              ...':
+  ~op_stx: self
+  ~all_stx: stx
+  let for_id = syntax_meta.dynamic_name('for', ~as_static: syntax_meta.is_static(self))
+  let g:
+    '(() in Forever()):
+       break_when ! $tst
+       $body
+       ...'
+  // fancy source-info transfer to make messages say `while` and show original form
+  let for_id = for_id.relocate(self)
+  let g:
+    Syntax.make_group(Syntax.relocate_split(g.unwrap_group(),
+                                            match stx
+                                            | '$_ $tail ...': '$tail ...'))
+  '$for_id $g'

--- a/rhombus/rhombus/scribblings/reference/for.scrbl
+++ b/rhombus/rhombus/scribblings/reference/for.scrbl
@@ -14,8 +14,7 @@ forms of iteration, including list comprehensions and other folds.
 
   expr.macro 'for $maybe_each:
                 $clause_or_body
-                ...
-                $body'
+                ...'
   expr.macro 'for $reducer $maybe_each:
                 $clause_or_body
                 ...
@@ -110,10 +109,12 @@ forms of iteration, including list comprehensions and other folds.
  If a @rhombus(reducer) is specified, either before the block or at the
  end with @rhombus(~into), it determines how each result of the last
  @rhombus(body) is combined to produce a result of the overall
- @rhombus(for) expression, otherwise the result of the last
- @rhombus(body) is ignored and the @rhombus(for) expression's value is
- @rhombus(#void). Example reducers include @rhombus(List, ~reducer),
- @rhombus(Map, ~reducer), and @rhombus(values, ~reducer).
+ @rhombus(for) expression. Example reducers include @rhombus(List, ~reducer),
+ @rhombus(Map, ~reducer), and @rhombus(values, ~reducer). If no
+ @rhombus(reducer) is specified, then @rhombus(#void) is implicitly added
+ to the end of the @rhombus(clause_or_body) sequence (which means that the
+ @rhombus(clause_or_body) sequence can otherwise end in a definition or
+ a clause form like @rhombus(break_when, ~for_clause)).
 
 @examples(
   ~repl:
@@ -211,5 +212,44 @@ forms of iteration, including list comprehensions and other folds.
 ){
 
  The primitive clause forms that are recognized by @rhombus(for).
+
+}
+
+
+@doc(
+  ~nonterminal:
+    test_expr: block expr
+    clause_or_body: for
+
+  expr.macro 'while $test_expr:
+                $clause_or_body
+                ...'
+){
+
+ Equivalent to
+
+@rhombusblock(
+  for (() in #,(@rhombus(forever, ~var))):
+    break_when !test_expr
+    clause_or_body
+    ...
+)
+
+ where @rhombus(forever, ~var) produces an infinite stream of
+ zero-valued elements. Use @rhombus(break_when, ~for_clause) or
+ @rhombus(skip_when, ~for_clause) in the @rhombus(clause_or_body)
+ sequence in a way similar to @tt{break} and @tt{continue} in a language
+ like C.
+
+@examples(
+  def mutable i = 0
+  while i < 3:
+    println(i)
+    i := i + 1
+  while #true:
+    println(i)
+    break_when i >= 4
+    i := i + 1
+)
 
 }

--- a/rhombus/rhombus/tests/for.rhm
+++ b/rhombus/rhombus/tests/for.rhm
@@ -26,6 +26,15 @@ block:
     ~is [11, 10, 11, 10, 1, 0, 1, 0]
 
 check:
+  for (i: 0..2):«»
+  ~is #void
+
+check:
+  for (i: 0..2):
+    let lonely = 1
+  ~is #void
+
+check:
   for List:
     each i in 0..2
     i

--- a/rhombus/rhombus/tests/while.rhm
+++ b/rhombus/rhombus/tests/while.rhm
@@ -1,0 +1,40 @@
+#lang rhombus/and_meta
+
+check:
+  let mutable i = 0
+  while i < 10:
+    i := i + 1
+  i
+  ~is 10
+
+check:
+  let mutable i = 0
+  while i < 100:
+    i := i + 1
+    break_when i >= 11
+  i
+  ~is 11
+
+check:
+  let mutable i = 0
+  let mutable v = 0
+  while i < 10:
+    i := i + 1
+    each j in 0..4
+    v := v + j
+  [i, v]
+  ~is [10, 60]
+
+check:
+  ~eval
+  while #true:
+    each i in 0
+  ~throws "while: value does not satisfy annotation"
+
+check:
+  ~eval
+  use_static
+  while #true:
+    each i in 0
+  ~throws "while: no specific iteration implementation available (based on static information)"
+

--- a/shrubbery-render-lib/shrubbery/render/private/rhombus-spacer.rhm
+++ b/shrubbery-render-lib/shrubbery/render/private/rhombus-spacer.rhm
@@ -75,6 +75,7 @@ export:
       s_MutableSet as MutableSet
       s_WeakMutableSet as WeakMutableSet
     for
+    while
     each
     keep_let
     import
@@ -1084,6 +1085,16 @@ spacer.bridge for(self, tail, context, esc):
         ': $new_g; ...; $new_gn'.relocate(b)
       '$self $new_reduce $new_b'
   | ~else: '$self $tail'
+
+spacer.bridge while(self, tail, context, esc):
+  ~in: ~expr
+  match tail
+  | '$e ... $(b && ': $g; ...')':
+      let new_e = spacer.adjust_sequence('$e ...', context, esc)
+      let new_b:
+        let [new_g, ...] = [spacer.adjust_group(g, for_spaces, esc), ...]
+        ': $new_g; ...'.relocate(b)
+      '$self $new_e $new_b'
 
 spacer.bridge each(self, tail, context, esc):
   ~in: ~for_clause


### PR DESCRIPTION
The `while` form is a shorthand for `for`, which means that `for` clause forms can be used in the body of `while` --- including forms like `each`, but the intent is to allow `break_when` and `skip_when` to play the roles traditionally served by `break` and `continue`.

Related to #771