### PR TITLE
change `PathString` to disallow mutable strings; add envvars and related annotations

### DIFF
--- a/rhombus-lib/rhombus/envvar.rhm
+++ b/rhombus-lib/rhombus/envvar.rhm
@@ -1,0 +1,83 @@
+#lang rhombus/static/and_meta
+import:
+  lib("racket/base.rkt") as rkt
+
+export:
+  StringEnvVarName
+  BytesEnvVarName
+  getenv
+  putenv
+  EnvVars
+
+fun is_string_envvar_name(v):
+  v is_a String && rkt.#{string-environment-variable-name?}(v)
+
+annot.macro 'StringEnvVarName':
+  'satisfying(is_string_envvar_name) && assuming(String)'
+annot.macro 'BytesEnvVarName':
+  'satisfying(rkt.#{bytes-environment-variable-name?}) && assuming(Bytes)'
+
+fun getenv(name :: StringEnvVarName) :~ String:
+  let s = rkt.getenv(name)
+  s && to_string(s)
+
+fun putenv(name :: StringEnvVarName, value :: maybe(StringNoNull)):
+  rkt.putenv(name, value)
+
+def cache = WeakMutableMap.by(===){}
+
+class EnvVars(private _handle):
+  property handle: _handle
+  internal _EnvVars
+
+  constructor ({ name :: BytesEnvVarName: val :: BytesNoNull,
+                 ... }):
+    let [[a, ...], ...] = [[name, val], ...]
+    _EnvVars(rkt.#{make-environment-variables}(a, ..., ...))
+
+  fun wrap(handle):
+    cache.maybe[handle] || (block:
+                              def e = _EnvVars(handle)
+                              cache[handle] := e
+                              e)
+
+  method get(name :: BytesEnvVarName) :~ maybe(Bytes):
+    rkt.#{environment-variables-ref}(_handle, name)
+
+  fun throw_error():
+    error("envvar set failed")
+
+  method set(name :: BytesEnvVarName,
+             val :: maybe(BytesNoNull),
+             ~fail: fail :: Function.of_arity(0) = throw_error):
+    if fail === throw_error
+    | rkt.#{environment-variables-set!}(_handle, name, val)
+    | rkt.#{environment-variables-set!}(_handle, name, val, fail)
+
+  method names() :~ List.of(BytesEnvVarName):
+    [& rkt.#{environment-variables-names}(_handle)]
+
+  method copy() :~ EnvVars:
+    wrap(rkt.#{environment-variables-copy}(_handle))
+
+  export:
+    current
+    from_handle
+
+  def current :~ Function.assume_of(Function.all_of(() -> EnvVars, EnvVars -> Void)):
+    rkt.#{make-derived-parameter}(
+      rkt.#{current-environment-variables},
+      fun (v :: EnvVars):
+        ~name: EnvVars.current
+        v.handle,
+      fun (handle):
+        wrap(handle),
+      #'rhombus,
+      #'#{EnvVars.current}
+    )
+
+  fun from_handle(handle) :: EnvVars:
+    ~who: who
+    unless rkt.#{environment-variables?}(handle)
+    | error(~who: who, "not an environment-variables handle")
+    wrap(handle)

--- a/rhombus-lib/rhombus/private/amalgam/bytes.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/bytes.rkt
@@ -27,7 +27,8 @@
                      Bytes)
          (for-space rhombus/annot
                     MutableBytes
-                    ImmutableBytes))
+                    ImmutableBytes
+                    BytesNoNull))
 
 (module+ for-builtin
   (provide bytes-method-table))
@@ -80,6 +81,14 @@
 (void (set-primitive-contract! 'mutable-bytes? "MutableBytes"))
 (define-annotation-syntax MutableBytes (identifier-annotation mutable-bytes? #,(get-bytes-static-infos)))
 (define-annotation-syntax ImmutableBytes (identifier-annotation immutable-bytes? #,(get-bytes-static-infos)))
+
+(define (bytes/no-null? s)
+  (and (bytes? s)
+       (for/and ([c (in-bytes s)])
+         (not (eqv? c 0)))))
+
+(define-annotation-syntax BytesNoNull
+  (identifier-annotation bytes/no-null? #,(get-bytes-static-infos)))
 
 (define (check-bytes who b)
   (unless (bytes? b)

--- a/rhombus-lib/rhombus/private/amalgam/path-object.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-object.rkt
@@ -23,7 +23,8 @@
          (submod "list.rkt" for-listable)
          (submod "string.rkt" static-infos)
          (submod "symbol.rkt" for-static-info)
-         "path-order.rkt")
+         "path-order.rkt"
+         "path-string.rkt")
 
 (provide (for-spaces (rhombus/namespace
                       #f
@@ -223,7 +224,7 @@
   (cond
     [(path-for-some-system? v)
      (path-convention-type v)]
-    [(or (path-string? v)
+    [(or (immutable-path-string? v)
          (eq? v 'up)
          (eq? v 'same))
      (system-path-convention-type)]
@@ -258,11 +259,13 @@
 
 (define/method (Path.name p)
   #:local-primitive (split-path)
+  (check-cross-path-string who p)
   (define-values (parent name dir?) (split-path p))
   name)
 
 (define/method (Path.parent p)
   #:local-primitive (split-path)
+  (check-cross-path-string who p)
   (define-values (parent name dir?) (split-path p))
   parent)
 
@@ -286,58 +289,75 @@
 (define/method (Path.add p . ss)
   #:primitive (build-path)
   #:static-infos ((#%call-result #,(get-path-static-infos)))
+  (define (check v)
+    (unless (or (path-for-some-system? v)
+                (immutable-path-string? v)
+                (eq? v 'up)
+                (eq? v 'same))
+      (raise-annotation-failure who v "PathString || CrossPath || Path.Dot")))
+  (check p)
+  (for ([s (in-list ss)]) (check s))
   (apply build-path p ss))
 
 (define/method (Path.split p)
   #:primitive (explode-path)
   #:static-infos ((#%call-result ((#%index-result #,(get-path-static-infos))
                                   #,@(get-treelist-static-infos))))
+  (check-cross-path-string who p)
   (to-treelist #f (explode-path p)))
 
 (define/method (Path.directory_only p)
   #:primitive (path-only)
+  (check-cross-path-string who p)
   (path-only p))
 
 (define/method (Path.suffix p)
   #:primitive (path-get-extension)
   #:static-infos ((#%call-result ((#%maybe #,(get-path-static-infos)))))
+  (check-cross-path-string who p)
   (define maybe-bstr (path-get-extension p))
   (and maybe-bstr (bytes->immutable-bytes maybe-bstr)))
 
 (define/method (Path.add_suffix p sfx #:sep [sep "_"])
   #:primitive (path-add-extension)
   #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (check-cross-path-string who p)
   (path-add-extension p sfx sep))
 
 (define/method (Path.replace_suffix p sfx)
   #:primitive (path-replace-extension)
   #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (check-cross-path-string who p)
   (path-replace-extension p sfx))
 
 (define/method (Path.to_absolute_path p #:relative_to [base-path (current-directory)])
   #:primitive (path->complete-path)
   #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (check-cross-path-string who p)
   (path->complete-path p base-path))
 
 (define/method (Path.to_directory_path p)
   #:primitive (path->directory-path)
   #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (check-cross-path-string who p)
   (path->directory-path p))
 
 (define/method (Path.cleanse p)
   #:primitive (cleanse-path)
   #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (check-cross-path-string who p)
   (cleanse-path p))
 
 (define/method (Path.normal_case p)
   #:primitive (normal-case-path)
   #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
+  (check-cross-path-string who p)
   (normal-case-path p))
 
 (define/method (Path.simplify p)
   #:primitive (simplify)
   #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
-  (unless (path-string? p) (raise-annotation-failure who p "PathString"))
+  (check-path-string who p)
   (simplify-path p #f))
 
 (define/method (Path.as_relative_to p base-p
@@ -345,15 +365,15 @@
                                     #:more_than_same [more-than-same? #t]
                                     #:normal_case [normalize-case? #t])
   #:static-infos ((#%call-result #,(get-path-for-some-system-static-infos)))
-  (unless (or (path-string? p) (path-for-some-system? p)) (raise-annotation-failure who p "PathString || CrossPath"))
-  (unless (or (path-string? base-p) (path-for-some-system? p)) (raise-annotation-failure who base-p "PathString || CrossPath"))
+  (check-cross-path-string who p)
+  (check-cross-path-string who base-p)
   (find-relative-path base-p
                       (if (string? p) (string->path p) p)
                       #:more-than-root? more-than-root?
                       #:more-than-same? more-than-same?
                       #:normalize-case? normalize-case?))
 
-(define-annotation-syntax PathString (identifier-annotation path-string? ()))
+(define-annotation-syntax PathString (identifier-annotation immutable-path-string? ()))
 
 (define (path-for-some-system-is-absolute? v)
   (and (path-for-some-system? v)

--- a/rhombus-lib/rhombus/private/amalgam/path-string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/path-string.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+(require racket/mutability
+         "annotation-failure.rkt")
+
+(provide immutable-path-string?
+         check-path-string
+         check-cross-path-string)
+
+(define (immutable-path-string? p)
+  (and (path-string? p)
+       (or (not (string? p))
+           (immutable-string? p))))
+
+(define (check-path-string who p)
+  (unless (immutable-path-string? p)
+    (raise-annotation-failure who p "PathString")))
+
+(define (check-cross-path-string who p)
+  (unless (or (immutable-path-string? p)
+              (path-for-some-system? p))
+    (raise-annotation-failure who p "PathString || CrossPath")))

--- a/rhombus-lib/rhombus/private/amalgam/port.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/port.rkt
@@ -32,7 +32,8 @@
          (submod "list.rkt" for-listable)
          (submod "listable.rkt" for-static-info)
          (submod "sequenceable.rkt" for-static-info)
-         "printer-property.rkt")
+         "printer-property.rkt"
+         "path-string.rkt")
 
 (provide (for-spaces (rhombus/annot
                       rhombus/namespace)
@@ -336,6 +337,7 @@
   #:static-infos ((#%call-result #,(static-infos-and
                                     (get-input-port-static-infos)
                                     (get-file-stream-port-static-infos))))
+  (check-path-string who path)
   (open-input-file path #:mode mode))
 
 (define/arity Port.Input.open_string
@@ -373,7 +375,7 @@
                                     (get-file-stream-port-static-infos))))
   (define exists (->ExistsMode exists-in))
   (unless exists
-    (if (path-string? path)
+    (if (immutable-path-string? path)
         (raise-annotation-failure who exists-in "Port.Output.ExistsMode")
         (raise-annotation-failure who path "PathString")))
   (open-output-file path
@@ -407,7 +409,7 @@
                                                 (get-file-stream-port-static-infos)))))))
   (define exists (->ExistsMode exists-in))
   (unless exists
-    (if (path-string? path)
+    (if (immutable-path-string? path)
         (raise-annotation-failure who exists-in "Port.Output.ExistsMode")
         (raise-annotation-failure who path "PathString")))
   (open-input-output-file path

--- a/rhombus-lib/rhombus/private/amalgam/string.rkt
+++ b/rhombus-lib/rhombus/private/amalgam/string.rkt
@@ -52,6 +52,7 @@
          (for-space rhombus/annot
                     ReadableString
                     MutableString
+                    StringNoNull
                     StringCI
                     ReadableStringCI
                     StringLocale
@@ -214,6 +215,14 @@
   (identifier-annotation immutable-string? #,(get-string-ci-static-infos) #:static-only))
 (define-annotation-syntax ReadableStringCI
   (identifier-annotation string? #,(get-readable-string-ci-static-infos) #:static-only))
+
+(define (string/no-null? s)
+  (and (immutable-string? s)
+       (for/and ([c (in-string s)])
+         (not (eqv? c #\nul)))))
+
+(define-annotation-syntax StringNoNull
+  (identifier-annotation string/no-null? #,(get-string-static-infos)))
 
 (define-for-syntax (convert-string-locale-compare-static-info static-info)
   (syntax-parse static-info

--- a/rhombus-lib/rhombus/subprocess.rhm
+++ b/rhombus-lib/rhombus/subprocess.rhm
@@ -127,13 +127,13 @@ fun run(exe :: PathString,
         ~out: out :: Port.Output || Subprocess.Pipe = stdout,
         ~err: err :: Port.Output || Subprocess.ErrorPipe = stderr,
         ~group: group :: Subprocess.Group || Subprocess.NewGroup = current_group(),
-        arg :: PathString || ReadableString, ...) :~ Subprocess:
+        arg :: Path || StringNoNull || BytesNoNull, ...) :~ Subprocess:
   let exe: if Path.parent(exe) == #'relative
            | find_executable_path(exe) || exe
            | exe
   do_run(to_string(exe), exe, arg, ..., ~in: in, ~out: out, ~err: err, ~group: group)
 
-fun run_shell(command :: String,
+fun run_shell(command :: StringNoNull,
               ~in: in :: Port.Input || Subprocess.Pipe = stdin,
               ~out: out :: Port.Output || Subprocess.Pipe = stdout,
               ~err: err :: Port.Output || Subprocess.ErrorPipe = stderr,
@@ -141,18 +141,17 @@ fun run_shell(command :: String,
   let args = rkt_shell.#{shell-path/args}(#'#{subprocess.shell}, command)
   do_run(command, & args, ~in: in, ~out: out, ~err: err, ~group: group)
 
-fun shell(command :: String):
+fun shell(command :: StringNoNull):
   let args = rkt_shell.#{shell-path/args}(#'#{subprocess.shell}, command)
   let sp = do_run(command, & args)
   sp.wait_ok()
 
 fun run_command(exe :: PathString,
-                command :: String,
+                command :: StringNoNull,
                 ~in: in :: Port.Input || Subprocess.Pipe = stdin,
                 ~out: out :: Port.Output || Subprocess.Pipe = stdout,
                 ~err: err :: Port.Output || Subprocess.ErrorPipe = stderr,
-                ~group: group :: Subprocess.Group || Subprocess.NewGroup = current_group(),
-                arg :: PathString || ReadableString, ...) :~ Subprocess:
+                ~group: group :: Subprocess.Group || Subprocess.NewGroup = current_group()) :~ Subprocess:
   unless system.type() == #'windows
   | error(~who: #'run_command, "supported only on Windows")
   do_run(command, exe, #'exact, command, ~in: in, ~out: out, ~err: err, ~group: group)

--- a/rhombus/rhombus/scribblings/reference/bytes.scrbl
+++ b/rhombus/rhombus/scribblings/reference/bytes.scrbl
@@ -27,11 +27,16 @@ like @rhombus(<) and @rhombus(>) work on byte strings.
     ~method_fallback: Bytes
   annot.macro 'ImmutableBytes':
     ~method_fallback: Bytes
+  annot.macro 'BytesNoNull':
+    ~method_fallback: Bytes
 ){
 
  Matches byte strings, where @rhombus(MutableBytes, ~annot) matches only
  mutable byte strings, and and @rhombus(ImmutableBytes, ~annot) matches
  only immutable byte strings.
+
+ The @rhombus(BytesNoNull, ~annot) annotation matches byte strings that do
+ not contain a @rhombus(0) byte.
 
  Static information associated by @rhombus(Bytes, ~annot), etc., makes
  an expression acceptable as a sequence to @rhombus(for) in static mode.

--- a/rhombus/rhombus/scribblings/reference/envvar.scrbl
+++ b/rhombus/rhombus/scribblings/reference/envvar.scrbl
@@ -1,0 +1,120 @@
+#lang rhombus/scribble/manual
+@(import:
+    "common.rhm" open
+    "nonterminal.rhm" open
+    meta_label:
+      rhombus/envvar
+      rhombus/envvar open)
+
+@title(~tag: "envvar"){Environment Variables}
+
+@docmodule(rhombus/envvar)
+
+@doc(
+  annot.macro 'envvar.StringEnvVarName'
+  annot.macro 'envvar.BytesEnvVarName'
+){
+
+ Annotations that recognize strings and bytes without null characters or
+ @litchar{=} characters, which makes them suitable as
+ environment-variable names.
+
+}
+
+@doc(
+  fun envvar.getenv(
+    name :: StringEnvVarName
+  ) :: StringNoNull
+  fun envvar.putenv(
+    name :: StringEnvVarName,
+    value :: StringNoNull
+  ) :: Boolean
+){
+
+ Convenience functions to get and set environment variables in terms of
+ strings.
+
+ The underlying environment-variables object works in terms of byte
+ strings. String names and values are converted using the current
+ locale’s default encoding, using @rhombus(Char"?") as the replacement
+ character for encoding errors.
+
+ The @rhombus(gettenv) and @rhombus(putenv) functions use
+ @rhombus(EnvVars.current) to get the current environment variables, and
+ then use @rhombus(EnvVars.get) or @rhombus(EnvVars.set) to get or set
+ the byte-string encoding of @rhombus(name).
+
+ The @rhombus(putenv) function returns @rhombus(#true) for success and
+ @rhombus(#false) for failure, where failure is only possible when
+ @rhombus(EnvVars.current) returns the original @rhombus(EnvVars, ~class)
+ object for the process.
+
+}
+
+@doc(
+  class envvar.EnvVars():
+    constructor ({ name :: BytesEnvVarName: value :: BytesNoNull,
+                   ... })
+  method (envvars :: envvar.EnvVars).copy() :: EnvVars
+  Parameter.def envvar.EnvVars.current :: EnvVars
+){
+
+ An @rhombus(EnvVars) instance represents a set of environment
+ variables. The current object installed in @rhombus(EnvVars.current)
+ determines the environment variables that are used for a subprocess
+ created via @rhombusmodname(rhombus/subprocess).
+
+ The initial value of @rhombus(EnvVars.current) corresponds to the
+ process's environment variables. Setting an environment variable in that
+ object adjusts the table of environment variables at the
+ operating-system process level.
+
+ Creating a new set of environment variables via @rhombus(EnvVars.copy)
+ or the @rhombus(EnvVars) allocates an object with independent state.
+
+}
+
+@doc(
+  method (envvars :: envvar.EnvVars).get(
+    name :: BytesEnvVarName
+  ) :~ maybe(ImmutableBytes)
+  method (envvars :: envvar.EnvVars).set(
+    name :: BytesEnvVarName,
+    val :: maybe(BytesNoNull),
+    ~fail: fail :: Function.of_arity(0) = ....
+  )
+){
+
+ Gets or sets an environment variable in @rhombus(envvars).
+
+ If @rhombus(envvars) is the initial value of @rhombus(EnvVars.current)
+ in the process, setting an environment variable adjusts the table of
+ environment variables at the operating-system process level.
+
+ Setting an environment variable to @rhombus(#false) removes it from the
+ set of environment-variable names and/or unsets it at the process level.
+
+}
+
+
+@doc(
+  method (envvars :: envvar.EnvVars).names()
+    :: List.of(BytesEnvVarName && ImmutableBytes)
+){
+
+ Returns a list of environment-variable names that are set in
+ @rhombus(envvars).
+
+}
+
+@doc(
+  property (envvars :: envvar.EnvVars).handle
+  fun envvar.EnvVars.from_handle(handle) :: EnvVars
+){
+
+ The @rhombus(EnvVars.handle) property accesses an environment-variables
+ object's underlying Racket representation. The
+ @rhombus(EnvVars.from_handle) function constructs a Rhombus
+ environment-variables object from a Racket environment-variables object.
+
+}

--- a/rhombus/rhombus/scribblings/reference/os.scrbl
+++ b/rhombus/rhombus/scribblings/reference/os.scrbl
@@ -9,6 +9,7 @@
 @include_section("path.scrbl")
 @include_section("cross_path.scrbl")
 @include_section("filesystem.scrbl")
+@include_section("envvar.scrbl")
 @include_section("subprocess.scrbl")
 @include_section("network.scrbl")
 @include_section("system.scrbl")

--- a/rhombus/rhombus/scribblings/reference/path.scrbl
+++ b/rhombus/rhombus/scribblings/reference/path.scrbl
@@ -38,11 +38,11 @@ Paths are @tech{comparable}, which means that generic operations like
 ){
 
  Matches a path value. The @rhombus(PathString, ~annot) annotation
- allows @rhombus(ReadableString, ~annot) as well as
+ allows @rhombus(String, ~annot) as well as
  @rhombus(Path, ~annot) values. The @rhombus(PathString.to_path, ~annot)
  @tech(~doc: model_doc){converter annotation} allows
  @rhombus(PathString, ~annot) values, but converts
- @rhombus(ReadableString, ~annot) values to @rhombus(Path) values.
+ @rhombus(String, ~annot) values to @rhombus(Path) values.
  Similarly @rhombus(PathString.to_absolute_path, ~annot) is a converter
  annotation that converts a @rhombus(PathString, ~annot) into an absolute
  path relative to @rhombus(Path.current_directory()) or to the

--- a/rhombus/rhombus/scribblings/reference/string.scrbl
+++ b/rhombus/rhombus/scribblings/reference/string.scrbl
@@ -35,6 +35,8 @@ Strings are @tech{comparable}, which means that generic operations like
   annot.macro 'ReadableString.to_string'
   annot.macro 'MutableString':
     ~method_fallback: String
+  annot.macro 'StringNoNull':
+    ~method_fallback: String
 ){
 
  Matches strings. The @rhombus(ReadableString, ~annot) annotation allows mutable
@@ -44,6 +46,9 @@ Strings are @tech{comparable}, which means that generic operations like
  allows the same strings as @rhombus(ReadableString, ~annot), but converts
  a mutable Racket string to an immutable Rhombus string, like
  @rhombus(String.snapshot).
+
+ The @rhombus(StringNoNull, ~annot) annotation matches strings that do
+ not contain @rhombus(Char"\0") character.
 
  Static information associated by @rhombus(String, ~annot), etc., makes
  an expression acceptable as a sequence to @rhombus(for) in static mode.

--- a/rhombus/rhombus/scribblings/reference/subprocess.scrbl
+++ b/rhombus/rhombus/scribblings/reference/subprocess.scrbl
@@ -3,7 +3,8 @@
     "common.rhm" open
     meta_label:
       rhombus/subprocess
-      rhombus/subprocess open)
+      rhombus/subprocess open
+      rhombus/envvar)
 
 @title(~tag: "subprocess"){Subprocesses}
 
@@ -30,7 +31,7 @@
     ~err: err :: Port.Output || Subprocess.ErrorPipe = stderr,
     ~group: group :: Subprocess.Group || Subprocess.NewGroup
               = (if current_group_new() | #'new | #'same),
-    arg :: PathString || ReadableString,
+    arg :: PathString || StringNoNull || BytesNoNull,
     ...
   ) :: Subprocess
 ){
@@ -66,19 +67,22 @@
  be closed explicitly, perhaps using @rhombus(Subprocess.close). See also
  @rhombus(Closeable.let, ~defn).
 
+ The environment variables for a new subprocess are determined by
+ the @rhombus(envvar.EnvVars.current) parameter.
+
 }
 
 
 @doc(
   fun subprocess.run_shell(
-    command :: String,
+    command :: StringNoNull,
     ~in: in :: Port.Input || Subprocess.Pipe = stdin,
     ~out: out :: Port.Output || Subprocess.Pipe = stdout,
     ~err: err :: Port.Output || Subprocess.ErrorPipe = stderr,
     ~group: group :: Subprocess.Group || Subprocess.NewGroup
               = (if current_group_new() | #'new | #'same)
   ) :: Subprocess
-  fun shell(command :: String) :: Boolean
+  fun shell(command :: StringNoNull) :: Boolean
 ){
 
  The @rhombus(run_shell) function is like @rhombus(run), but it runs a
@@ -90,6 +94,27 @@
 
  The @rhombus(shell) function is a shorthand to combine @rhombus(run_shell)
  and @rhombus(Subprocess.wait_ok) as @rhombus(run_shell(command).wait_ok()).
+
+}
+
+@doc(
+  fun subprocess.run_command(
+    program :: PathString,
+    command :: StringNoNull,
+    ~in: in :: Port.Input || Subprocess.Pipe = stdin,
+    ~out: out :: Port.Output || Subprocess.Pipe = stdout,
+    ~err: err :: Port.Output || Subprocess.ErrorPipe = stderr,
+    ~group: group :: Subprocess.Group || Subprocess.NewGroup
+              = (if current_group_new() | #'new | #'same)
+  ) :: Subprocess
+){
+
+ Like @rhombus(subprocess.run), but only for Windows, where the
+ @rhombus(command) string is provided to @rhombus(program) as its
+ complete command line. This function reflects the fact that Windows
+ programs natively receive a single command-line string, although most
+ Windows programs parse a command line consistent with one that
+ @rhombus(subprocess.run) constructs from individual arguments.
 
 }
 

--- a/rhombus/rhombus/tests/bytes.rhm
+++ b/rhombus/rhombus/tests/bytes.rhm
@@ -378,3 +378,10 @@ block:
   check #"a"[0] compares_unequal #"b"[0] ~is #true
   check #"a"[0] >= #"b"[0] ~is #false
   check #"a"[0] > #"b"[0] ~is #false
+
+
+check:
+  #"a" is_a BytesNoNull ~is #true
+  #"" is_a BytesNoNull ~is #true
+  #"a\0b" is_a BytesNoNull ~is #false
+  #"a".copy() is_a BytesNoNull ~is #true

--- a/rhombus/rhombus/tests/envvar.rhm
+++ b/rhombus/rhombus/tests/envvar.rhm
@@ -1,0 +1,48 @@
+#lang rhombus/static
+import:
+  rhombus/envvar open
+  rhombus/subprocess
+
+check:
+  "PATH" is_a StringEnvVarName ~is #true
+  "PATH=" is_a StringEnvVarName ~is #false
+  "PATH".copy() is_a StringEnvVarName ~is #false
+  #"PATH" is_a BytesEnvVarName ~is #true
+  #"PATH=" is_a BytesEnvVarName ~is #false
+  #"PATH".copy() is_a BytesEnvVarName ~is #true
+
+check:
+  getenv("PATH") ~is_a maybe(String)
+  getenv("RHOMBUS_GETENV_CHECK") ~is #false
+  putenv("RHOMBUS_GETENV_CHECK", "on") ~is #true
+  getenv("RHOMBUS_GETENV_CHECK") ~is "on"
+  EnvVars.current().get(#"RHOMBUS_GETENV_CHECK") ~is #"on"
+  (if system.type() == #'windows
+   | println("on")
+   | subprocess.shell("echo $RHOMBUS_GETENV_CHECK")) ~prints "on\n"
+  EnvVars.current().set(#"RHOMBUS_GETENV_CHECK", #false) ~is #void
+  getenv("RHOMBUS_GETENV_CHECK") ~is #false
+
+check:
+  EnvVars.current().set(#"RHOMBUS_GETENV_CHECK", #"on") ~is #void
+  EnvVars.current().get(#"RHOMBUS_GETENV_CHECK") ~is #"on"
+
+def e = EnvVars.current().copy()
+
+check:
+  e.get(#"RHOMBUS_GETENV_CHECK") ~is #"on"
+  EnvVars.current().set(#"RHOMBUS_GETENV_CHECK", #false) ~is #void
+  EnvVars.current().get(#"RHOMBUS_GETENV_CHECK") ~is #false
+  e.get(#"RHOMBUS_GETENV_CHECK") ~is #"on"
+  e.names() ~is_a List.of(Bytes)
+  Set(& e.names()) ~is Set(& EnvVars.current().names()) ++ { #"RHOMBUS_GETENV_CHECK" }
+
+def e2 = EnvVars({ #"A": #"apple", #"B": #"banana" })
+check:
+  e2.get(#"A") ~is #"apple"
+  e2.get(#"B") ~is #"banana"
+  e2.get(#"C") ~is #false
+  e2.get(#"PATH") ~is #false
+
+check:
+  EnvVars.from_handle(EnvVars.current().handle) === EnvVars.current() ~is #true

--- a/rhombus/rhombus/tests/path.rhm
+++ b/rhombus/rhombus/tests/path.rhm
@@ -364,3 +364,10 @@ check:
     error.annot("Path.like(Path(\"/\"))").msg,
     error.val("oops").msg,
   )
+
+check:
+  "a" is_a PathString ~is #true
+  "" is_a PathString ~is #false
+  "a\0b" is_a PathString ~is #false
+  "a".copy() is_a PathString ~is #false
+  #"a" is_a PathString ~is #false

--- a/rhombus/rhombus/tests/string.rhm
+++ b/rhombus/rhombus/tests/string.rhm
@@ -702,3 +702,9 @@ block:
   check:
     ([1, 2, 3] :~ matching(_ :: ReadableString.to_string)).first ~is 1
     (PairList[1, 2, 3] :~ matching(_ :: ReadableString.to_string)).first ~is 1
+
+check:
+  "a" is_a StringNoNull ~is #true
+  "" is_a StringNoNull ~is #true
+  "a\0b" is_a StringNoNull ~is #false
+  "a".copy() is_a StringNoNull ~is #false


### PR DESCRIPTION
The environment-variables API needs `StringEnvVarName` and `BytesEnvVarName`, so include those in `rhombus/envvar`. It also needs `StringNoNull` and `BytesNoNull`, but those are added to `rhombus`, since they are also useful in other places --- like the subprocess API.

Meanwhile, change `PathString` to not include `MutableString`. Previously, `PathString` was the same as `path-string?` in the Racket, which allows mutable strings. Keeping them the same meant that Rhombus functions could rely on the Racket argument checks. Including mutable strings in `PathString` seems likely to cause long-term trouble for Rhombus, though, and it does not seem that difficult to check relevant arguments.